### PR TITLE
feat(cloudcontrol): add errgroup.WithContext for better context cancellation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/sync v0.19.0
 	google.golang.org/api v0.257.0
 )
 

--- a/pkg/links/aws/cloudcontrol/cloud_control_list.go
+++ b/pkg/links/aws/cloudcontrol/cloud_control_list.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
@@ -14,19 +13,18 @@ import (
 	"github.com/praetorian-inc/aurelian/internal/message"
 	"github.com/praetorian-inc/aurelian/pkg/links/aws/base"
 	"github.com/praetorian-inc/aurelian/pkg/types"
+	"golang.org/x/sync/errgroup"
 )
 
 type AWSCloudControl struct {
 	*base.NativeAWSLink
 	semaphores          map[string]chan struct{}
-	wg                  sync.WaitGroup
 	cloudControlClients map[string]*cloudcontrol.Client
 }
 
 func NewAWSCloudControl(args map[string]any) *AWSCloudControl {
 	return &AWSCloudControl{
 		NativeAWSLink: base.NewNativeAWSLink("CloudControlList", args),
-		wg:            sync.WaitGroup{},
 	}
 }
 
@@ -65,28 +63,44 @@ func (a *AWSCloudControl) Process(ctx context.Context, input any) ([]any, error)
 			return nil, err
 		}
 	}
+
+	g, ctx := errgroup.WithContext(ctx)
+
 	for _, region := range a.Regions {
 		if a.isGlobalService(resourceType, region) {
 			slog.Debug("Skipping global service", "type", resourceType, "region", region)
 			continue
 		}
 
-		a.wg.Add(1)
-		go a.listResourcesInRegion(ctx, resourceType, region)
+		region := region // Capture loop variable
+
+		// Acquire per-region semaphore with context awareness
+		select {
+		case a.semaphores[region] <- struct{}{}:
+		case <-ctx.Done():
+			break // Context cancelled, stop spawning
+		}
+
+		g.Go(func() error {
+			defer func() { <-a.semaphores[region] }()
+			err := a.listResourcesInRegion(ctx, resourceType, region)
+			if err != nil {
+				slog.Warn("region failed", "region", region, "error", err)
+				return nil // Continue scanning, don't cancel others
+			}
+			return nil
+		})
 	}
 
-	a.wg.Wait()
 	slog.Debug("cloudcontrol complete")
-	return nil, nil
+	return a.Outputs(), g.Wait()
 }
 
 func (a *AWSCloudControl) isGlobalService(resourceType, region string) bool {
 	return helpers.IsGlobalService(resourceType) && region != "us-east-1"
 }
 
-func (a *AWSCloudControl) listResourcesInRegion(ctx context.Context, resourceType, region string) {
-	defer a.wg.Done()
-
+func (a *AWSCloudControl) listResourcesInRegion(ctx context.Context, resourceType, region string) error {
 	message.Info("Listing %s resources in %s (profile: %s)", resourceType, region, a.Profile)
 	slog.Debug("Listing resources in region", "type", resourceType, "region", region, "profile", a.Profile)
 
@@ -94,13 +108,13 @@ func (a *AWSCloudControl) listResourcesInRegion(ctx context.Context, resourceTyp
 
 	if err != nil {
 		slog.Error("Failed to create AWS config", "error", err)
-		return
+		return fmt.Errorf("failed to create AWS config for region %s: %w", region, err)
 	}
 
 	accountId, err := helpers.GetAccountId(config)
 	if err != nil {
 		slog.Error("Failed to get account ID", "error", err, "region", region)
-		return
+		return fmt.Errorf("failed to get account ID for region %s: %w", region, err)
 	}
 
 	cc := a.cloudControlClients[region]
@@ -117,7 +131,7 @@ func (a *AWSCloudControl) listResourcesInRegion(ctx context.Context, resourceTyp
 			err, shouldBreak := a.processError(resourceType, region, err)
 			if err != nil {
 				slog.Error("Failed to list resources", "error", err)
-				return
+				return err
 			}
 
 			if shouldBreak {
@@ -131,6 +145,7 @@ func (a *AWSCloudControl) listResourcesInRegion(ctx context.Context, resourceTyp
 		}
 
 	}
+	return nil
 }
 
 func (a *AWSCloudControl) processError(resourceType, region string, err error) (error, bool) {
@@ -184,7 +199,7 @@ func (a *AWSCloudControl) sendResource(region string, resource *types.EnrichedRe
 }
 
 func (a *AWSCloudControl) Complete() error {
-	a.wg.Wait()
+	// errgroup.Wait() is now called in Process()
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Replace `sync.WaitGroup` with `errgroup.WithContext` in CloudControl list operation
- Improves context cancellation support while preserving per-region semaphore rate limiting
- Follows architecture review recommendation for minor improvement

## Changes

- Add `golang.org/x/sync/errgroup` import
- Replace WaitGroup with errgroup for goroutine coordination
- Add context-aware semaphore acquisition (respects `ctx.Done()`)
- Update `listResourcesInRegion` to return errors for better observability
- Preserve continue-on-error behavior (return `nil` to keep scanning other regions)

## Architecture Context

This change was identified during an architecture review comparing the current Aurelian implementation against a proposed V2 architecture. Key findings:

| Proposed V2 Pattern | Decision | Reason |
|---------------------|----------|--------|
| `errgroup.SetLimit(25)` global | ❌ Rejected | EC2/S3 have per-region rate limits |
| Channel-based streaming | ❌ Rejected | NoseyParker is batch-based |
| `errgroup.WithContext()` | ✅ Adopted | Better context cancellation |
| Cancel-on-first-error | ❌ Rejected | Partial results matter for security scanning |

## Test plan

- [x] `go build ./...` passes
- [ ] Manual test: Run CloudControl list with context timeout
- [ ] Verify per-region semaphores still limit to 5 concurrent per region