### PR TITLE
refactor: move CloudControlToERD to internal/helpers/aws

### DIFF
--- a/internal/helpers/aws/cloudcontrol.go
+++ b/internal/helpers/aws/cloudcontrol.go
@@ -2,14 +2,13 @@ package helpers
 
 import (
 	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
-	awshelpers "github.com/praetorian-inc/aurelian/internal/helpers/aws"
 	"github.com/praetorian-inc/aurelian/pkg/types"
 )
 
 // CloudControlToERD converts a CloudControl ResourceDescription to an EnrichedResourceDescription.
 // Handles global service region normalization and SDK pointer dereferencing.
 func CloudControlToERD(desc cctypes.ResourceDescription, resourceType, accountID, region string) *types.EnrichedResourceDescription {
-	if awshelpers.IsGlobalService(resourceType) {
+	if IsGlobalService(resourceType) {
 		region = ""
 	}
 

--- a/pkg/aws/cloudcontrol/list.go
+++ b/pkg/aws/cloudcontrol/list.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
-	"github.com/praetorian-inc/aurelian/internal/helpers"
 	awshelpers "github.com/praetorian-inc/aurelian/internal/helpers/aws"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
@@ -139,7 +138,7 @@ func (cc *CloudControlLister) listByType(client *cloudcontrol.Client, accountID,
 		}
 
 		for _, desc := range result.ResourceDescriptions {
-			cr := helpers.CloudControlToERD(desc, resourceType, accountID, region).ToCloudResource()
+			cr := awshelpers.CloudControlToERD(desc, resourceType, accountID, region).ToCloudResource()
 			enrich(&cr)
 			all = append(all, cr)
 		}


### PR DESCRIPTION
## Summary
- Move `CloudControlToERD` from `internal/helpers/cloudcontrol.go` to `internal/helpers/aws/cloudcontrol.go`
- Eliminate the now-empty top-level `internal/helpers/` package
- `list.go` now imports a single helpers package (`awshelpers`) instead of two

Follow-up to #28 — `CloudControlToERD` is AWS-specific and belongs alongside `IsGlobalService`, `NewAWSConfig`, and `EnabledRegions` in `internal/helpers/aws/`.

## Test plan
- [x] `go build ./...` passes
- [x] No behavior change — function moved, not modified
- [x] No other consumers of `internal/helpers` exist