### PR TITLE
Add automated PR review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,138 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (
+        github.event.pull_request.draft == false &&
+        !contains(github.actor, '[bot]') &&
+        github.actor != 'coderabbitai' &&
+        github.actor != 'devin-ai-integration'
+      )
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout PR branch (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: gh pr checkout ${{ github.event.inputs.pr_number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Claude PR review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          direct_prompt: |
+            You are an advisory code reviewer for the Aurelian repository, a modular cloud security framework built in Go. You provide technical feedback. You do NOT approve or reject PRs — that is the human reviewer's job.
+
+            REPO: ${{ github.repository }}
+            PR: #${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+
+            ## How to Review
+
+            1. Run `gh pr diff ${{ github.event.pull_request.number || github.event.inputs.pr_number }}` to see what changed.
+            2. Run `gh pr view ${{ github.event.pull_request.number || github.event.inputs.pr_number }}` to read the PR description.
+            3. Read the changed files in full to understand context. Do not review diffs in isolation — read the surrounding code.
+            4. Check each change against the rules below. Only flag rules that are actually relevant to the changes in this PR.
+            5. Write your top-level review to /tmp/review.md following the output format below, then post it with:
+               `gh pr comment ${{ github.event.pull_request.number || github.event.inputs.pr_number }} --body-file /tmp/review.md`
+            6. For each finding that maps to a specific line, also post an inline comment on that line using `mcp__github_inline_comment__create_inline_comment`. Keep inline comments brief: state the rule and what should change.
+
+            ## Rules
+
+            Only apply rules that are relevant to the files changed in this PR. Skip rules about modules if the PR doesn't touch modules, skip enricher rules if no enrichers are changed, etc.
+
+            ### Module Architecture
+            1. Module `Run()` should be ~30 lines or fewer. It should: bind config via `plugin.Bind(cfg, &c)`, delegate to a shared package under `pkg/aws/<service>/`, and return results. Flag inline control flow (errgroup, rate limiting, pagination) inside `Run()`.
+            2. Parameters must use struct-tag binding via `plugin.Bind(cfg, &c)`. Flag manual `plugin.NewParameters()`, `params.Set()`, `params.Validate()`, or raw `cfg.Args["key"].(type)` assertions.
+            3. Config structs should embed `AWSCommonRecon` (multi-region services) or `AWSReconBase` (global/single-region). Flag params like profile, regions, or concurrency being redefined from scratch.
+            4. Modules must self-register via `init()` with `plugin.Register()`. No central manifests.
+
+            ### Shared Packages
+            5. All errgroup, rate limiting, pagination, and type handling logic belongs in `pkg/aws/<service>/`, not in module `Run()`.
+            6. Rate limiting must use `ratelimit.NewAWSRegionLimiter(concurrency)`. Flag any use of `ratelimit.Global()`.
+            7. If a module makes custom AWS SDK calls (not via CloudControl), it should have a corresponding shared package under `pkg/aws/<service>/`.
+
+            ### Enrichers
+            8. Enrichers should define a narrow client interface for AWS SDK calls, with a wrapper + core function split for testability.
+            9. Missing-resource errors (e.g., `ResourceNotFoundException`) should return nil, not propagate as errors.
+
+            ### SDK & Types
+            10. All code must use AWS SDK v2 (`github.com/aws/aws-sdk-go-v2`). Flag any AWS SDK v1 imports (`github.com/aws/aws-sdk-go`).
+            11. When handling AWS JSON responses, check whether `pkg/types/` already has enhanced types with custom `UnmarshalJSON` before defining new ones.
+
+            ### Testing
+            12. New modules should have integration tests using the `TerraformFixture` pattern from `test/integration/testutil/`.
+            13. Integration test files must start with `//go:build integration`.
+            14. Test files must blank-import module packages (`_ "github.com/praetorian-inc/aurelian/pkg/modules/..."`) to trigger `init()` registration.
+            15. Terraform test resources must use a `random_id` prefix for name isolation.
+
+            ### Anti-Patterns
+            16. Flag creation of `pkg/dispatcher/` or `pkg/orchestrator/` directories — modules belong in `pkg/modules/`.
+            17. Flag raw `map[string]interface{}` for AWS types when `pkg/types/` has structured alternatives.
+            18. Flag Chariot or Tabularium imports inside Aurelian module code — modules return `output.CloudResource` only.
+            19. Flag error returns without context wrapping (bare `return err` instead of `fmt.Errorf("context: %w", err)`).
+
+            ## Output Format for /tmp/review.md
+
+            Write the file using exactly this markdown structure:
+
+            ```
+            ## PR Review
+
+            ### Summary
+            - (1-3 bullets describing what the PR does)
+
+            ### Findings
+
+            | # | Severity | Rule | File | Location | Detail |
+            |---|----------|------|------|----------|--------|
+            | 1 | high | Thin module | `pkg/modules/aws/recon/foo.go` | L45-L90 | `Run()` is 45 lines with inline errgroup; move control flow to `pkg/aws/foo/` |
+
+            Severity levels:
+            - **high**: architectural violation (wrong package structure, inline control flow in module, SDK v1)
+            - **medium**: pattern deviation (missing integration test, bare error return, missing enricher interface)
+            - **low**: suggestion (could use existing enhanced types, minor naming)
+
+            If there are no findings, write: "No issues found."
+
+            ### Checklist
+
+            Only include items relevant to what this PR touches. Mark [x] for compliant, [ ] for non-compliant.
+
+            - [ ] Module `Run()` ≤ ~30 lines, delegates to shared package
+            - [ ] Struct-tag parameter binding via `plugin.Bind()`
+            - [ ] Rate limiting via `NewAWSRegionLimiter` (not `Global()`)
+            - [ ] AWS SDK v2 only
+            - [ ] Integration tests with TerraformFixture (if new module)
+            - [ ] No anti-pattern directories or imports
+            ```
+
+            After posting the top-level comment, post inline comments for findings that have a specific file and line location. Each inline comment should be one or two sentences: what the rule is and what to change.
+
+          claude_args: |
+            --model claude-opus-4-6
+            --max-turns 25
+            --allowedTools "Read,Glob,Grep,Write,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-review.yml` — an automated PR review bot using Claude Opus 4.6 via `anthropics/claude-code-action@v1`
- Triggers on PR open and workflow_dispatch (manual re-runs with a PR number input)
- Reviews against Aurelian-specific rules: thin module architecture, shared package patterns, struct-tag binding, SDK v2, integration testing, and anti-patterns
- Posts hybrid feedback: top-level PR comment (summary + findings table + checklist) and inline comments on specific lines
- Skips draft PRs and bot actors (coderabbit, devin, [bot])

## Rules Enforced
1. **Module architecture** — thin `Run()`, `plugin.Bind()`, config struct inheritance, `init()` registration
2. **Shared packages** — control flow in `pkg/aws/<service>/`, `NewAWSRegionLimiter` over `Global()`
3. **Enrichers** — narrow client interfaces, graceful degradation on missing resources
4. **SDK & types** — SDK v2 only, check `pkg/types/` for enhanced types
5. **Testing** — TerraformFixture integration tests, build tags, blank imports, random prefixes
6. **Anti-patterns** — no dispatcher/orchestrator dirs, no raw map types, no Chariot imports, error wrapping

## Test plan
- [ ] Merge this PR, then open a test PR that touches a module to verify the workflow triggers
- [ ] Run via workflow_dispatch with a PR number to verify manual re-run path
- [ ] Confirm top-level comment and inline comments are posted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)