### PR TITLE
Add EC2 IMDSv2 enforcement check via enricher and YAML rule

### DIFF
--- a/pkg/modules/aws/enrichers/ec2_imds.go
+++ b/pkg/modules/aws/enrichers/ec2_imds.go
@@ -1,0 +1,67 @@
+package enrichers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	smithy "github.com/aws/smithy-go"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+)
+
+func init() {
+	plugin.RegisterEnricher("AWS::EC2::Instance", fetchIMDSMetadataWrapper)
+}
+
+// EC2DescribeInstancesAPI is the minimal interface needed for testing.
+type EC2DescribeInstancesAPI interface {
+	DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, opts ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+}
+
+func fetchIMDSMetadataWrapper(cfg plugin.EnricherConfig, r *output.CloudResource) error {
+	client := ec2.NewFromConfig(cfg.AWSConfig)
+	return FetchIMDSMetadata(cfg, r, client)
+}
+
+// FetchIMDSMetadata enriches an EC2 instance resource with IMDS metadata properties.
+func FetchIMDSMetadata(cfg plugin.EnricherConfig, r *output.CloudResource, client EC2DescribeInstancesAPI) error {
+	out, err := client.DescribeInstances(cfg.Context, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{r.ResourceID},
+	})
+	if err != nil {
+		// Handle instance not found (terminated and cleaned up)
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "InvalidInstanceID.NotFound" {
+			return nil
+		}
+		return fmt.Errorf("failed to describe instance %s: %w", r.ResourceID, err)
+	}
+
+	// Extract instance from response
+	if len(out.Reservations) == 0 || len(out.Reservations[0].Instances) == 0 {
+		return nil
+	}
+	instance := out.Reservations[0].Instances[0]
+
+	// Flatten instance state
+	if instance.State != nil {
+		r.Properties["InstanceStateName"] = string(instance.State.Name)
+	}
+
+	// Add IMDS metadata options (use AWS defaults when nil)
+	if instance.MetadataOptions != nil {
+		r.Properties["MetadataHttpTokens"] = string(instance.MetadataOptions.HttpTokens)
+		r.Properties["MetadataHttpEndpoint"] = string(instance.MetadataOptions.HttpEndpoint)
+		if instance.MetadataOptions.HttpPutResponseHopLimit != nil {
+			r.Properties["MetadataHttpPutResponseHopLimit"] = int(*instance.MetadataOptions.HttpPutResponseHopLimit)
+		}
+	} else {
+		// AWS defaults: IMDSv1 allowed, endpoint enabled
+		r.Properties["MetadataHttpTokens"] = "optional"
+		r.Properties["MetadataHttpEndpoint"] = "enabled"
+	}
+
+	return nil
+}

--- a/pkg/modules/aws/enrichers/ec2_imds_test.go
+++ b/pkg/modules/aws/enrichers/ec2_imds_test.go
@@ -1,0 +1,188 @@
+package enrichers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/praetorian-inc/aurelian/pkg/modules/aws/enrichers"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockEC2Client struct {
+	output *ec2.DescribeInstancesOutput
+	err    error
+}
+
+func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, opts ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return m.output, m.err
+}
+
+func TestFetchIMDSMetadata(t *testing.T) {
+	cfg := plugin.EnricherConfig{
+		Context:   context.Background(),
+		AWSConfig: aws.Config{},
+	}
+
+	t.Run("IMDSv1 allowed", func(t *testing.T) {
+		client := &mockEC2Client{
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{{
+					Instances: []ec2types.Instance{{
+						State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning},
+						MetadataOptions: &ec2types.InstanceMetadataOptionsResponse{
+							HttpTokens:              ec2types.HttpTokensStateOptional,
+							HttpEndpoint:            ec2types.InstanceMetadataEndpointStateEnabled,
+							HttpPutResponseHopLimit: aws.Int32(1),
+						},
+					}},
+				}},
+			},
+		}
+
+		r := &output.CloudResource{
+			ResourceType: "AWS::EC2::Instance",
+			ResourceID:   "i-0123456789abcdef0",
+			Properties:   make(map[string]any),
+		}
+
+		err := enrichers.FetchIMDSMetadata(cfg, r, client)
+		require.NoError(t, err)
+		assert.Equal(t, "optional", r.Properties["MetadataHttpTokens"])
+		assert.Equal(t, "enabled", r.Properties["MetadataHttpEndpoint"])
+		assert.Equal(t, 1, r.Properties["MetadataHttpPutResponseHopLimit"])
+		assert.Equal(t, "running", r.Properties["InstanceStateName"])
+	})
+
+	t.Run("IMDSv2 enforced", func(t *testing.T) {
+		client := &mockEC2Client{
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{{
+					Instances: []ec2types.Instance{{
+						State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning},
+						MetadataOptions: &ec2types.InstanceMetadataOptionsResponse{
+							HttpTokens:              ec2types.HttpTokensStateRequired,
+							HttpEndpoint:            ec2types.InstanceMetadataEndpointStateEnabled,
+							HttpPutResponseHopLimit: aws.Int32(2),
+						},
+					}},
+				}},
+			},
+		}
+
+		r := &output.CloudResource{
+			ResourceType: "AWS::EC2::Instance",
+			ResourceID:   "i-0123456789abcdef0",
+			Properties:   make(map[string]any),
+		}
+
+		err := enrichers.FetchIMDSMetadata(cfg, r, client)
+		require.NoError(t, err)
+		assert.Equal(t, "required", r.Properties["MetadataHttpTokens"])
+		assert.Equal(t, "enabled", r.Properties["MetadataHttpEndpoint"])
+	})
+
+	t.Run("IMDS disabled", func(t *testing.T) {
+		client := &mockEC2Client{
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{{
+					Instances: []ec2types.Instance{{
+						State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning},
+						MetadataOptions: &ec2types.InstanceMetadataOptionsResponse{
+							HttpTokens:              ec2types.HttpTokensStateOptional,
+							HttpEndpoint:            ec2types.InstanceMetadataEndpointStateDisabled,
+							HttpPutResponseHopLimit: aws.Int32(1),
+						},
+					}},
+				}},
+			},
+		}
+
+		r := &output.CloudResource{
+			ResourceType: "AWS::EC2::Instance",
+			ResourceID:   "i-0123456789abcdef0",
+			Properties:   make(map[string]any),
+		}
+
+		err := enrichers.FetchIMDSMetadata(cfg, r, client)
+		require.NoError(t, err)
+		assert.Equal(t, "disabled", r.Properties["MetadataHttpEndpoint"])
+	})
+
+	t.Run("nil MetadataOptions uses defaults", func(t *testing.T) {
+		client := &mockEC2Client{
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{{
+					Instances: []ec2types.Instance{{
+						State:           &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning},
+						MetadataOptions: nil,
+					}},
+				}},
+			},
+		}
+
+		r := &output.CloudResource{
+			ResourceType: "AWS::EC2::Instance",
+			ResourceID:   "i-0123456789abcdef0",
+			Properties:   make(map[string]any),
+		}
+
+		err := enrichers.FetchIMDSMetadata(cfg, r, client)
+		require.NoError(t, err)
+		assert.Equal(t, "optional", r.Properties["MetadataHttpTokens"])
+		assert.Equal(t, "enabled", r.Properties["MetadataHttpEndpoint"])
+		assert.Equal(t, "running", r.Properties["InstanceStateName"])
+	})
+
+	t.Run("terminated instance", func(t *testing.T) {
+		client := &mockEC2Client{
+			output: &ec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{{
+					Instances: []ec2types.Instance{{
+						State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameTerminated},
+						MetadataOptions: &ec2types.InstanceMetadataOptionsResponse{
+							HttpTokens:              ec2types.HttpTokensStateOptional,
+							HttpEndpoint:            ec2types.InstanceMetadataEndpointStateEnabled,
+							HttpPutResponseHopLimit: aws.Int32(1),
+						},
+					}},
+				}},
+			},
+		}
+
+		r := &output.CloudResource{
+			ResourceType: "AWS::EC2::Instance",
+			ResourceID:   "i-0123456789abcdef0",
+			Properties:   make(map[string]any),
+		}
+
+		err := enrichers.FetchIMDSMetadata(cfg, r, client)
+		require.NoError(t, err)
+		assert.Equal(t, "terminated", r.Properties["InstanceStateName"])
+	})
+
+	t.Run("instance not found", func(t *testing.T) {
+		client := &mockEC2Client{
+			err: &smithy.GenericAPIError{
+				Code:    "InvalidInstanceID.NotFound",
+				Message: "The instance ID 'i-nonexistent' does not exist",
+			},
+		}
+
+		r := &output.CloudResource{
+			ResourceType: "AWS::EC2::Instance",
+			ResourceID:   "i-nonexistent",
+			Properties:   make(map[string]any),
+		}
+
+		err := enrichers.FetchIMDSMetadata(cfg, r, client)
+		assert.NoError(t, err)
+		assert.Empty(t, r.Properties, "No properties should be added for missing instance")
+	})
+}

--- a/pkg/modules/aws/rules/ec2/ec2-imdsv1-enabled.yaml
+++ b/pkg/modules/aws/rules/ec2/ec2-imdsv1-enabled.yaml
@@ -1,0 +1,23 @@
+id: ec2-imdsv1-enabled
+name: EC2 Instance Allows IMDSv1
+platform: aws
+resource_type: AWS::EC2::Instance
+severity: medium
+description: |
+  EC2 instance allows IMDSv1 (Instance Metadata Service v1), which is vulnerable
+  to SSRF-based credential theft. An attacker who achieves SSRF can steal
+  temporary IAM credentials from the metadata endpoint without requiring a session token.
+references:
+  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+  - https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/
+recommendation: |
+  Enforce IMDSv2 by setting HttpTokens to "required":
+  aws ec2 modify-instance-metadata-options --instance-id <id> --http-tokens required --http-endpoint enabled
+
+match:
+  - field: InstanceStateName
+    not_equals: terminated
+  - field: MetadataHttpEndpoint
+    not_equals: disabled
+  - field: MetadataHttpTokens
+    not_equals: required

--- a/test/integration/aws/recon/ec2_imds_enricher_test.go
+++ b/test/integration/aws/recon/ec2_imds_enricher_test.go
@@ -1,0 +1,118 @@
+//go:build integration
+
+package recon
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/enrichers" // register enrichers
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/recon"     // register modules
+	"github.com/praetorian-inc/aurelian/pkg/modules/common"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestEC2IMDSEnricher(t *testing.T) {
+	fixture := testutil.NewFixture(t, "aws/recon/ec2-imds-check")
+	fixture.Setup()
+
+	mod, ok := plugin.Get(plugin.PlatformAWS, plugin.CategoryRecon, "list-all")
+	if !ok {
+		t.Fatal("list-all module not registered in plugin system")
+	}
+
+	// Run list-all with EC2 resource type (enricher auto-runs)
+	results, err := mod.Run(plugin.Config{
+		Args: map[string]any{
+			"resource-type": []string{"AWS::EC2::Instance"},
+			"regions":       []string{"us-east-1"},
+			"scan-type":     "full",
+		},
+		Context: context.Background(),
+	})
+	require.NoError(t, err, "enumeration should succeed")
+	testutil.AssertMinResults(t, results, 1)
+
+	// Parse CloudResource data from results
+	resources := flattenCloudResources(t, results[0].Data)
+
+	// Build lookup sets from fixture outputs
+	allInstanceIDs := fixture.OutputList("all_instance_ids")
+	flaggedIDs := fixture.OutputList("flagged_instance_ids")
+	safeIDs := fixture.OutputList("safe_instance_ids")
+	require.NotEmpty(t, allInstanceIDs, "fixture should provide instance IDs")
+
+	allIDSet := make(map[string]bool)
+	for _, id := range allInstanceIDs {
+		allIDSet[id] = true
+	}
+	flaggedIDSet := make(map[string]bool)
+	for _, id := range flaggedIDs {
+		flaggedIDSet[id] = true
+	}
+	safeIDSet := make(map[string]bool)
+	for _, id := range safeIDs {
+		safeIDSet[id] = true
+	}
+
+	// Filter to test instances
+	var testInstances []output.CloudResource
+	for _, r := range resources {
+		if r.ResourceType == "AWS::EC2::Instance" && allIDSet[r.ResourceID] {
+			testInstances = append(testInstances, r)
+		}
+	}
+	require.Len(t, testInstances, len(allInstanceIDs), "should find all 3 test instances")
+
+	// Assert enrichment: verify IMDS properties are present on each resource
+	t.Run("enrichment adds IMDS properties", func(t *testing.T) {
+		for _, instance := range testInstances {
+			assert.Contains(t, instance.Properties, "MetadataHttpTokens",
+				"instance %s should have MetadataHttpTokens", instance.ResourceID)
+			assert.Contains(t, instance.Properties, "MetadataHttpEndpoint",
+				"instance %s should have MetadataHttpEndpoint", instance.ResourceID)
+			assert.Contains(t, instance.Properties, "InstanceStateName",
+				"instance %s should have InstanceStateName", instance.ResourceID)
+		}
+	})
+
+	// Assert YAML rule: Load rule and evaluate against each instance
+	t.Run("YAML rule flags only non-compliant instances", func(t *testing.T) {
+		ruleBytes, err := os.ReadFile("../../../../pkg/modules/aws/rules/ec2/ec2-imdsv1-enabled.yaml")
+		require.NoError(t, err)
+
+		var rule common.YAMLRule
+		err = yaml.Unmarshal(ruleBytes, &rule)
+		require.NoError(t, err)
+
+		analyzer := common.NewYAMLAnalyzer([]common.YAMLRule{rule})
+
+		for _, instance := range testInstances {
+			analyzerResults, err := analyzer.Run(plugin.Config{
+				Context: context.Background(),
+				Args:    map[string]any{"resource": instance},
+			})
+			require.NoError(t, err)
+			findings, ok := analyzerResults[0].Data.([]plugin.Finding)
+			require.True(t, ok)
+
+			if flaggedIDSet[instance.ResourceID] {
+				assert.NotEmpty(t, findings,
+					"instance %s (IMDSv1 allowed) should produce a finding", instance.ResourceID)
+				if len(findings) > 0 {
+					assert.Equal(t, "ec2-imdsv1-enabled", findings[0].RuleID)
+					assert.Equal(t, "medium", findings[0].Severity)
+				}
+			} else if safeIDSet[instance.ResourceID] {
+				assert.Empty(t, findings,
+					"instance %s (safe) should not produce a finding", instance.ResourceID)
+			}
+		}
+	})
+}

--- a/test/terraform/aws/recon/ec2-imds-check/main.tf
+++ b/test/terraform/aws/recon/ec2-imds-check/main.tf
@@ -1,0 +1,82 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+
+  backend "s3" {
+    # All configured via -backend-config at init time
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "random_id" "run" {
+  byte_length = 4
+}
+
+locals {
+  prefix = "aurelian-imds-${random_id.run.hex}"
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+}
+
+# TC1: IMDSv1 allowed (should be flagged)
+resource "aws_instance" "imdsv1_allowed" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t3.micro"
+
+  metadata_options {
+    http_tokens   = "optional"
+    http_endpoint = "enabled"
+  }
+
+  tags = {
+    Name = "${local.prefix}-imdsv1-allowed"
+  }
+}
+
+# TC2: IMDSv2 enforced (should NOT be flagged)
+resource "aws_instance" "imdsv2_enforced" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t3.micro"
+
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
+
+  tags = {
+    Name = "${local.prefix}-imdsv2-enforced"
+  }
+}
+
+# TC3: IMDS disabled (should NOT be flagged)
+resource "aws_instance" "imds_disabled" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t3.micro"
+
+  metadata_options {
+    http_endpoint = "disabled"
+  }
+
+  tags = {
+    Name = "${local.prefix}-imds-disabled"
+  }
+}

--- a/test/terraform/aws/recon/ec2-imds-check/outputs.tf
+++ b/test/terraform/aws/recon/ec2-imds-check/outputs.tf
@@ -1,0 +1,19 @@
+output "flagged_instance_ids" {
+  value = [aws_instance.imdsv1_allowed.id]
+}
+
+output "safe_instance_ids" {
+  value = [aws_instance.imdsv2_enforced.id, aws_instance.imds_disabled.id]
+}
+
+output "all_instance_ids" {
+  value = [
+    aws_instance.imdsv1_allowed.id,
+    aws_instance.imdsv2_enforced.id,
+    aws_instance.imds_disabled.id,
+  ]
+}
+
+output "prefix" {
+  value = local.prefix
+}

--- a/test/terraform/aws/recon/ec2-imds-check/variables.tf
+++ b/test/terraform/aws/recon/ec2-imds-check/variables.tf
@@ -1,0 +1,4 @@
+variable "region" {
+  description = "AWS region to deploy test resources"
+  default     = "us-east-1"
+}


### PR DESCRIPTION
## Summary
- Adds an enricher (`ec2_imds.go`) that calls `ec2:DescribeInstances` to fetch `MetadataOptions` for each EC2 instance, since CloudControl's `ListResources` doesn't return this data
- Adds a YAML rule (`ec2-imdsv1-enabled.yaml`) that flags running instances with IMDS enabled but IMDSv1 not disabled (HttpTokens != required)
- Includes unit tests (6 cases) and integration test with Terraform infra (3 EC2 instances: IMDSv1 allowed, IMDSv2 enforced, IMDS disabled)

## Dependencies
- **Integration tests require a fix to `test/testutil/fixture.go`** — the hardcoded state bucket name `aurelian-integration-tests` is owned by another AWS account (403). A separate PR will add `resolveStateBucket()` using STS `GetCallerIdentity` to dynamically construct the bucket name.

## Linear
Closes LAB-1198

## Test plan
- [x] `go build` compiles cleanly
- [x] Unit tests pass (`go test ./pkg/modules/aws/enrichers/...`)
- [x] Integration test passes: enrichment adds IMDS properties to all 3 instances
- [x] Integration test passes: YAML rule flags only IMDSv1-allowed instance, zero false positives