### PR TITLE
refactor: consolidate duplicate template loader

### DIFF
--- a/pkg/templates/azure/loader.go
+++ b/pkg/templates/azure/loader.go
@@ -2,115 +2,14 @@ package azure
 
 import (
 	"embed"
-	"fmt"
-	"os"
-	"path/filepath"
 
-	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/templates"
-	"gopkg.in/yaml.v3"
 )
 
 //go:embed *.yaml
 var embeddedTemplates embed.FS
 
-// Loader loads ARG query templates from embedded files and optional user directories.
-type Loader struct {
-	templates []*templates.ARGQueryTemplate
-}
-
-// NewLoader creates a Loader pre-populated with all embedded YAML templates.
-func NewLoader() (*Loader, error) {
-	l := &Loader{}
-
-	entries, err := embeddedTemplates.ReadDir(".")
-	if err != nil {
-		return nil, fmt.Errorf("failed to read embedded azure templates: %w", err)
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
-			continue
-		}
-
-		data, err := embeddedTemplates.ReadFile(entry.Name())
-		if err != nil {
-			return nil, fmt.Errorf("failed to read embedded template %s: %w", entry.Name(), err)
-		}
-
-		var tmpl templates.ARGQueryTemplate
-		if err := yaml.Unmarshal(data, &tmpl); err != nil {
-			return nil, fmt.Errorf("failed to parse template %s: %w", entry.Name(), err)
-		}
-
-		if err := validateTemplate(&tmpl); err != nil {
-			return nil, fmt.Errorf("invalid template %s: %w", entry.Name(), err)
-		}
-
-		l.templates = append(l.templates, &tmpl)
-	}
-
-	return l, nil
-}
-
-// LoadUserTemplates loads additional templates from a user-specified directory.
-func (l *Loader) LoadUserTemplates(dir string) error {
-	if dir == "" {
-		return nil
-	}
-
-	info, err := os.Stat(dir)
-	if err != nil {
-		return fmt.Errorf("template directory %q: %w", dir, err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("%q is not a directory", dir)
-	}
-
-	files, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
-	if err != nil {
-		return fmt.Errorf("failed to list template files: %w", err)
-	}
-
-	for _, file := range files {
-		data, err := os.ReadFile(file)
-		if err != nil {
-			return fmt.Errorf("failed to read template %s: %w", file, err)
-		}
-
-		var tmpl templates.ARGQueryTemplate
-		if err := yaml.Unmarshal(data, &tmpl); err != nil {
-			return fmt.Errorf("failed to parse template %s: %w", file, err)
-		}
-
-		if err := validateTemplate(&tmpl); err != nil {
-			return fmt.Errorf("invalid template %s: %w", file, err)
-		}
-
-		l.templates = append(l.templates, &tmpl)
-	}
-
-	return nil
-}
-
-// GetTemplates returns all loaded templates.
-func (l *Loader) GetTemplates() []*templates.ARGQueryTemplate {
-	return l.templates
-}
-
-func validateTemplate(t *templates.ARGQueryTemplate) error {
-	if t.ID == "" {
-		return fmt.Errorf("template ID is required")
-	}
-	if t.Name == "" {
-		return fmt.Errorf("template name is required")
-	}
-	if t.Query == "" {
-		return fmt.Errorf("template query is required")
-	}
-	if t.Severity == "" {
-		return fmt.Errorf("template severity is required")
-	}
-	t.Severity = output.NormalizeSeverity(t.Severity)
-	return nil
+// NewLoader creates a TemplateLoader pre-populated with all embedded Azure YAML templates.
+func NewLoader() (*templates.TemplateLoader, error) {
+	return templates.NewTemplateLoader(embeddedTemplates)
 }

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"gopkg.in/yaml.v3"
 )
@@ -12,52 +13,41 @@ import (
 //go:embed *.yaml
 var EmbeddedTemplates embed.FS
 
-// TemplateSource specifies the source of templates to load
-type TemplateSource int
-
-const (
-	LoadEmbedded TemplateSource = iota
-	UserTemplatesOnly
-)
-
 // TemplateLoader loads templates from both embedded files and optional user-supplied directory
 type TemplateLoader struct {
 	templates []*ARGQueryTemplate
 }
 
-// NewTemplateLoader creates a new template loader with specified source
-func NewTemplateLoader(source TemplateSource) (*TemplateLoader, error) {
+// NewTemplateLoader creates a new template loader that reads YAML templates from the given embed.FS.
+func NewTemplateLoader(fs embed.FS) (*TemplateLoader, error) {
 	loader := &TemplateLoader{}
 
-	if source == LoadEmbedded {
-		// Load embedded templates
-		entries, err := EmbeddedTemplates.ReadDir(".")
-		if err != nil {
-			return nil, fmt.Errorf("failed to read embedded templates: %v", err)
-		}
-
-		for _, entry := range entries {
-			if !entry.IsDir() && filepath.Ext(entry.Name()) == ".yaml" {
-				data, err := EmbeddedTemplates.ReadFile(entry.Name())
-				if err != nil {
-					return nil, fmt.Errorf("failed to read embedded template %s: %v", entry.Name(), err)
-				}
-
-				var template ARGQueryTemplate
-				if err := yaml.Unmarshal(data, &template); err != nil {
-					return nil, fmt.Errorf("failed to parse embedded template %s: %v", entry.Name(), err)
-				}
-
-				// Validate template
-				if err := validateTemplate(&template); err != nil {
-					return nil, fmt.Errorf("invalid embedded template %s: %v", entry.Name(), err)
-				}
-
-				loader.templates = append(loader.templates, &template)
-			}
-		}
+	entries, err := fs.ReadDir(".")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read embedded templates: %w", err)
 	}
-	// For UserTemplatesOnly, we start with empty templates slice
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+
+		data, err := fs.ReadFile(entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read embedded template %s: %w", entry.Name(), err)
+		}
+
+		var template ARGQueryTemplate
+		if err := yaml.Unmarshal(data, &template); err != nil {
+			return nil, fmt.Errorf("failed to parse embedded template %s: %w", entry.Name(), err)
+		}
+
+		if err := ValidateTemplate(&template); err != nil {
+			return nil, fmt.Errorf("invalid embedded template %s: %w", entry.Name(), err)
+		}
+
+		loader.templates = append(loader.templates, &template)
+	}
 
 	return loader, nil
 }
@@ -100,7 +90,7 @@ func (l *TemplateLoader) LoadUserTemplates(templateDir string) error {
 		}
 
 		// Validate template
-		if err := validateTemplate(&template); err != nil {
+		if err := ValidateTemplate(&template); err != nil {
 			return fmt.Errorf("invalid template %s: %v", file, err)
 		}
 
@@ -119,8 +109,8 @@ func (l *TemplateLoader) GetTemplates() []*ARGQueryTemplate {
 	return l.templates
 }
 
-// validateTemplate performs basic validation and normalizes severity to lowercase.
-func validateTemplate(template *ARGQueryTemplate) error {
+// ValidateTemplate performs basic validation and normalizes severity to lowercase.
+func ValidateTemplate(template *ARGQueryTemplate) error {
 	if template.ID == "" {
 		return fmt.Errorf("template ID is required")
 	}

--- a/pkg/templates/templates_types.go
+++ b/pkg/templates/templates_types.go
@@ -11,7 +11,8 @@ type ARGQueryTemplate struct {
 	Query       string              `yaml:"query"`
 	Category    []string            `yaml:"category"`
 	References  []string            `yaml:"references"`
-	TriageNotes string              `yaml:"triageNotes,omitempty"`
+	TriageNotes   string              `yaml:"triageNotes,omitempty"`
+	Reportability string              `yaml:"reportability,omitempty"`
 }
 
 // ARGQueryResult represents a standardized result from an ARG query


### PR DESCRIPTION
## Summary

- **Consolidate duplicate template loader**: `pkg/templates/azure/loader.go` was a near-copy of `pkg/templates/templates.go`. Replaced with a thin wrapper that delegates to `templates.NewTemplateLoader(embed.FS)`.
- **Export `ValidateTemplate`**: Renamed from unexported `validateTemplate` so the azure package can call it instead of duplicating the logic.
- **Add `Reportability` field**: Many YAML templates include `reportability: Automatic` or `reportability: Manual Triage` but the struct was missing this field, causing silent data loss during unmarshalling.

## Test plan

- [x] `go vet ./pkg/templates/...` passes
- [x] `go test ./pkg/templates/azure/...` — all 5 tests pass
- [x] `go vet ./pkg/modules/azure/recon/...` passes
- [x] Unit tests in `pkg/modules/azure/recon/` pass