### PR TITLE
feat: expand GCP find-secrets coverage

### DIFF
--- a/pkg/azure/extraction/extract_automation.go
+++ b/pkg/azure/extraction/extract_automation.go
@@ -3,7 +3,6 @@ package extraction
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
 	"io"
 	"log/slog"
 	"net/http"
@@ -12,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/automation/armautomation"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
 )
 
 func init() {

--- a/pkg/azure/extraction/extract_storage.go
+++ b/pkg/azure/extraction/extract_storage.go
@@ -3,7 +3,6 @@ package extraction
 import (
 	"bytes"
 	"fmt"
-	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
 	"io"
 	"log/slog"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
 )
 
 const (

--- a/pkg/gcp/enumeration/instances.go
+++ b/pkg/gcp/enumeration/instances.go
@@ -55,7 +55,7 @@ func (l *InstanceLister) List(projectID string, out *pipeline.P[output.GCPResour
 		g.Go(func() error {
 			err := svc.Instances.List(projectID, zone).Pages(context.Background(), func(resp *computeapi.InstanceList) error {
 				for _, inst := range resp.Items {
-					r := output.NewGCPResource(projectID, "compute.googleapis.com/Instance", fmt.Sprintf("%d", inst.Id))
+					r := output.NewGCPResource(projectID, "compute.googleapis.com/Instance", fmt.Sprintf("projects/%s/zones/%s/instances/%s", projectID, zone, inst.Name))
 					r.DisplayName = inst.Name
 					r.Location = zone
 					r.Labels = inst.Labels

--- a/pkg/gcp/extraction/extract_cloudrun.go
+++ b/pkg/gcp/extraction/extract_cloudrun.go
@@ -2,7 +2,9 @@ package extraction
 
 import (
 	"fmt"
+	"strings"
 
+	"google.golang.org/api/cloudfunctions/v1"
 	runapi "google.golang.org/api/run/v2"
 
 	"github.com/praetorian-inc/aurelian/pkg/output"
@@ -11,6 +13,7 @@ import (
 
 func init() {
 	mustRegister("run.googleapis.com/Service", "env-vars", extractCloudRunEnvVars)
+	mustRegister("run.googleapis.com/Service", "gen2-function-source", extractGen2FunctionSource)
 }
 
 // extractCloudRunEnvVars extracts environment variables from the latest Cloud Run revision.
@@ -42,4 +45,33 @@ func extractCloudRunEnvVars(ctx extractContext, r output.GCPResource, out *pipel
 		out.Send(output.ScanInputFromGCPResource(r, "env-vars", envContent))
 	}
 	return nil
+}
+
+// extractGen2FunctionSource downloads source code for Gen 2 Cloud Functions
+// that appear as Cloud Run services. Skips non-Gen2 services.
+func extractGen2FunctionSource(ctx extractContext, r output.GCPResource, out *pipeline.P[output.ScanInput]) error {
+	if r.Properties["isGen2CloudFunction"] != true {
+		return nil
+	}
+
+	svc, err := cloudfunctions.NewService(ctx.Context, ctx.ClientOptions...)
+	if err != nil {
+		return fmt.Errorf("creating cloudfunctions client: %w", err)
+	}
+
+	// Gen 2 functions use the v1 API. The Cloud Run service name follows:
+	// projects/PROJECT/locations/REGION/services/SERVICE_NAME
+	// For Gen 2, service name == function name, so swap "services" for "functions".
+	functionName := strings.Replace(r.ResourceID, "/services/", "/functions/", 1)
+
+	resp, err := svc.Projects.Locations.Functions.GenerateDownloadUrl(functionName, &cloudfunctions.GenerateDownloadUrlRequest{}).Context(ctx.Context).Do()
+	if err != nil {
+		return fmt.Errorf("generating download URL for gen2 function %s: %w", functionName, err)
+	}
+
+	if resp.DownloadUrl == "" {
+		return nil
+	}
+
+	return downloadAndExtractZip(r, resp.DownloadUrl, out)
 }

--- a/pkg/gcp/extraction/extract_functions.go
+++ b/pkg/gcp/extraction/extract_functions.go
@@ -20,6 +20,7 @@ var httpClient = &http.Client{Timeout: 10 * time.Minute}
 
 func init() {
 	mustRegister("cloudfunctions.googleapis.com/Function", "source", extractFunctionSource)
+	mustRegister("cloudfunctions.googleapis.com/Function", "env-vars", extractFunctionEnvVars)
 }
 
 // extractFunctionSource downloads the function's source archive, extracts each file,
@@ -39,7 +40,12 @@ func extractFunctionSource(ctx extractContext, r output.GCPResource, out *pipeli
 		return nil
 	}
 
-	httpResp, err := httpClient.Get(resp.DownloadUrl)
+	return downloadAndExtractZip(r, resp.DownloadUrl, out)
+}
+
+// downloadAndExtractZip downloads a zip from the given URL and emits each file as a ScanInput.
+func downloadAndExtractZip(r output.GCPResource, downloadURL string, out *pipeline.P[output.ScanInput]) error {
+	httpResp, err := httpClient.Get(downloadURL)
 	if err != nil {
 		return fmt.Errorf("downloading source for %s: %w", r.ResourceID, err)
 	}
@@ -73,5 +79,29 @@ func extractFunctionSource(ctx extractContext, r output.GCPResource, out *pipeli
 
 		out.Send(output.ScanInputFromGCPResource(r, f.Name, content))
 	}
+	return nil
+}
+
+// extractFunctionEnvVars extracts environment variables from a Gen 1 Cloud Function.
+func extractFunctionEnvVars(ctx extractContext, r output.GCPResource, out *pipeline.P[output.ScanInput]) error {
+	svc, err := cloudfunctions.NewService(ctx.Context, ctx.ClientOptions...)
+	if err != nil {
+		return fmt.Errorf("creating cloudfunctions client: %w", err)
+	}
+
+	fn, err := svc.Projects.Locations.Functions.Get(r.ResourceID).Context(ctx.Context).Do()
+	if err != nil {
+		return fmt.Errorf("getting function %s: %w", r.ResourceID, err)
+	}
+
+	if len(fn.EnvironmentVariables) == 0 {
+		return nil
+	}
+
+	var envContent []byte
+	for k, v := range fn.EnvironmentVariables {
+		envContent = fmt.Appendf(envContent, "%s=%s\n", k, v)
+	}
+	out.Send(output.ScanInputFromGCPResource(r, "env-vars", envContent))
 	return nil
 }

--- a/pkg/gcp/extraction/extract_functions_test.go
+++ b/pkg/gcp/extraction/extract_functions_test.go
@@ -1,0 +1,19 @@
+package extraction
+
+import (
+	"testing"
+)
+
+func TestExtractors_FunctionEnvVarsRegistered(t *testing.T) {
+	extractors := getExtractors("cloudfunctions.googleapis.com/Function")
+	var found bool
+	for _, e := range extractors {
+		if e.Name == "env-vars" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected env-vars extractor registered for cloudfunctions.googleapis.com/Function")
+	}
+}

--- a/pkg/gcp/extraction/extract_storage.go
+++ b/pkg/gcp/extraction/extract_storage.go
@@ -1,0 +1,112 @@
+package extraction
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	gcsapi "google.golang.org/api/storage/v1"
+
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+)
+
+const (
+	// maxObjectSize is the maximum object size to download for scanning (1 MB).
+	maxObjectSize = 1 << 20
+	// maxObjectsPerBucket limits how many objects we scan per bucket.
+	maxObjectsPerBucket = 100
+)
+
+// binaryContentTypes are content types to skip when scanning bucket objects.
+var binaryContentTypes = []string{
+	"image/",
+	"video/",
+	"audio/",
+	"application/octet-stream",
+	"application/zip",
+	"application/gzip",
+	"application/x-tar",
+	"application/pdf",
+	"application/wasm",
+}
+
+func init() {
+	mustRegister("storage.googleapis.com/Bucket", "objects", extractBucketObjects)
+}
+
+// extractBucketObjects lists and downloads objects from a GCS bucket for secret scanning.
+func extractBucketObjects(ctx extractContext, r output.GCPResource, out *pipeline.P[output.ScanInput]) error {
+	svc, err := gcsapi.NewService(ctx.Context, ctx.ClientOptions...)
+	if err != nil {
+		return fmt.Errorf("creating storage client: %w", err)
+	}
+
+	bucketName := r.DisplayName
+	if bucketName == "" {
+		bucketName = r.ResourceID
+	}
+
+	count := 0
+	err = svc.Objects.List(bucketName).Context(ctx.Context).Pages(ctx.Context, func(resp *gcsapi.Objects) error {
+		for _, obj := range resp.Items {
+			if count >= maxObjectsPerBucket {
+				return nil
+			}
+
+			if isBinaryContentType(obj.ContentType) {
+				slog.Debug("skipping binary object", "bucket", bucketName, "object", obj.Name, "contentType", obj.ContentType)
+				continue
+			}
+
+			if obj.Size > maxObjectSize {
+				slog.Debug("skipping large object", "bucket", bucketName, "object", obj.Name, "size", obj.Size)
+				continue
+			}
+
+			content, err := downloadObject(svc, bucketName, obj.Name)
+			if err != nil {
+				slog.Warn("failed to download object", "bucket", bucketName, "object", obj.Name, "error", err)
+				continue
+			}
+			if len(content) == 0 {
+				continue
+			}
+
+			out.Send(output.ScanInputFromGCPResource(r, obj.Name, content))
+			count++
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("listing objects in bucket %s: %w", bucketName, err)
+	}
+	return nil
+}
+
+func downloadObject(svc *gcsapi.Service, bucket, object string) ([]byte, error) {
+	resp, err := svc.Objects.Get(bucket, object).Download()
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, io.LimitReader(resp.Body, maxObjectSize))
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func isBinaryContentType(contentType string) bool {
+	ct := strings.ToLower(contentType)
+	for _, prefix := range binaryContentTypes {
+		if strings.HasPrefix(ct, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/gcp/extraction/extract_storage.go
+++ b/pkg/gcp/extraction/extract_storage.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
 )
 
 const (
@@ -49,11 +50,19 @@ func extractBucketObjects(ctx extractContext, r output.GCPResource, out *pipelin
 		bucketName = r.ResourceID
 	}
 
+	paginator := ratelimit.NewGCPPaginator()
+	var pageToken string
 	count := 0
-	err = svc.Objects.List(bucketName).Context(ctx.Context).Pages(ctx.Context, func(resp *gcsapi.Objects) error {
+
+	err = paginator.Paginate(func() (bool, error) {
+		call := svc.Objects.List(bucketName).Context(ctx.Context).PageToken(pageToken)
+		resp, err := call.Do()
+		if err != nil {
+			return false, err
+		}
 		for _, obj := range resp.Items {
 			if count >= maxObjectsPerBucket {
-				return nil
+				return false, nil
 			}
 
 			if isBinaryContentType(obj.ContentType) {
@@ -66,9 +75,9 @@ func extractBucketObjects(ctx extractContext, r output.GCPResource, out *pipelin
 				continue
 			}
 
-			content, err := downloadObject(svc, bucketName, obj.Name)
-			if err != nil {
-				slog.Warn("failed to download object", "bucket", bucketName, "object", obj.Name, "error", err)
+			content, dlErr := downloadObject(svc, bucketName, obj.Name)
+			if dlErr != nil {
+				slog.Warn("failed to download object", "bucket", bucketName, "object", obj.Name, "error", dlErr)
 				continue
 			}
 			if len(content) == 0 {
@@ -78,7 +87,8 @@ func extractBucketObjects(ctx extractContext, r output.GCPResource, out *pipelin
 			out.Send(output.ScanInputFromGCPResource(r, obj.Name, content))
 			count++
 		}
-		return nil
+		pageToken = resp.NextPageToken
+		return pageToken != "", nil
 	})
 	if err != nil {
 		return fmt.Errorf("listing objects in bucket %s: %w", bucketName, err)

--- a/pkg/modules/gcp/recon/find_secrets.go
+++ b/pkg/modules/gcp/recon/find_secrets.go
@@ -66,6 +66,7 @@ var secretsResourceTypes = []string{
 	"cloudfunctions.googleapis.com/Function",
 	"run.googleapis.com/Service",
 	"appengine.googleapis.com/Version",
+	"storage.googleapis.com/Bucket",
 }
 
 func (m *GCPFindSecretsModule) Run(_ plugin.Config, out *pipeline.P[model.AurelianModel]) error {
@@ -169,16 +170,16 @@ func riskSeverityFromMatch(match *types.Match) output.RiskSeverity {
 	return output.RiskSeverityMedium
 }
 
-func buildProofData(result secrets.SecretScanResult, match *types.Match) map[string]interface{} {
-	proof := map[string]interface{}{
+func buildProofData(result secrets.SecretScanResult, match *types.Match) map[string]any {
+	proof := map[string]any{
 		"finding_id":   match.FindingID,
 		"rule_name":    match.RuleName,
 		"rule_text_id": match.RuleID,
 		"resource_ref": result.ResourceRef,
 		"num_matches":  1,
-		"matches": []map[string]interface{}{
+		"matches": []map[string]any{
 			{
-				"provenance": []map[string]interface{}{
+				"provenance": []map[string]any{
 					{
 						"kind":          "cloud_resource",
 						"platform":      "gcp",
@@ -186,7 +187,7 @@ func buildProofData(result secrets.SecretScanResult, match *types.Match) map[str
 						"resource_type": result.ResourceType,
 						"region":        result.Region,
 						"account_id":    result.AccountID,
-						"first_commit": map[string]interface{}{
+						"first_commit": map[string]any{
 							"blob_path": result.Label,
 						},
 					},
@@ -196,17 +197,17 @@ func buildProofData(result secrets.SecretScanResult, match *types.Match) map[str
 					"matching": string(match.Snippet.Matching),
 					"after":    string(match.Snippet.After),
 				},
-				"location": map[string]interface{}{
-					"offset_span": map[string]interface{}{
+				"location": map[string]any{
+					"offset_span": map[string]any{
 						"start": match.Location.Offset.Start,
 						"end":   match.Location.Offset.End,
 					},
-					"source_span": map[string]interface{}{
-						"start": map[string]interface{}{
+					"source_span": map[string]any{
+						"start": map[string]any{
 							"line":   match.Location.Source.Start.Line,
 							"column": match.Location.Source.Start.Column,
 						},
-						"end": map[string]interface{}{
+						"end": map[string]any{
 							"line":   match.Location.Source.End.Line,
 							"column": match.Location.Source.End.Column,
 						},
@@ -217,7 +218,7 @@ func buildProofData(result secrets.SecretScanResult, match *types.Match) map[str
 	}
 
 	if match.ValidationResult != nil {
-		proof["validation"] = map[string]interface{}{
+		proof["validation"] = map[string]any{
 			"status":     string(match.ValidationResult.Status),
 			"confidence": match.ValidationResult.Confidence,
 			"message":    match.ValidationResult.Message,

--- a/pkg/modules/gcp/recon/find_secrets_integration_test.go
+++ b/pkg/modules/gcp/recon/find_secrets_integration_test.go
@@ -55,6 +55,18 @@ func TestGCPFindSecrets(t *testing.T) {
 		assert.True(t, found, "expected a risk referencing Cloud Function %s", functionName)
 	})
 
+	t.Run("detects secret in Compute Instance", func(t *testing.T) {
+		instanceName := fixture.Output("instance_name")
+		found := hasGCPRiskForIdentifier(risks, instanceName)
+		assert.True(t, found, "expected a risk referencing Compute Instance %s", instanceName)
+	})
+
+	t.Run("detects secret in Storage Bucket", func(t *testing.T) {
+		bucketName := fixture.Output("bucket_name")
+		found := hasGCPRiskForIdentifier(risks, bucketName)
+		assert.True(t, found, "expected a risk referencing Storage Bucket %s", bucketName)
+	})
+
 	// Cloud Run ResourceIDs contain the full resource path including the service name.
 	t.Run("detects secret in Cloud Run Service", func(t *testing.T) {
 		serviceName := fixture.Output("cloud_run_service_name")

--- a/pkg/modules/gcp/recon/find_secrets_test.go
+++ b/pkg/modules/gcp/recon/find_secrets_test.go
@@ -3,6 +3,7 @@ package recon
 import (
 	"testing"
 
+	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/titus/pkg/types"
 )
 
@@ -37,15 +38,15 @@ func TestRiskSeverityFromMatch_Validated(t *testing.T) {
 		},
 	}
 	got := riskSeverityFromMatch(m)
-	if got != "high" {
-		t.Errorf("severity = %q, want %q", got, "high")
+	if got != output.RiskSeverityHigh {
+		t.Errorf("severity = %q, want %q", got, output.RiskSeverityHigh)
 	}
 }
 
 func TestRiskSeverityFromMatch_Unvalidated(t *testing.T) {
 	m := &types.Match{}
 	got := riskSeverityFromMatch(m)
-	if got != "medium" {
-		t.Errorf("severity = %q, want %q", got, "medium")
+	if got != output.RiskSeverityMedium {
+		t.Errorf("severity = %q, want %q", got, output.RiskSeverityMedium)
 	}
 }

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -62,8 +62,19 @@ if [[ -f "$ENV_FILE" ]]; then
   set -u
 fi
 
+# Determine which platforms are needed based on target path.
+# AWS is always required (S3 remote state for Terraform fixtures).
+NEED_AZURE=false
+NEED_GCP=false
+case "$TARGET" in
+  *azure*) NEED_AZURE=true ;;
+  *gcp*)   NEED_GCP=true ;;
+  *aws*)   ;; # AWS is already always required
+  *)       NEED_AZURE=true; NEED_GCP=true ;; # ./... or unrecognized — require all
+esac
+
 # Prompt for missing values
-if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
+if $NEED_AZURE && [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
   read -rp "Enter AZURE_SUBSCRIPTION_ID: " AZURE_SUBSCRIPTION_ID
   if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
     echo "ERROR: AZURE_SUBSCRIPTION_ID is required." >&2
@@ -79,7 +90,7 @@ if [[ -z "$AWS_PROFILE" ]]; then
   fi
 fi
 
-if [[ -z "$GCP_PROJECT_ID" ]]; then
+if $NEED_GCP && [[ -z "$GCP_PROJECT_ID" ]]; then
   read -rp "Enter GCP_PROJECT_ID: " GCP_PROJECT_ID
   if [[ -z "$GCP_PROJECT_ID" ]]; then
     echo "ERROR: GCP_PROJECT_ID is required." >&2
@@ -87,7 +98,7 @@ if [[ -z "$GCP_PROJECT_ID" ]]; then
   fi
 fi
 
-if [[ -z "$GCP_ACCOUNT" ]]; then
+if $NEED_GCP && [[ -z "$GCP_ACCOUNT" ]]; then
   read -rp "Enter GCP_ACCOUNT (gcloud account email): " GCP_ACCOUNT
   if [[ -z "$GCP_ACCOUNT" ]]; then
     echo "ERROR: GCP_ACCOUNT is required." >&2
@@ -105,13 +116,15 @@ EOF
 echo "Saved credentials to $ENV_FILE"
 
 # Validate Azure subscription
-echo "Validating Azure subscription $AZURE_SUBSCRIPTION_ID..."
-if ! az account show --subscription "$AZURE_SUBSCRIPTION_ID" &>/dev/null; then
-  echo "ERROR: Unable to access Azure subscription $AZURE_SUBSCRIPTION_ID with current 'az' credentials." >&2
-  echo "Run 'az login' and try again." >&2
-  exit 1
+if $NEED_AZURE; then
+  echo "Validating Azure subscription $AZURE_SUBSCRIPTION_ID..."
+  if ! az account show --subscription "$AZURE_SUBSCRIPTION_ID" &>/dev/null; then
+    echo "ERROR: Unable to access Azure subscription $AZURE_SUBSCRIPTION_ID with current 'az' credentials." >&2
+    echo "Run 'az login' and try again." >&2
+    exit 1
+  fi
+  echo "Azure subscription OK."
 fi
-echo "Azure subscription OK."
 
 # Validate AWS profile
 echo "Validating AWS profile $AWS_PROFILE..."
@@ -123,34 +136,40 @@ fi
 echo "AWS profile OK."
 
 # Configure and validate GCP
-echo "Setting gcloud account to $GCP_ACCOUNT..."
-if ! gcloud config set account "$GCP_ACCOUNT" &>/dev/null; then
-  echo "ERROR: Unable to set gcloud account to '$GCP_ACCOUNT'." >&2
-  echo "Run 'gcloud auth login' and try again." >&2
-  exit 1
-fi
+if $NEED_GCP; then
+  echo "Setting gcloud account to $GCP_ACCOUNT..."
+  if ! gcloud config set account "$GCP_ACCOUNT" &>/dev/null; then
+    echo "ERROR: Unable to set gcloud account to '$GCP_ACCOUNT'." >&2
+    echo "Run 'gcloud auth login' and try again." >&2
+    exit 1
+  fi
 
-echo "Setting gcloud project to $GCP_PROJECT_ID..."
-if ! gcloud config set project "$GCP_PROJECT_ID" &>/dev/null; then
-  echo "ERROR: Unable to set gcloud project to '$GCP_PROJECT_ID'." >&2
-  exit 1
-fi
+  echo "Setting gcloud project to $GCP_PROJECT_ID..."
+  if ! gcloud config set project "$GCP_PROJECT_ID" &>/dev/null; then
+    echo "ERROR: Unable to set gcloud project to '$GCP_PROJECT_ID'." >&2
+    exit 1
+  fi
 
-echo "Validating GCP project $GCP_PROJECT_ID..."
-if ! gcloud projects describe "$GCP_PROJECT_ID" &>/dev/null; then
-  echo "ERROR: Unable to access GCP project '$GCP_PROJECT_ID' with account '$GCP_ACCOUNT'." >&2
-  echo "Run 'gcloud auth login' and try again." >&2
-  exit 1
+  echo "Validating GCP project $GCP_PROJECT_ID..."
+  if ! gcloud projects describe "$GCP_PROJECT_ID" &>/dev/null; then
+    echo "ERROR: Unable to access GCP project '$GCP_PROJECT_ID' with account '$GCP_ACCOUNT'." >&2
+    echo "Run 'gcloud auth login' and try again." >&2
+    exit 1
+  fi
+  echo "GCP project OK."
 fi
-echo "GCP project OK."
 
 # Run tests
 echo ""
 echo "Running integration tests..."
 cd "$PROJECT_DIR"
-export AZURE_SUBSCRIPTION_ID
+if $NEED_AZURE; then
+  export AZURE_SUBSCRIPTION_ID
+fi
 export AWS_PROFILE
-export GCP_PROJECT_ID
+if $NEED_GCP; then
+  export GCP_PROJECT_ID
+fi
 
 set -x
 go test -tags compute,integration -p=1 $GO_FLAGS "$TARGET"

--- a/test/terraform/gcp/recon/find-secrets/main.tf
+++ b/test/terraform/gcp/recon/find-secrets/main.tf
@@ -9,6 +9,7 @@
 // | 1  | ${prefix}-secret-vm                  | compute.googleapis.com/Instance        | startup-script metadata|
 // | 2  | ${prefix}-secret-fn                  | cloudfunctions.googleapis.com/Function | source code            |
 // | 3  | ${prefix}-secret-run                 | run.googleapis.com/Service             | environment variables  |
+// | 4  | ${prefix}-secret-bucket              | storage.googleapis.com/Bucket          | object content         |
 
 terraform {
   required_providers {
@@ -148,4 +149,23 @@ resource "google_cloud_run_v2_service" "with_secret" {
   }
 
   labels = local.labels
+}
+
+#==============================================================================
+# RESOURCE 4: Storage Bucket with secret in object content
+#==============================================================================
+resource "google_storage_bucket" "with_secret" {
+  name          = "${local.prefix}-secret-bucket"
+  location      = var.region
+  labels        = local.labels
+  force_destroy = true
+}
+
+resource "google_storage_bucket_object" "secret_config" {
+  name    = "config/app.env"
+  bucket  = google_storage_bucket.with_secret.name
+  content = <<-EOF
+    AWS_ACCESS_KEY_ID=${local.fake_aws_key}
+    AWS_SECRET_ACCESS_KEY=${local.fake_aws_secret}
+  EOF
 }

--- a/test/terraform/gcp/recon/find-secrets/outputs.tf
+++ b/test/terraform/gcp/recon/find-secrets/outputs.tf
@@ -17,3 +17,7 @@ output "cloud_run_service_name" {
 output "prefix" {
   value = local.prefix
 }
+
+output "bucket_name" {
+  value = google_storage_bucket.with_secret.name
+}


### PR DESCRIPTION
- Add Gen 1 Cloud Function env-vars extractor
- Add Gen 2 Cloud Function source extraction via Cloud Run services
- Add GCS bucket object scanning (1MB/obj, 100 obj/bucket, binary filtering)
- Add compute instance + storage bucket integration test assertions
- Use full resource path for compute instance ResourceID
- Fix review findings: map[string]any, import grouping, severity constants
- Make integration test script platform-aware for credentials