### PR TITLE
refactor(enrichers): extract shared helpers to eliminate duplicate code

### DIFF
--- a/pkg/modules/azure/enrichers/app_service.go
+++ b/pkg/modules/azure/enrichers/app_service.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v4"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/pkg/templates"
 )
@@ -37,7 +36,7 @@ func enrichAppServicePublicAccess(cfg plugin.AzureEnricherConfig, result *templa
 	commands = append(commands, mainCmd)
 
 	// Step 2: SCM/Kudu probe
-	scmCmd := probeAppServiceSCMSite(httpClient, appServiceName)
+	scmCmd := probeSCMSite(httpClient, appServiceName)
 	commands = append(commands, scmCmd)
 
 	// Step 3: For function apps, enumerate triggers via Management API
@@ -115,50 +114,6 @@ func probeAppServiceMainPage(client *http.Client, appName string) plugin.AzureEn
 	return cmd
 }
 
-// probeAppServiceSCMSite tests the SCM/Kudu management endpoint.
-func probeAppServiceSCMSite(client *http.Client, appName string) plugin.AzureEnrichmentCommand {
-	scmURL := fmt.Sprintf("https://%s.scm.azurewebsites.net", appName)
-
-	cmd := plugin.AzureEnrichmentCommand{
-		Command:                   fmt.Sprintf("curl -i --max-redirects 0 '%s' --max-time 10", scmURL),
-		Description:               "Test access to SCM/Kudu management site (high risk if accessible)",
-		ExpectedOutputDescription: "200 = SCM accessible (HIGH RISK) | 3xx = redirect (auth) | 401/403 = auth required | timeout = blocked",
-	}
-
-	resp, err := client.Get(scmURL)
-	if err != nil {
-		cmd.Error = err.Error()
-		cmd.ActualOutput = fmt.Sprintf("Request failed: %s", err.Error())
-		cmd.ExitCode = -1
-		return cmd
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1000))
-
-	var exitCode int
-	var verdict string
-	switch {
-	case resp.StatusCode >= 200 && resp.StatusCode < 300:
-		exitCode = 1
-		verdict = "SCM ACCESSIBLE (HIGH RISK)"
-	case resp.StatusCode >= 300 && resp.StatusCode < 400:
-		exitCode = 0
-		verdict = "Redirect (auth required)"
-	case resp.StatusCode == 401 || resp.StatusCode == 403:
-		exitCode = 0
-		verdict = "Auth required"
-	default:
-		exitCode = 0
-		verdict = fmt.Sprintf("HTTP %d", resp.StatusCode)
-	}
-
-	cmd.ActualOutput = fmt.Sprintf("Status: %d, %s\nBody preview: %s", resp.StatusCode, verdict, TruncateString(string(body), 200))
-	cmd.ExitCode = exitCode
-
-	return cmd
-}
-
 // enrichAppServiceFunctionApp uses the Management API to enumerate HTTP triggers,
 // check IP restrictions, and check EasyAuth for a function app embedded in an App Service.
 func enrichAppServiceFunctionApp(cfg plugin.AzureEnricherConfig, subscriptionID, resourceGroupName, appName string) []plugin.AzureEnrichmentCommand {
@@ -174,7 +129,7 @@ func enrichAppServiceFunctionApp(cfg plugin.AzureEnricherConfig, subscriptionID,
 	var commands []plugin.AzureEnrichmentCommand
 
 	// Check IP restrictions
-	ipCmd := checkAppServiceIPRestrictions(cfg, webAppsClient, resourceGroupName, appName)
+	ipCmd := checkIPRestrictionsCommand(cfg, webAppsClient, resourceGroupName, appName, "App Service")
 	commands = append(commands, ipCmd)
 
 	// Enumerate HTTP triggers
@@ -248,123 +203,8 @@ func enrichAppServiceFunctionApp(cfg plugin.AzureEnricherConfig, subscriptionID,
 	})
 
 	// Check EasyAuth as compensating control
-	easyAuthCmd := checkAppServiceEasyAuth(cfg, webAppsClient, resourceGroupName, appName)
+	easyAuthCmd := checkEasyAuthCommand(cfg, webAppsClient, resourceGroupName, appName)
 	commands = append(commands, easyAuthCmd)
 
 	return commands
-}
-
-// checkAppServiceIPRestrictions queries IP security restrictions via Management API.
-func checkAppServiceIPRestrictions(cfg plugin.AzureEnricherConfig, client *armappservice.WebAppsClient, resourceGroupName, appName string) plugin.AzureEnrichmentCommand {
-	cmd := plugin.AzureEnrichmentCommand{
-		Command:                   fmt.Sprintf("az webapp config access-restriction show --resource-group %s --name %s", resourceGroupName, appName),
-		Description:               "Check IP security restrictions via Management API (not available in ARG)",
-		ExpectedOutputDescription: "IP restrictions present = lower severity | No restrictions = fully open to internet",
-	}
-
-	siteConfig, err := client.GetConfiguration(cfg.Context, resourceGroupName, appName, nil)
-	if err != nil {
-		cmd.Error = err.Error()
-		cmd.ActualOutput = fmt.Sprintf("Error getting site configuration: %s", err.Error())
-		cmd.ExitCode = -1
-		return cmd
-	}
-
-	if siteConfig.Properties == nil || siteConfig.Properties.IPSecurityRestrictions == nil {
-		cmd.ActualOutput = "No IP restrictions configured — App Service is fully open to all internet traffic."
-		cmd.ExitCode = 1
-		return cmd
-	}
-
-	restrictions := siteConfig.Properties.IPSecurityRestrictions
-
-	// Filter out the default "Allow all" rule (priority 2147483647)
-	var meaningful []*armappservice.IPSecurityRestriction
-	for _, r := range restrictions {
-		if r.Priority != nil && *r.Priority == 2147483647 {
-			continue
-		}
-		meaningful = append(meaningful, r)
-	}
-
-	if len(meaningful) == 0 {
-		cmd.ActualOutput = "No IP restrictions configured — App Service is fully open to all internet traffic."
-		cmd.ExitCode = 1
-		return cmd
-	}
-
-	// Check if any meaningful rule is a broad allow-all
-	for _, r := range meaningful {
-		if r.Action != nil && strings.EqualFold(*r.Action, "Allow") {
-			if r.IPAddress != nil {
-				ip := strings.TrimSpace(*r.IPAddress)
-				if ip == "0.0.0.0/0" || ip == "::/0" {
-					cmd.ActualOutput = "No effective IP restrictions — broad allow-all rule (0.0.0.0/0) present. App Service is open to all internet traffic."
-					cmd.ExitCode = 1
-					return cmd
-				}
-			}
-			if r.Tag != nil && *r.Tag == armappservice.IPFilterTagServiceTag && r.IPAddress != nil {
-				if strings.EqualFold(strings.TrimSpace(*r.IPAddress), "Internet") {
-					cmd.ActualOutput = "No effective IP restrictions — Allow rule with ServiceTag 'Internet' present. App Service is open to all internet traffic."
-					cmd.ExitCode = 1
-					return cmd
-				}
-			}
-		}
-	}
-
-	var rsb strings.Builder
-	rsb.WriteString(fmt.Sprintf("IP restrictions found: %d rule(s)\n", len(meaningful)))
-	for _, r := range meaningful {
-		name := ""
-		if r.Name != nil {
-			name = *r.Name
-		}
-		action := ""
-		if r.Action != nil {
-			action = *r.Action
-		}
-		ipAddress := ""
-		if r.IPAddress != nil {
-			ipAddress = *r.IPAddress
-		}
-		priority := int32(0)
-		if r.Priority != nil {
-			priority = *r.Priority
-		}
-		rsb.WriteString(fmt.Sprintf("  [%d] %s: %s %s\n", priority, name, action, ipAddress))
-	}
-	rsb.WriteString("\nIP restrictions are present — network-level filtering is in place.")
-
-	cmd.ActualOutput = rsb.String()
-	cmd.ExitCode = 0
-	return cmd
-}
-
-// checkAppServiceEasyAuth queries EasyAuth / Entra ID platform authentication status.
-func checkAppServiceEasyAuth(cfg plugin.AzureEnricherConfig, client *armappservice.WebAppsClient, resourceGroupName, appName string) plugin.AzureEnrichmentCommand {
-	cmd := plugin.AzureEnrichmentCommand{
-		Command:                   fmt.Sprintf("az webapp auth show --resource-group %s --name %s", resourceGroupName, appName),
-		Description:               "Check EasyAuth / Entra ID platform authentication",
-		ExpectedOutputDescription: "Enabled = compensating control | Disabled = anonymous triggers are truly unauthenticated",
-	}
-
-	status := CheckEasyAuth(cfg.Context, client, resourceGroupName, appName)
-	if status.Err != nil {
-		cmd.Error = status.Err.Error()
-		cmd.ActualOutput = fmt.Sprintf("Error checking EasyAuth: %s", status.Err.Error())
-		cmd.ExitCode = -1
-		return cmd
-	}
-
-	if status.Enabled {
-		cmd.ActualOutput = "EasyAuth is ENABLED — platform enforces authentication before requests reach function code. Anonymous trigger auth levels are overridden by EasyAuth."
-		cmd.ExitCode = 0
-	} else {
-		cmd.ActualOutput = "EasyAuth is DISABLED — no platform-level authentication. Anonymous triggers are truly accessible without any authentication."
-		cmd.ExitCode = 1
-	}
-
-	return cmd
 }

--- a/pkg/modules/azure/enrichers/container_registry.go
+++ b/pkg/modules/azure/enrichers/container_registry.go
@@ -136,7 +136,7 @@ func getAnonymousACRToken(client *http.Client, loginServer, scope string) (strin
 
 	var tok tokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
-		return "", fmt.Errorf("failed to decode token response: %v", err)
+		return "", fmt.Errorf("failed to decode token response: %w", err)
 	}
 
 	return tok.AccessToken, nil

--- a/pkg/modules/azure/enrichers/event_grid.go
+++ b/pkg/modules/azure/enrichers/event_grid.go
@@ -1,13 +1,6 @@
 package enrichers
 
 import (
-	"bytes"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
-
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/pkg/templates"
 )
@@ -17,48 +10,6 @@ func init() {
 }
 
 func enrichEventGrid(cfg plugin.AzureEnricherConfig, result *templates.ARGQueryResult) ([]plugin.AzureEnrichmentCommand, error) {
-	eventGridName := result.ResourceName
-	location := result.Location
-
-	var eventGridEndpoint string
-	if ep, ok := result.Properties["endpoint"].(string); ok && ep != "" {
-		eventGridEndpoint = ep
-		if !strings.HasSuffix(eventGridEndpoint, "/api/events") {
-			eventGridEndpoint = strings.TrimSuffix(eventGridEndpoint, "/") + "/api/events"
-		}
-	} else {
-		if location == "" || eventGridName == "" {
-			return nil, nil
-		}
-		normalizedLocation := strings.TrimSpace(strings.ToLower(location))
-		eventGridEndpoint = fmt.Sprintf("https://%s.%s-1.eventgrid.azure.net/api/events", eventGridName, normalizedLocation)
-	}
-
-	client := NewHTTPClient(10 * time.Second)
-
-	body := bytes.NewBuffer([]byte("[]"))
-	req, err := http.NewRequestWithContext(cfg.Context, "POST", eventGridEndpoint, body)
-	if err != nil {
-		return nil, nil
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	cmd := plugin.AzureEnrichmentCommand{
-		Command:                   fmt.Sprintf("curl -X POST -H 'Content-Type: application/json' -d '[]' -i '%s' --max-time 10", eventGridEndpoint),
-		Description:               "Test Event Grid domain POST endpoint",
-		ExpectedOutputDescription: "401/405 = publicly accessible but authentication required | 403 = blocked via firewall rules",
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		cmd.ExitCode = 1
-		cmd.Error = err.Error()
-	} else {
-		defer resp.Body.Close()
-		io.Copy(io.Discard, resp.Body)
-		cmd.ActualOutput = fmt.Sprintf("HTTP %d", resp.StatusCode)
-		cmd.ExitCode = 0
-	}
-
-	return []plugin.AzureEnrichmentCommand{cmd}, nil
+	ep, _ := result.Properties["endpoint"].(string)
+	return enrichEventGridPOSTEndpoint(cfg.Context, result.ResourceName, result.Location, ep, "Test Event Grid domain POST endpoint")
 }

--- a/pkg/modules/azure/enrichers/event_grid_topics.go
+++ b/pkg/modules/azure/enrichers/event_grid_topics.go
@@ -1,13 +1,6 @@
 package enrichers
 
 import (
-	"bytes"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
-
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/pkg/templates"
 )
@@ -17,48 +10,6 @@ func init() {
 }
 
 func enrichEventGridTopics(cfg plugin.AzureEnricherConfig, result *templates.ARGQueryResult) ([]plugin.AzureEnrichmentCommand, error) {
-	topicName := result.ResourceName
-	location := result.Location
-
-	var topicEndpoint string
-	if ep, ok := result.Properties["endpoint"].(string); ok && ep != "" {
-		topicEndpoint = ep
-		if !strings.HasSuffix(topicEndpoint, "/api/events") {
-			topicEndpoint = strings.TrimSuffix(topicEndpoint, "/") + "/api/events"
-		}
-	} else {
-		if location == "" || topicName == "" {
-			return nil, nil
-		}
-		normalizedLocation := strings.TrimSpace(strings.ToLower(location))
-		topicEndpoint = fmt.Sprintf("https://%s.%s-1.eventgrid.azure.net/api/events", topicName, normalizedLocation)
-	}
-
-	client := NewHTTPClient(10 * time.Second)
-
-	body := bytes.NewBuffer([]byte("[]"))
-	req, err := http.NewRequestWithContext(cfg.Context, "POST", topicEndpoint, body)
-	if err != nil {
-		return nil, nil
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	cmd := plugin.AzureEnrichmentCommand{
-		Command:                   fmt.Sprintf("curl -X POST -H 'Content-Type: application/json' -d '[]' -i '%s' --max-time 10", topicEndpoint),
-		Description:               "Test Event Grid Topic POST endpoint",
-		ExpectedOutputDescription: "401/405 = publicly accessible but authentication required | 403 = blocked via firewall rules",
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		cmd.ExitCode = 1
-		cmd.Error = err.Error()
-	} else {
-		defer resp.Body.Close()
-		io.Copy(io.Discard, resp.Body)
-		cmd.ActualOutput = fmt.Sprintf("HTTP %d", resp.StatusCode)
-		cmd.ExitCode = 0
-	}
-
-	return []plugin.AzureEnrichmentCommand{cmd}, nil
+	ep, _ := result.Properties["endpoint"].(string)
+	return enrichEventGridPOSTEndpoint(cfg.Context, result.ResourceName, result.Location, ep, "Test Event Grid Topic POST endpoint")
 }

--- a/pkg/modules/azure/enrichers/function_app.go
+++ b/pkg/modules/azure/enrichers/function_app.go
@@ -39,7 +39,7 @@ func enrichFunctionApp(cfg plugin.AzureEnricherConfig, result *templates.ARGQuer
 	}
 
 	// Step 0: Check IP restrictions via Management API
-	ipRestrictionsCmd := funcAppCheckIPRestrictions(cfg, webAppsClient, resourceGroupName, functionAppName)
+	ipRestrictionsCmd := checkIPRestrictionsCommand(cfg, webAppsClient, resourceGroupName, functionAppName, "Function App")
 
 	// Step 1: Enumerate triggers from production slot
 	cliEquiv := fmt.Sprintf("az functionapp function list --resource-group %s --name %s", resourceGroupName, functionAppName)
@@ -79,11 +79,11 @@ func enrichFunctionApp(cfg plugin.AzureEnricherConfig, result *templates.ARGQuer
 	}
 
 	// Step 4: SCM/Kudu probe
-	scmCmd := funcAppTestSCMSite(client, functionAppName)
+	scmCmd := probeSCMSite(client, functionAppName)
 	commands = append(commands, scmCmd)
 
 	// Step 5: EasyAuth cross-reference
-	easyAuthCmd := funcAppCheckEasyAuth(cfg, webAppsClient, resourceGroupName, functionAppName)
+	easyAuthCmd := checkEasyAuthCommand(cfg, webAppsClient, resourceGroupName, functionAppName)
 	commands = append(commands, easyAuthCmd)
 
 	return commands, nil
@@ -245,161 +245,3 @@ func funcAppProbeInvokeURL(client *http.Client, trigger HTTPTriggerInfo) plugin.
 	return cmd
 }
 
-// funcAppTestSCMSite tests the SCM/Kudu management site.
-func funcAppTestSCMSite(client *http.Client, appName string) plugin.AzureEnrichmentCommand {
-	scmURL := fmt.Sprintf("https://%s.scm.azurewebsites.net", appName)
-
-	cmd := plugin.AzureEnrichmentCommand{
-		Command:                   fmt.Sprintf("curl -i --max-redirects 0 '%s' --max-time 10", scmURL),
-		Description:               "Test access to SCM/Kudu management site (high risk if accessible)",
-		ExpectedOutputDescription: "200 = SCM accessible (HIGH RISK) | 3xx = redirect (auth) | 401/403 = auth required | timeout = blocked",
-	}
-
-	resp, err := client.Get(scmURL)
-	if err != nil {
-		cmd.Error = err.Error()
-		cmd.ActualOutput = fmt.Sprintf("Request failed: %s", err.Error())
-		cmd.ExitCode = -1
-		return cmd
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1000))
-
-	var exitCode int
-	var verdict string
-	switch {
-	case resp.StatusCode >= 200 && resp.StatusCode < 300:
-		exitCode = 1
-		verdict = "SCM ACCESSIBLE (HIGH RISK)"
-	case resp.StatusCode >= 300 && resp.StatusCode < 400:
-		exitCode = 0
-		verdict = "Redirect (auth required)"
-	case resp.StatusCode == 401 || resp.StatusCode == 403:
-		exitCode = 0
-		verdict = "Auth required"
-	default:
-		exitCode = 0
-		verdict = fmt.Sprintf("HTTP %d", resp.StatusCode)
-	}
-
-	cmd.ActualOutput = fmt.Sprintf("HTTP %d — %s\nBody preview: %s", resp.StatusCode, verdict, TruncateString(string(body), 500))
-	cmd.ExitCode = exitCode
-
-	return cmd
-}
-
-// funcAppCheckIPRestrictions queries IP security restrictions via the Management API.
-func funcAppCheckIPRestrictions(cfg plugin.AzureEnricherConfig, client *armappservice.WebAppsClient, resourceGroupName, appName string) plugin.AzureEnrichmentCommand {
-	cmd := plugin.AzureEnrichmentCommand{
-		Command:                   fmt.Sprintf("az webapp config access-restriction show --resource-group %s --name %s", resourceGroupName, appName),
-		Description:               "Check IP security restrictions via Management API (not available in ARG)",
-		ExpectedOutputDescription: "IP restrictions present = lower severity (network-level filtering in place) | No restrictions = fully open to internet",
-	}
-
-	siteConfig, err := client.GetConfiguration(cfg.Context, resourceGroupName, appName, nil)
-	if err != nil {
-		cmd.Error = err.Error()
-		cmd.ActualOutput = fmt.Sprintf("Error getting site configuration: %s", err.Error())
-		cmd.ExitCode = -1
-		return cmd
-	}
-
-	if siteConfig.Properties == nil || siteConfig.Properties.IPSecurityRestrictions == nil {
-		cmd.ActualOutput = "No IP restrictions configured — Function App is fully open to all internet traffic."
-		cmd.ExitCode = 1
-		return cmd
-	}
-
-	restrictions := siteConfig.Properties.IPSecurityRestrictions
-
-	// Filter out the default "Allow all" rule (priority 2147483647)
-	var meaningful []*armappservice.IPSecurityRestriction
-	for _, r := range restrictions {
-		if r.Priority != nil && *r.Priority == 2147483647 {
-			continue
-		}
-		meaningful = append(meaningful, r)
-	}
-
-	if len(meaningful) == 0 {
-		cmd.ActualOutput = "No IP restrictions configured — Function App is fully open to all internet traffic."
-		cmd.ExitCode = 1
-		return cmd
-	}
-
-	// Check if any meaningful rule is a broad allow-all
-	for _, r := range meaningful {
-		if r.Action != nil && strings.EqualFold(*r.Action, "Allow") {
-			if r.IPAddress != nil {
-				ip := strings.TrimSpace(*r.IPAddress)
-				if ip == "0.0.0.0/0" || ip == "::/0" {
-					cmd.ActualOutput = "No effective IP restrictions — broad allow-all rule (0.0.0.0/0) present. Function App is open to all internet traffic."
-					cmd.ExitCode = 1
-					return cmd
-				}
-			}
-			if r.Tag != nil && *r.Tag == armappservice.IPFilterTagServiceTag && r.IPAddress != nil {
-				if strings.EqualFold(strings.TrimSpace(*r.IPAddress), "Internet") {
-					cmd.ActualOutput = "No effective IP restrictions — Allow rule with ServiceTag 'Internet' present. Function App is open to all internet traffic."
-					cmd.ExitCode = 1
-					return cmd
-				}
-			}
-		}
-	}
-
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("IP restrictions found: %d rule(s)\n", len(meaningful)))
-	for _, r := range meaningful {
-		name := ""
-		if r.Name != nil {
-			name = *r.Name
-		}
-		action := ""
-		if r.Action != nil {
-			action = *r.Action
-		}
-		ipAddress := ""
-		if r.IPAddress != nil {
-			ipAddress = *r.IPAddress
-		}
-		priority := int32(0)
-		if r.Priority != nil {
-			priority = *r.Priority
-		}
-		sb.WriteString(fmt.Sprintf("  [%d] %s: %s %s\n", priority, name, action, ipAddress))
-	}
-	sb.WriteString("\nIP restrictions are present — network-level filtering is in place. This is a compensating control that reduces exposure.")
-
-	cmd.ActualOutput = sb.String()
-	cmd.ExitCode = 0
-	return cmd
-}
-
-// funcAppCheckEasyAuth queries EasyAuth / Entra ID platform authentication status.
-func funcAppCheckEasyAuth(cfg plugin.AzureEnricherConfig, client *armappservice.WebAppsClient, resourceGroupName, appName string) plugin.AzureEnrichmentCommand {
-	cmd := plugin.AzureEnrichmentCommand{
-		Command:                   fmt.Sprintf("az webapp auth show --resource-group %s --name %s", resourceGroupName, appName),
-		Description:               "Check EasyAuth / Entra ID platform authentication",
-		ExpectedOutputDescription: "Enabled = compensating control present | Disabled = anonymous triggers are truly unauthenticated",
-	}
-
-	status := CheckEasyAuth(cfg.Context, client, resourceGroupName, appName)
-	if status.Err != nil {
-		cmd.Error = status.Err.Error()
-		cmd.ActualOutput = fmt.Sprintf("Error checking EasyAuth: %s", status.Err.Error())
-		cmd.ExitCode = -1
-		return cmd
-	}
-
-	if status.Enabled {
-		cmd.ActualOutput = "EasyAuth is ENABLED - platform enforces authentication before requests reach function code. Anonymous trigger auth levels are overridden by EasyAuth."
-		cmd.ExitCode = 0
-	} else {
-		cmd.ActualOutput = "EasyAuth is DISABLED - no platform-level authentication. Anonymous triggers are truly accessible without any authentication."
-		cmd.ExitCode = 1
-	}
-
-	return cmd
-}

--- a/pkg/modules/azure/enrichers/helpers.go
+++ b/pkg/modules/azure/enrichers/helpers.go
@@ -1,7 +1,9 @@
 package enrichers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -296,4 +298,254 @@ func ExtractHTMLTitle(body string) string {
 	}
 
 	return strings.TrimSpace(body[contentStart : contentStart+end])
+}
+
+// derefString safely dereferences a string pointer, returning "" if nil.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// probeSCMSite tests the SCM/Kudu management endpoint for an App Service or Function App.
+func probeSCMSite(client *http.Client, appName string) plugin.AzureEnrichmentCommand {
+	scmURL := fmt.Sprintf("https://%s.scm.azurewebsites.net", appName)
+
+	cmd := plugin.AzureEnrichmentCommand{
+		Command:                   fmt.Sprintf("curl -i --max-redirects 0 '%s' --max-time 10", scmURL),
+		Description:               "Test access to SCM/Kudu management site (high risk if accessible)",
+		ExpectedOutputDescription: "200 = SCM accessible (HIGH RISK) | 3xx = redirect (auth) | 401/403 = auth required | timeout = blocked",
+	}
+
+	resp, err := client.Get(scmURL)
+	if err != nil {
+		cmd.Error = err.Error()
+		cmd.ActualOutput = fmt.Sprintf("Request failed: %s", err.Error())
+		cmd.ExitCode = -1
+		return cmd
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1000))
+
+	var exitCode int
+	var verdict string
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		exitCode = 1
+		verdict = "SCM ACCESSIBLE (HIGH RISK)"
+	case resp.StatusCode >= 300 && resp.StatusCode < 400:
+		exitCode = 0
+		verdict = "Redirect (auth required)"
+	case resp.StatusCode == 401 || resp.StatusCode == 403:
+		exitCode = 0
+		verdict = "Auth required"
+	default:
+		exitCode = 0
+		verdict = fmt.Sprintf("HTTP %d", resp.StatusCode)
+	}
+
+	cmd.ActualOutput = fmt.Sprintf("HTTP %d — %s\nBody preview: %s", resp.StatusCode, verdict, TruncateString(string(body), 500))
+	cmd.ExitCode = exitCode
+
+	return cmd
+}
+
+// checkIPRestrictionsCommand queries IP security restrictions via the Management API.
+// resourceLabel is used in messages (e.g. "App Service" or "Function App").
+func checkIPRestrictionsCommand(cfg plugin.AzureEnricherConfig, client *armappservice.WebAppsClient, resourceGroup, appName, resourceLabel string) plugin.AzureEnrichmentCommand {
+	cmd := plugin.AzureEnrichmentCommand{
+		Command:                   fmt.Sprintf("az webapp config access-restriction show --resource-group %s --name %s", resourceGroup, appName),
+		Description:               "Check IP security restrictions via Management API (not available in ARG)",
+		ExpectedOutputDescription: "IP restrictions present = lower severity | No restrictions = fully open to internet",
+	}
+
+	siteConfig, err := client.GetConfiguration(cfg.Context, resourceGroup, appName, nil)
+	if err != nil {
+		cmd.Error = err.Error()
+		cmd.ActualOutput = fmt.Sprintf("Error getting site configuration: %s", err.Error())
+		cmd.ExitCode = -1
+		return cmd
+	}
+
+	if siteConfig.Properties == nil || siteConfig.Properties.IPSecurityRestrictions == nil {
+		cmd.ActualOutput = fmt.Sprintf("No IP restrictions configured — %s is fully open to all internet traffic.", resourceLabel)
+		cmd.ExitCode = 1
+		return cmd
+	}
+
+	restrictions := siteConfig.Properties.IPSecurityRestrictions
+
+	// Filter out the default "Allow all" rule (priority 2147483647)
+	var meaningful []*armappservice.IPSecurityRestriction
+	for _, r := range restrictions {
+		if r.Priority != nil && *r.Priority == 2147483647 {
+			continue
+		}
+		meaningful = append(meaningful, r)
+	}
+
+	if len(meaningful) == 0 {
+		cmd.ActualOutput = fmt.Sprintf("No IP restrictions configured — %s is fully open to all internet traffic.", resourceLabel)
+		cmd.ExitCode = 1
+		return cmd
+	}
+
+	// Check if any meaningful rule is a broad allow-all
+	for _, r := range meaningful {
+		if r.Action != nil && strings.EqualFold(*r.Action, "Allow") {
+			if r.IPAddress != nil {
+				ip := strings.TrimSpace(*r.IPAddress)
+				if ip == "0.0.0.0/0" || ip == "::/0" {
+					cmd.ActualOutput = fmt.Sprintf("No effective IP restrictions — broad allow-all rule (0.0.0.0/0) present. %s is open to all internet traffic.", resourceLabel)
+					cmd.ExitCode = 1
+					return cmd
+				}
+			}
+			if r.Tag != nil && *r.Tag == armappservice.IPFilterTagServiceTag && r.IPAddress != nil {
+				if strings.EqualFold(strings.TrimSpace(*r.IPAddress), "Internet") {
+					cmd.ActualOutput = fmt.Sprintf("No effective IP restrictions — Allow rule with ServiceTag 'Internet' present. %s is open to all internet traffic.", resourceLabel)
+					cmd.ExitCode = 1
+					return cmd
+				}
+			}
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("IP restrictions found: %d rule(s)\n", len(meaningful)))
+	for _, r := range meaningful {
+		sb.WriteString(fmt.Sprintf("  [%d] %s: %s %s\n",
+			derefInt32(r.Priority), derefString(r.Name), derefString(r.Action), derefString(r.IPAddress)))
+	}
+	sb.WriteString("\nIP restrictions are present — network-level filtering is in place.")
+
+	cmd.ActualOutput = sb.String()
+	cmd.ExitCode = 0
+	return cmd
+}
+
+// derefInt32 safely dereferences an int32 pointer, returning 0 if nil.
+func derefInt32(p *int32) int32 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+// checkEasyAuthCommand queries EasyAuth / Entra ID platform authentication status.
+func checkEasyAuthCommand(cfg plugin.AzureEnricherConfig, client *armappservice.WebAppsClient, resourceGroup, appName string) plugin.AzureEnrichmentCommand {
+	cmd := plugin.AzureEnrichmentCommand{
+		Command:                   fmt.Sprintf("az webapp auth show --resource-group %s --name %s", resourceGroup, appName),
+		Description:               "Check EasyAuth / Entra ID platform authentication",
+		ExpectedOutputDescription: "Enabled = compensating control | Disabled = anonymous triggers are truly unauthenticated",
+	}
+
+	status := CheckEasyAuth(cfg.Context, client, resourceGroup, appName)
+	if status.Err != nil {
+		cmd.Error = status.Err.Error()
+		cmd.ActualOutput = fmt.Sprintf("Error checking EasyAuth: %s", status.Err.Error())
+		cmd.ExitCode = -1
+		return cmd
+	}
+
+	if status.Enabled {
+		cmd.ActualOutput = "EasyAuth is ENABLED — platform enforces authentication before requests reach function code. Anonymous trigger auth levels are overridden by EasyAuth."
+		cmd.ExitCode = 0
+	} else {
+		cmd.ActualOutput = "EasyAuth is DISABLED — no platform-level authentication. Anonymous triggers are truly accessible without any authentication."
+		cmd.ExitCode = 1
+	}
+
+	return cmd
+}
+
+// firewallRuleOutput represents a firewall rule in the format expected by Azure CLI output.
+type firewallRuleOutput struct {
+	EndIPAddress   string `json:"endIpAddress"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	ResourceGroup  string `json:"resourceGroup"`
+	StartIPAddress string `json:"startIpAddress"`
+	Type           string `json:"type"`
+}
+
+// buildFirewallRulesCommand creates an enrichment command that fetches firewall rules
+// using the provided callback and formats them as JSON.
+func buildFirewallRulesCommand(azCommand, description string, fetchRules func() ([]firewallRuleOutput, error)) plugin.AzureEnrichmentCommand {
+	rules, err := fetchRules()
+	if err != nil {
+		return plugin.AzureEnrichmentCommand{
+			Command:      azCommand,
+			Description:  description + " (SDK failed)",
+			ActualOutput: fmt.Sprintf("SDK retrieval failed: %s", err.Error()),
+			Error:        err.Error(),
+			ExitCode:     1,
+		}
+	}
+
+	output := "[]"
+	if len(rules) > 0 {
+		b, err := json.MarshalIndent(rules, "", "  ")
+		if err != nil {
+			output = fmt.Sprintf("Error formatting output: %s", err.Error())
+		} else {
+			output = string(b)
+		}
+	}
+
+	return plugin.AzureEnrichmentCommand{
+		Command:                   azCommand,
+		Description:               description,
+		ExpectedOutputDescription: "List of firewall rules with names and IP address ranges",
+		ActualOutput:              output,
+		ExitCode:                  0,
+	}
+}
+
+// enrichEventGridPOSTEndpoint tests an Event Grid endpoint by POSTing an empty events array.
+// endpointFromProps is the endpoint extracted from resource properties (may be empty).
+func enrichEventGridPOSTEndpoint(ctx context.Context, resourceName, location, endpointFromProps, description string) ([]plugin.AzureEnrichmentCommand, error) {
+	var endpoint string
+	if endpointFromProps != "" {
+		endpoint = endpointFromProps
+		if !strings.HasSuffix(endpoint, "/api/events") {
+			endpoint = strings.TrimSuffix(endpoint, "/") + "/api/events"
+		}
+	} else {
+		if location == "" || resourceName == "" {
+			return nil, nil
+		}
+		normalizedLocation := strings.TrimSpace(strings.ToLower(location))
+		endpoint = fmt.Sprintf("https://%s.%s-1.eventgrid.azure.net/api/events", resourceName, normalizedLocation)
+	}
+
+	client := NewHTTPClient(10 * time.Second)
+
+	body := bytes.NewBuffer([]byte("[]"))
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, body)
+	if err != nil {
+		return nil, nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	cmd := plugin.AzureEnrichmentCommand{
+		Command:                   fmt.Sprintf("curl -X POST -H 'Content-Type: application/json' -d '[]' -i '%s' --max-time 10", endpoint),
+		Description:               description,
+		ExpectedOutputDescription: "401/405 = publicly accessible but authentication required | 403 = blocked via firewall rules",
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		cmd.ExitCode = 1
+		cmd.Error = err.Error()
+	} else {
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body)
+		cmd.ActualOutput = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		cmd.ExitCode = 0
+	}
+
+	return []plugin.AzureEnrichmentCommand{cmd}, nil
 }

--- a/pkg/modules/azure/enrichers/mysql_flexible_server.go
+++ b/pkg/modules/azure/enrichers/mysql_flexible_server.go
@@ -2,9 +2,7 @@ package enrichers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
@@ -41,11 +39,12 @@ func enrichMySQLFlexibleServer(cfg plugin.AzureEnricherConfig, result *templates
 
 func getMySQLFirewallRulesCommand(cfg plugin.AzureEnricherConfig, subscriptionID, resourceGroup, serverName string) plugin.AzureEnrichmentCommand {
 	azCommand := fmt.Sprintf("az mysql flexible-server firewall-rule list --resource-group %s --server-name %s", resourceGroup, serverName)
+	description := "Retrieve MySQL Flexible Server firewall rules"
 
 	if serverName == "" || subscriptionID == "" || resourceGroup == "" {
 		return plugin.AzureEnrichmentCommand{
 			Command:      azCommand,
-			Description:  "Retrieve MySQL Flexible Server firewall rules",
+			Description:  description,
 			ActualOutput: "Error: Server name, subscription ID, or resource group is missing",
 			ExitCode:     1,
 		}
@@ -56,86 +55,33 @@ func getMySQLFirewallRulesCommand(cfg plugin.AzureEnricherConfig, subscriptionID
 		ctx = context.Background()
 	}
 
-	clientFactory, err := armmysqlflexibleservers.NewClientFactory(subscriptionID, cfg.Credential, nil)
-	if err != nil {
-		return plugin.AzureEnrichmentCommand{
-			Command:      azCommand,
-			Description:  "Retrieve MySQL Flexible Server firewall rules (SDK failed)",
-			ActualOutput: fmt.Sprintf("SDK retrieval failed: %s", err.Error()),
-			Error:        err.Error(),
-			ExitCode:     1,
-		}
-	}
-
-	firewallClient := clientFactory.NewFirewallRulesClient()
-	pager := firewallClient.NewListByServerPager(resourceGroup, serverName, nil)
-
-	type mysqlFirewallRuleOutput struct {
-		EndIPAddress   string `json:"endIpAddress"`
-		ID             string `json:"id"`
-		Name           string `json:"name"`
-		ResourceGroup  string `json:"resourceGroup"`
-		StartIPAddress string `json:"startIpAddress"`
-		Type           string `json:"type"`
-	}
-
-	var outputRules []mysqlFirewallRuleOutput
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
+	return buildFirewallRulesCommand(azCommand, description, func() ([]firewallRuleOutput, error) {
+		clientFactory, err := armmysqlflexibleservers.NewClientFactory(subscriptionID, cfg.Credential, nil)
 		if err != nil {
-			return plugin.AzureEnrichmentCommand{
-				Command:      azCommand,
-				Description:  "Retrieve MySQL Flexible Server firewall rules (SDK failed)",
-				ActualOutput: fmt.Sprintf("SDK retrieval failed: %s", err.Error()),
-				Error:        err.Error(),
-				ExitCode:     1,
-			}
+			return nil, err
 		}
-		for _, rule := range page.Value {
-			if rule == nil {
-				continue
-			}
-			o := mysqlFirewallRuleOutput{Type: "Microsoft.DBforMySQL/flexibleServers/firewallRules"}
-			if rule.Name != nil {
-				o.Name = *rule.Name
-			}
-			if rule.ID != nil {
-				o.ID = *rule.ID
-				parts := strings.Split(o.ID, "/")
-				for i, part := range parts {
-					if part == "resourceGroups" && i+1 < len(parts) {
-						o.ResourceGroup = parts[i+1]
-						break
-					}
-				}
-			}
-			if rule.Properties != nil {
-				if rule.Properties.StartIPAddress != nil {
-					o.StartIPAddress = *rule.Properties.StartIPAddress
-				}
-				if rule.Properties.EndIPAddress != nil {
-					o.EndIPAddress = *rule.Properties.EndIPAddress
-				}
-			}
-			outputRules = append(outputRules, o)
-		}
-	}
 
-	output := "[]"
-	if len(outputRules) > 0 {
-		b, err := json.MarshalIndent(outputRules, "", "  ")
-		if err != nil {
-			output = fmt.Sprintf("Error formatting output: %s", err.Error())
-		} else {
-			output = string(b)
+		pager := clientFactory.NewFirewallRulesClient().NewListByServerPager(resourceGroup, serverName, nil)
+		var rules []firewallRuleOutput
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, rule := range page.Value {
+				if rule == nil || rule.Properties == nil {
+					continue
+				}
+				rules = append(rules, firewallRuleOutput{
+					Type:           "Microsoft.DBforMySQL/flexibleServers/firewallRules",
+					Name:           derefString(rule.Name),
+					ID:             derefString(rule.ID),
+					ResourceGroup:  ParseResourceGroup(derefString(rule.ID)),
+					StartIPAddress: derefString(rule.Properties.StartIPAddress),
+					EndIPAddress:   derefString(rule.Properties.EndIPAddress),
+				})
+			}
 		}
-	}
-
-	return plugin.AzureEnrichmentCommand{
-		Command:                   azCommand,
-		Description:               "Retrieve MySQL Flexible Server firewall rules",
-		ExpectedOutputDescription: "List of firewall rules with names and IP address ranges",
-		ActualOutput:              output,
-		ExitCode:                  0,
-	}
+		return rules, nil
+	})
 }

--- a/pkg/modules/azure/enrichers/postgresql_flexible_server.go
+++ b/pkg/modules/azure/enrichers/postgresql_flexible_server.go
@@ -2,9 +2,7 @@ package enrichers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers"
@@ -41,11 +39,12 @@ func enrichPostgreSQLFlexibleServer(cfg plugin.AzureEnricherConfig, result *temp
 
 func getPostgreSQLFirewallRulesCommand(cfg plugin.AzureEnricherConfig, subscriptionID, resourceGroup, serverName string) plugin.AzureEnrichmentCommand {
 	azCommand := fmt.Sprintf("az postgres flexible-server firewall-rule list --resource-group %s --server-name %s", resourceGroup, serverName)
+	description := "Retrieve PostgreSQL Flexible Server firewall rules"
 
 	if serverName == "" || subscriptionID == "" || resourceGroup == "" {
 		return plugin.AzureEnrichmentCommand{
 			Command:      azCommand,
-			Description:  "Retrieve PostgreSQL Flexible Server firewall rules",
+			Description:  description,
 			ActualOutput: "Error: Server name, subscription ID, or resource group is missing",
 			ExitCode:     1,
 		}
@@ -56,85 +55,33 @@ func getPostgreSQLFirewallRulesCommand(cfg plugin.AzureEnricherConfig, subscript
 		ctx = context.Background()
 	}
 
-	firewallClient, err := armpostgresqlflexibleservers.NewFirewallRulesClient(subscriptionID, cfg.Credential, nil)
-	if err != nil {
-		return plugin.AzureEnrichmentCommand{
-			Command:      azCommand,
-			Description:  "Retrieve PostgreSQL Flexible Server firewall rules (SDK failed)",
-			ActualOutput: fmt.Sprintf("SDK retrieval failed: %s", err.Error()),
-			Error:        err.Error(),
-			ExitCode:     1,
-		}
-	}
-
-	pager := firewallClient.NewListByServerPager(resourceGroup, serverName, nil)
-
-	type pgFirewallRuleOutput struct {
-		EndIPAddress   string `json:"endIpAddress"`
-		ID             string `json:"id"`
-		Name           string `json:"name"`
-		ResourceGroup  string `json:"resourceGroup"`
-		StartIPAddress string `json:"startIpAddress"`
-		Type           string `json:"type"`
-	}
-
-	var outputRules []pgFirewallRuleOutput
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
+	return buildFirewallRulesCommand(azCommand, description, func() ([]firewallRuleOutput, error) {
+		firewallClient, err := armpostgresqlflexibleservers.NewFirewallRulesClient(subscriptionID, cfg.Credential, nil)
 		if err != nil {
-			return plugin.AzureEnrichmentCommand{
-				Command:      azCommand,
-				Description:  "Retrieve PostgreSQL Flexible Server firewall rules (SDK failed)",
-				ActualOutput: fmt.Sprintf("SDK retrieval failed: %s", err.Error()),
-				Error:        err.Error(),
-				ExitCode:     1,
-			}
+			return nil, err
 		}
-		for _, rule := range page.Value {
-			if rule == nil {
-				continue
-			}
-			o := pgFirewallRuleOutput{Type: "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules"}
-			if rule.Name != nil {
-				o.Name = *rule.Name
-			}
-			if rule.ID != nil {
-				o.ID = *rule.ID
-				parts := strings.Split(o.ID, "/")
-				for i, part := range parts {
-					if part == "resourceGroups" && i+1 < len(parts) {
-						o.ResourceGroup = parts[i+1]
-						break
-					}
-				}
-			}
-			if rule.Properties != nil {
-				if rule.Properties.StartIPAddress != nil {
-					o.StartIPAddress = *rule.Properties.StartIPAddress
-				}
-				if rule.Properties.EndIPAddress != nil {
-					o.EndIPAddress = *rule.Properties.EndIPAddress
-				}
-			}
-			outputRules = append(outputRules, o)
-		}
-	}
 
-	output := "[]"
-	if len(outputRules) > 0 {
-		b, err := json.MarshalIndent(outputRules, "", "  ")
-		if err != nil {
-			output = fmt.Sprintf("Error formatting output: %s", err.Error())
-		} else {
-			output = string(b)
+		pager := firewallClient.NewListByServerPager(resourceGroup, serverName, nil)
+		var rules []firewallRuleOutput
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, rule := range page.Value {
+				if rule == nil || rule.Properties == nil {
+					continue
+				}
+				rules = append(rules, firewallRuleOutput{
+					Type:           "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules",
+					Name:           derefString(rule.Name),
+					ID:             derefString(rule.ID),
+					ResourceGroup:  ParseResourceGroup(derefString(rule.ID)),
+					StartIPAddress: derefString(rule.Properties.StartIPAddress),
+					EndIPAddress:   derefString(rule.Properties.EndIPAddress),
+				})
+			}
 		}
-	}
-
-	return plugin.AzureEnrichmentCommand{
-		Command:                   azCommand,
-		Description:               "Retrieve PostgreSQL Flexible Server firewall rules",
-		ExpectedOutputDescription: "List of firewall rules with names and IP address ranges",
-		ActualOutput:              output,
-		ExitCode:                  0,
-	}
+		return rules, nil
+	})
 }

--- a/pkg/modules/azure/enrichers/sql_server.go
+++ b/pkg/modules/azure/enrichers/sql_server.go
@@ -2,9 +2,7 @@ package enrichers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql/v2"
@@ -41,11 +39,12 @@ func enrichSQLServer(cfg plugin.AzureEnricherConfig, result *templates.ARGQueryR
 
 func getSQLFirewallRulesCommand(cfg plugin.AzureEnricherConfig, subscriptionID, resourceGroup, serverName string) plugin.AzureEnrichmentCommand {
 	azCommand := fmt.Sprintf("az sql server firewall-rule list --resource-group %s --server %s", resourceGroup, serverName)
+	description := "Retrieve SQL Server firewall rules"
 
 	if serverName == "" || subscriptionID == "" || resourceGroup == "" {
 		return plugin.AzureEnrichmentCommand{
 			Command:      azCommand,
-			Description:  "Retrieve SQL Server firewall rules",
+			Description:  description,
 			ActualOutput: "Error: Server name, subscription ID, or resource group is missing",
 			ExitCode:     1,
 		}
@@ -56,86 +55,33 @@ func getSQLFirewallRulesCommand(cfg plugin.AzureEnricherConfig, subscriptionID, 
 		ctx = context.Background()
 	}
 
-	clientFactory, err := armsql.NewClientFactory(subscriptionID, cfg.Credential, nil)
-	if err != nil {
-		return plugin.AzureEnrichmentCommand{
-			Command:      azCommand,
-			Description:  "Retrieve SQL Server firewall rules (SDK failed)",
-			ActualOutput: fmt.Sprintf("SDK retrieval failed: %s", err.Error()),
-			Error:        err.Error(),
-			ExitCode:     1,
-		}
-	}
-
-	firewallClient := clientFactory.NewFirewallRulesClient()
-	pager := firewallClient.NewListByServerPager(resourceGroup, serverName, nil)
-
-	type firewallRuleOutput struct {
-		EndIPAddress   string `json:"endIpAddress"`
-		ID             string `json:"id"`
-		Name           string `json:"name"`
-		ResourceGroup  string `json:"resourceGroup"`
-		StartIPAddress string `json:"startIpAddress"`
-		Type           string `json:"type"`
-	}
-
-	var outputRules []firewallRuleOutput
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
+	return buildFirewallRulesCommand(azCommand, description, func() ([]firewallRuleOutput, error) {
+		clientFactory, err := armsql.NewClientFactory(subscriptionID, cfg.Credential, nil)
 		if err != nil {
-			return plugin.AzureEnrichmentCommand{
-				Command:      azCommand,
-				Description:  "Retrieve SQL Server firewall rules (SDK failed)",
-				ActualOutput: fmt.Sprintf("SDK retrieval failed: %s", err.Error()),
-				Error:        err.Error(),
-				ExitCode:     1,
-			}
+			return nil, err
 		}
-		for _, rule := range page.Value {
-			if rule == nil {
-				continue
-			}
-			o := firewallRuleOutput{Type: "Microsoft.Sql/servers/firewallRules"}
-			if rule.Name != nil {
-				o.Name = *rule.Name
-			}
-			if rule.ID != nil {
-				o.ID = *rule.ID
-				parts := strings.Split(o.ID, "/")
-				for i, part := range parts {
-					if part == "resourceGroups" && i+1 < len(parts) {
-						o.ResourceGroup = parts[i+1]
-						break
-					}
-				}
-			}
-			if rule.Properties != nil {
-				if rule.Properties.StartIPAddress != nil {
-					o.StartIPAddress = *rule.Properties.StartIPAddress
-				}
-				if rule.Properties.EndIPAddress != nil {
-					o.EndIPAddress = *rule.Properties.EndIPAddress
-				}
-			}
-			outputRules = append(outputRules, o)
-		}
-	}
 
-	output := "[]"
-	if len(outputRules) > 0 {
-		b, err := json.MarshalIndent(outputRules, "", "  ")
-		if err != nil {
-			output = fmt.Sprintf("Error formatting output: %s", err.Error())
-		} else {
-			output = string(b)
+		pager := clientFactory.NewFirewallRulesClient().NewListByServerPager(resourceGroup, serverName, nil)
+		var rules []firewallRuleOutput
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, rule := range page.Value {
+				if rule == nil || rule.Properties == nil {
+					continue
+				}
+				rules = append(rules, firewallRuleOutput{
+					Type:           "Microsoft.Sql/servers/firewallRules",
+					Name:           derefString(rule.Name),
+					ID:             derefString(rule.ID),
+					ResourceGroup:  ParseResourceGroup(derefString(rule.ID)),
+					StartIPAddress: derefString(rule.Properties.StartIPAddress),
+					EndIPAddress:   derefString(rule.Properties.EndIPAddress),
+				})
+			}
 		}
-	}
-
-	return plugin.AzureEnrichmentCommand{
-		Command:                   azCommand,
-		Description:               "Retrieve SQL Server firewall rules",
-		ExpectedOutputDescription: "List of firewall rules with names and IP address ranges",
-		ActualOutput:              output,
-		ExitCode:                  0,
-	}
+		return rules, nil
+	})
 }


### PR DESCRIPTION
Consolidate duplicated logic across Azure enrichers into shared helpers:
- probeSCMSite, checkIPRestrictionsCommand, checkEasyAuthCommand for App Service and Function App enrichers (~330 lines removed)
- buildFirewallRulesCommand with callback pattern for SQL, PostgreSQL, and MySQL firewall rule fetchers (shared output struct + JSON marshal)
- enrichEventGridPOSTEndpoint for Event Grid Topic and Domain enrichers
- derefString/derefInt32 helpers for safe pointer dereferences

Also fix error wrapping: %v → %w in container_registry.go.