### PR TITLE
Add --validate flag to find-secrets modules

### DIFF
--- a/docs/aurelian_aws_recon_find-secrets.md
+++ b/docs/aurelian_aws_recon_find-secrets.md
@@ -28,6 +28,7 @@ aurelian aws recon find-secrets [flags]
   -r, --regions strings                AWS regions to scan (default [all])
   -a, --resource-arn strings           AWS target resource ARN
   -t, --resource-type strings          AWS Cloud Control resource type (default [all])
+      --validate                       Validate detected secrets against their source APIs
 ```
 
 ### SEE ALSO

--- a/docs/aurelian_azure_recon_find-secrets.md
+++ b/docs/aurelian_azure_recon_find-secrets.md
@@ -14,6 +14,7 @@ aurelian azure recon find-secrets [flags]
   -h, --help                           help for find-secrets
       --output-dir string              Base output directory (default "aurelian-output")
   -s, --subscription-ids strings       Azure subscription ID(s) or 'all' to enumerate all accessible subscriptions (default [all])
+      --validate                       Validate detected secrets against their source APIs
 ```
 
 ### SEE ALSO

--- a/docs/aurelian_gcp_recon_find-secrets.md
+++ b/docs/aurelian_gcp_recon_find-secrets.md
@@ -20,6 +20,7 @@ aurelian gcp recon find-secrets [flags]
       --output-dir string              Base output directory (default "aurelian-output")
   -p, --project-id strings             GCP project IDs
   -t, --resource-type strings          Resource types to enumerate (default [all])
+      --validate                       Validate detected secrets against their source APIs
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,9 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.8 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/terraform-json v0.27.1 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.7.2 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,12 @@ github.com/hashicorp/terraform-json v0.27.1 h1:zWhEracxJW6lcjt/JvximOYyc12pS/gaK
 github.com/hashicorp/terraform-json v0.27.1/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.7.2 h1:mLoDLV6sonKlvjIEsV56SkWNCnuNv531l94GaIzO+XI=
+github.com/jackc/pgx/v5 v5.7.2/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
@@ -312,6 +318,7 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=

--- a/pkg/modules/aws/recon/find_secrets.go
+++ b/pkg/modules/aws/recon/find_secrets.go
@@ -76,7 +76,7 @@ func (m *AWSFindSecretsModule) Run(cfg plugin.Config, out *pipeline.P[model.Aure
 	}
 
 	var s secrets.SecretScanner
-	if err := s.Start(c.DBPath, c.DisabledTitusRules); err != nil {
+	if err := s.Start(c.ScannerConfig); err != nil {
 		return fmt.Errorf("failed to create Titus scanner: %w", err)
 	}
 	defer func() {

--- a/pkg/modules/azure/recon/find_secrets.go
+++ b/pkg/modules/azure/recon/find_secrets.go
@@ -68,7 +68,7 @@ func (m *AzureFindSecretsModule) Run(_ plugin.Config, out *pipeline.P[model.Aure
 	}
 
 	var s secrets.SecretScanner
-	if err := s.Start(c.DBPath, c.DisabledTitusRules); err != nil {
+	if err := s.Start(c.ScannerConfig); err != nil {
 		return fmt.Errorf("failed to create Titus scanner: %w", err)
 	}
 	defer func() {

--- a/pkg/modules/gcp/recon/find_secrets.go
+++ b/pkg/modules/gcp/recon/find_secrets.go
@@ -75,7 +75,7 @@ func (m *GCPFindSecretsModule) Run(_ plugin.Config, out *pipeline.P[model.Aureli
 	}
 
 	var s secrets.SecretScanner
-	if err := s.Start(c.DBPath, c.DisabledTitusRules); err != nil {
+	if err := s.Start(c.ScannerConfig); err != nil {
 		return fmt.Errorf("failed to create Titus scanner: %w", err)
 	}
 	defer func() {

--- a/pkg/secrets/scanner.go
+++ b/pkg/secrets/scanner.go
@@ -1,17 +1,21 @@
 package secrets
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/titus/pkg/types"
+	"github.com/praetorian-inc/titus/pkg/validator"
 )
 
 // SecretScanner provides an object-oriented interface for scanning content for secrets.
 type SecretScanner struct {
-	ps *persistentScanner
+	ps       *persistentScanner
+	validate bool
+	engine   *validator.Engine
 }
 
 // SecretScanResult represents a secret detection result emitted by the scanner.
@@ -25,15 +29,21 @@ type SecretScanResult struct {
 }
 
 // Start creates a new persistent scanner and stores it as a field.
-// The dbPath parameter specifies the SQLite database path; if empty, a default is used.
-// Any rules whose IDs appear in disabledRules are excluded from scanning.
-func (s *SecretScanner) Start(dbPath string, disabledRules []string) error {
-	ps, err := newPersistentScanner(dbPath, disabledRules)
+func (s *SecretScanner) Start(cfg ScannerConfig) error {
+	ps, err := newPersistentScanner(cfg.DBPath, cfg.DisabledTitusRules)
 	if err != nil {
 		return fmt.Errorf("failed to create Titus scanner: %w", err)
 	}
 	s.ps = ps
-	slog.Info("secret scanner started", "db", ps.dbPath)
+	s.validate = cfg.Validate
+
+	if cfg.Validate {
+		s.engine = validator.NewDefaultEngine(4)
+		slog.Info("secret scanner started with validation enabled", "db", ps.dbPath)
+	} else {
+		slog.Info("secret scanner started", "db", ps.dbPath)
+	}
+
 	return nil
 }
 
@@ -68,9 +78,22 @@ func (s *SecretScanner) Scan(input output.ScanInput, out *pipeline.P[SecretScanR
 	}
 
 	for _, match := range matches {
+		if s.validate && s.engine != nil {
+			s.validateMatch(match, input.ResourceID)
+		}
 		out.Send(toScanResult(input, match))
 	}
 	return nil
+}
+
+// validateMatch runs the validation engine against a match, populating its ValidationResult.
+func (s *SecretScanner) validateMatch(match *types.Match, resourceID string) {
+	result, err := s.engine.ValidateMatch(context.Background(), match)
+	if err != nil {
+		slog.Warn("failed to validate secret", "resource", resourceID, "rule", match.RuleID, "error", err)
+		return
+	}
+	match.ValidationResult = result
 }
 
 func toScanResult(input output.ScanInput, match *types.Match) SecretScanResult {

--- a/pkg/secrets/scanner_params.go
+++ b/pkg/secrets/scanner_params.go
@@ -9,6 +9,7 @@ const defaultDBFilename = "titus.db"
 type ScannerConfig struct {
 	DBPath             string   `param:"db-path" desc:"Path for Titus SQLite database"`
 	DisabledTitusRules []string `param:"disabled-titus-rules" desc:"Rule IDs to exclude from scanning"`
+	Validate           bool     `param:"validate" desc:"Validate detected secrets against their source APIs" default:"false"`
 }
 
 // DefaultDBPath returns the default database path for the given output directory.

--- a/pkg/secrets/scanner_test.go
+++ b/pkg/secrets/scanner_test.go
@@ -17,7 +17,7 @@ func startScanner(t *testing.T) *SecretScanner {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "titus.db")
 	var s SecretScanner
-	require.NoError(t, s.Start(dbPath, nil))
+	require.NoError(t, s.Start(ScannerConfig{DBPath: dbPath}))
 	t.Cleanup(func() { s.Close() })
 	return &s
 }
@@ -30,7 +30,7 @@ func TestSecretScanner_StartAndClose(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "titus.db")
 
 	var s SecretScanner
-	require.NoError(t, s.Start(dbPath, nil))
+	require.NoError(t, s.Start(ScannerConfig{DBPath: dbPath}))
 
 	assert.Equal(t, dbPath, s.DBPath())
 	_, err := os.Stat(dbPath)
@@ -111,7 +111,7 @@ func TestStart_ExplicitPath(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "titus.db")
 
 	var s SecretScanner
-	require.NoError(t, s.Start(dbPath, nil))
+	require.NoError(t, s.Start(ScannerConfig{DBPath: dbPath}))
 	defer s.Close()
 
 	assert.Equal(t, dbPath, s.DBPath(), "DBPath should return the provided path")
@@ -123,7 +123,7 @@ func TestStart_CustomPath(t *testing.T) {
 	customPath := filepath.Join(t.TempDir(), "custom-titus.db")
 
 	var s SecretScanner
-	require.NoError(t, s.Start(customPath, nil))
+	require.NoError(t, s.Start(ScannerConfig{DBPath: customPath}))
 	defer s.Close()
 
 	assert.Equal(t, customPath, s.DBPath(), "DBPath should return custom path")
@@ -135,7 +135,7 @@ func TestStart_CreatesParentDirectories(t *testing.T) {
 	customPath := filepath.Join(t.TempDir(), "deeply", "nested", "path", "titus.db")
 
 	var s SecretScanner
-	require.NoError(t, s.Start(customPath, nil))
+	require.NoError(t, s.Start(ScannerConfig{DBPath: customPath}))
 	defer s.Close()
 
 	_, err := os.Stat(filepath.Dir(customPath))
@@ -149,7 +149,7 @@ func TestStart_OutputDirectoryCreated(t *testing.T) {
 	dbPath := filepath.Join(tmpDir, "output", "titus.db")
 
 	var s SecretScanner
-	require.NoError(t, s.Start(dbPath, nil))
+	require.NoError(t, s.Start(ScannerConfig{DBPath: dbPath}))
 	defer s.Close()
 
 	_, err := os.Stat(filepath.Join(tmpDir, "output"))
@@ -217,7 +217,7 @@ func TestDatabasePersistence(t *testing.T) {
 
 	// Create scanner and scan content
 	var s1 SecretScanner
-	require.NoError(t, s1.Start(dbPath, nil))
+	require.NoError(t, s1.Start(ScannerConfig{DBPath: dbPath}))
 
 	initialMatches, err := s1.ps.scanContent(content, blobID, provenance)
 	require.NoError(t, err, "scanContent should succeed")
@@ -231,7 +231,7 @@ func TestDatabasePersistence(t *testing.T) {
 
 	// Create new scanner with same database
 	var s2 SecretScanner
-	require.NoError(t, s2.Start(dbPath, nil))
+	require.NoError(t, s2.Start(ScannerConfig{DBPath: dbPath}))
 	defer s2.Close()
 
 	// Scan same content — should find it already exists
@@ -288,7 +288,7 @@ func TestExplicitPathUsed(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "titus.db")
 
 	var s SecretScanner
-	require.NoError(t, s.Start(dbPath, nil))
+	require.NoError(t, s.Start(ScannerConfig{DBPath: dbPath}))
 	defer s.Close()
 
 	assert.Equal(t, dbPath, s.DBPath(), "DBPath should return provided path")
@@ -305,7 +305,7 @@ func TestCustomPathPersistence(t *testing.T) {
 
 	// Create scanner with custom path and scan content
 	var s1 SecretScanner
-	require.NoError(t, s1.Start(customPath, nil))
+	require.NoError(t, s1.Start(ScannerConfig{DBPath: customPath}))
 
 	initialMatches, err := s1.ps.scanContent(content, blobID, provenance)
 	require.NoError(t, err, "scanContent should succeed")
@@ -319,7 +319,7 @@ func TestCustomPathPersistence(t *testing.T) {
 
 	// Create new scanner with same custom path
 	var s2 SecretScanner
-	require.NoError(t, s2.Start(customPath, nil))
+	require.NoError(t, s2.Start(ScannerConfig{DBPath: customPath}))
 	defer s2.Close()
 
 	// Scan same content — should find it already exists


### PR DESCRIPTION
## Summary
- Adds a `--validate` flag (default `false`) to `ScannerConfig`, automatically available to all three cloud find-secrets modules (AWS, Azure, GCP)
- When enabled, detected secrets are validated against their source APIs using the Titus validator engine
- Refactors `SecretScanner.Start` to accept `ScannerConfig` directly instead of individual parameters

## Test plan
- [x] `go build ./...` passes
- [x] `pkg/secrets` tests pass
- [x] AWS, Azure, GCP find-secrets module tests pass
- [ ] Manual: run find-secrets with `--validate` against a test environment to confirm validation results appear in proof output