### PR TITLE
fix: rewrite azure find_secrets_test.go to match AWS test pattern

### DIFF
--- a/pkg/modules/azure/recon/find_secrets_test.go
+++ b/pkg/modules/azure/recon/find_secrets_test.go
@@ -1,60 +1,300 @@
 package recon
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/praetorian-inc/aurelian/pkg/model"
 	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/pkg/secrets"
 	"github.com/praetorian-inc/titus/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestFormatSecretRiskName(t *testing.T) {
+func TestFindSecretsModuleMetadata(t *testing.T) {
 	m := &AzureFindSecretsModule{}
+
+	assert.Equal(t, "find-secrets", m.ID())
+	assert.Equal(t, "Azure Find Secrets", m.Name())
+	assert.Equal(t, plugin.PlatformAzure, m.Platform())
+	assert.Equal(t, plugin.CategoryRecon, m.Category())
+	assert.Equal(t, "moderate", m.OpsecLevel())
+
+	authors := m.Authors()
+	require.Len(t, authors, 1)
+	assert.Equal(t, "Praetorian", authors[0])
+
+	assert.NotEmpty(t, m.Description())
+	assert.NotEmpty(t, m.References())
+}
+
+func TestFindSecretsSupportedResourceTypes(t *testing.T) {
+	m := &AzureFindSecretsModule{}
+	types := m.SupportedResourceTypes()
+
+	expected := []string{
+		"Microsoft.Resources/subscriptions",
+	}
+
+	assert.Equal(t, expected, types)
+}
+
+func TestFindSecretsParameters(t *testing.T) {
+	m := &AzureFindSecretsModule{}
+	params, err := plugin.ParametersFrom(m.Parameters())
+	require.NoError(t, err)
+
+	paramNames := make(map[string]bool)
+	for _, p := range params {
+		paramNames[p.Name] = true
+	}
+
+	assert.True(t, paramNames["subscription-ids"], "should have subscription-ids param")
+	assert.True(t, paramNames["output-dir"], "should have output-dir param")
+	assert.True(t, paramNames["db-path"], "should have db-path param")
+	assert.True(t, paramNames["max-cosmos-doc-size"], "should have max-cosmos-doc-size param")
+}
+
+func TestExtractRuleShortName(t *testing.T) {
 	tests := []struct {
 		ruleID   string
 		expected string
 	}{
-		// Standard case: "prefix.RuleName" → "azure-secret-RuleName"
-		{"aws.AccessKey", "azure-secret-AccessKey"},
-		// No dots: whole ID lowercased
-		{"genericcredential", "azure-secret-genericcredential"},
-		// Multiple dots: second segment used (parts[1])
-		{"provider.RuleName.extra", "azure-secret-RuleName"},
-		// Empty string
-		{"", "azure-secret-"},
-		// Single dot with empty second segment
-		{"prefix.", "azure-secret-"},
+		{"np.aws.1", "aws"},
+		{"np.github.2", "github"},
+		{"np.generic.3", "generic"},
+		{"singleword", "singleword"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.ruleID, func(t *testing.T) {
-			got := m.formatSecretRiskName(tt.ruleID)
-			assert.Equal(t, tt.expected, got)
+			assert.Equal(t, tt.expected, secrets.ExtractRuleShortName(tt.ruleID))
 		})
 	}
 }
 
-func TestRiskSeverityFromMatch_ValidatedHigh(t *testing.T) {
-	m := &AzureFindSecretsModule{}
-	match := &types.Match{
-		ValidationResult: &types.ValidationResult{
-			Status: types.StatusValid,
-		},
+func TestRiskNameFormatting(t *testing.T) {
+	tests := []struct {
+		ruleID   string
+		expected string
+	}{
+		{"np.aws.1", "azure-secret-aws"},
+		{"np.github.2", "azure-secret-github"},
+		{"np.generic.3", "azure-secret-generic"},
+		{"singleword", "azure-secret-singleword"},
 	}
-	assert.Equal(t, output.RiskSeverityHigh, m.riskSeverityFromMatch(match))
+	for _, tt := range tests {
+		t.Run(tt.ruleID, func(t *testing.T) {
+			assert.Equal(t, tt.expected, fmt.Sprintf("azure-secret-%s", secrets.ExtractRuleShortName(tt.ruleID)))
+		})
+	}
 }
 
-func TestRiskSeverityFromMatch_UnvalidatedMedium(t *testing.T) {
-	m := &AzureFindSecretsModule{}
-	// nil ValidationResult
-	assert.Equal(t, output.RiskSeverityMedium, m.riskSeverityFromMatch(&types.Match{}))
+func TestRiskSeverityFromMatch(t *testing.T) {
+	t.Run("validated secret returns high", func(t *testing.T) {
+		match := &types.Match{
+			ValidationResult: &types.ValidationResult{Status: types.StatusValid},
+		}
+		assert.Equal(t, output.RiskSeverityHigh, secrets.RiskSeverityFromMatch(match))
+	})
+
+	t.Run("no validation returns medium", func(t *testing.T) {
+		match := &types.Match{}
+		assert.Equal(t, output.RiskSeverityMedium, secrets.RiskSeverityFromMatch(match))
+	})
+
+	t.Run("invalid validation returns medium", func(t *testing.T) {
+		match := &types.Match{
+			ValidationResult: &types.ValidationResult{Status: types.StatusInvalid},
+		}
+		assert.Equal(t, output.RiskSeverityMedium, secrets.RiskSeverityFromMatch(match))
+	})
 }
 
-func TestRiskSeverityFromMatch_InvalidStatusMedium(t *testing.T) {
-	m := &AzureFindSecretsModule{}
+func TestBuildProofData(t *testing.T) {
 	match := &types.Match{
-		ValidationResult: &types.ValidationResult{
-			Status: types.StatusInvalid,
+		RuleID:    "np.aws.1",
+		RuleName:  "AWS API Key",
+		FindingID: "abc123def456",
+		Snippet: types.Snippet{
+			Before:   []byte("key="),
+			Matching: []byte("AKIAIOSFODNN7EXAMPLE"),
+			After:    []byte("\n"),
+		},
+		Location: types.Location{
+			Offset: types.OffsetSpan{Start: 4, End: 24},
+			Source: types.SourceSpan{
+				Start: types.SourcePoint{Line: 1, Column: 5},
+				End:   types.SourcePoint{Line: 1, Column: 25},
+			},
 		},
 	}
-	assert.Equal(t, output.RiskSeverityMedium, m.riskSeverityFromMatch(match))
+
+	result := secrets.SecretScanResult{
+		ResourceRef:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/myapp",
+		ResourceType: "Microsoft.Web/sites",
+		Region:       "eastus",
+		AccountID:    "00000000-0000-0000-0000-000000000000",
+		Label:        "appsettings.json",
+	}
+
+	m := &AzureFindSecretsModule{}
+	proof := m.buildProofData(result, match)
+
+	assert.Equal(t, "abc123def456", proof["finding_id"])
+	assert.Equal(t, "AWS API Key", proof["rule_name"])
+	assert.Equal(t, "np.aws.1", proof["rule_text_id"])
+	assert.Equal(t, result.ResourceRef, proof["resource_ref"])
+	assert.Equal(t, 1, proof["num_matches"])
+
+	matches := proof["matches"].([]map[string]interface{})
+	require.Len(t, matches, 1)
+
+	snippet := matches[0]["snippet"].(map[string]string)
+	assert.Equal(t, "key=", snippet["before"])
+	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", snippet["matching"])
+	assert.Equal(t, "\n", snippet["after"])
+
+	location := matches[0]["location"].(map[string]interface{})
+	offsetSpan := location["offset_span"].(map[string]interface{})
+	assert.Equal(t, int64(4), offsetSpan["start"])
+	assert.Equal(t, int64(24), offsetSpan["end"])
+
+	sourceSpan := location["source_span"].(map[string]interface{})
+	start := sourceSpan["start"].(map[string]interface{})
+	assert.Equal(t, 1, start["line"])
+	assert.Equal(t, 5, start["column"])
+
+	_, hasValidation := proof["validation"]
+	assert.False(t, hasValidation, "no validation when ValidationResult is nil")
+}
+
+func TestBuildProofData_WithValidation(t *testing.T) {
+	match := &types.Match{
+		RuleID:    "np.aws.1",
+		RuleName:  "AWS API Key",
+		FindingID: "abc123",
+		ValidationResult: &types.ValidationResult{
+			Status:     types.StatusValid,
+			Confidence: 0.95,
+			Message:    "Key is active",
+		},
+	}
+
+	result := secrets.SecretScanResult{
+		ResourceRef:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/myaccount",
+		ResourceType: "Microsoft.Storage/storageAccounts",
+		Label:        "connection-string",
+	}
+
+	m := &AzureFindSecretsModule{}
+	proof := m.buildProofData(result, match)
+
+	validation := proof["validation"].(map[string]interface{})
+	assert.Equal(t, string(types.StatusValid), validation["status"])
+	assert.Equal(t, 0.95, validation["confidence"])
+	assert.Equal(t, "Key is active", validation["message"])
+}
+
+func TestBuildRiskContextRoundTrip(t *testing.T) {
+	match := &types.Match{
+		RuleID:    "np.aws.1",
+		RuleName:  "AWS API Key",
+		FindingID: "abc123def456",
+		Snippet: types.Snippet{
+			Before:   []byte("key="),
+			Matching: []byte("AKIAIOSFODNN7EXAMPLE"),
+			After:    []byte("\n"),
+		},
+		Location: types.Location{
+			Offset: types.OffsetSpan{Start: 4, End: 24},
+			Source: types.SourceSpan{
+				Start: types.SourcePoint{Line: 1, Column: 5},
+				End:   types.SourcePoint{Line: 1, Column: 25},
+			},
+		},
+	}
+
+	result := secrets.SecretScanResult{
+		ResourceRef:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/myvm",
+		ResourceType: "Microsoft.Compute/virtualMachines",
+		Region:       "eastus",
+		AccountID:    "00000000-0000-0000-0000-000000000000",
+		Label:        "userdata.sh",
+	}
+
+	m := &AzureFindSecretsModule{}
+	proof := m.buildProofData(result, match)
+	proofBytes, err := json.MarshalIndent(proof, "", "  ")
+	require.NoError(t, err)
+
+	var decoded map[string]interface{}
+	err = json.Unmarshal(proofBytes, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "abc123def456", decoded["finding_id"])
+	assert.Equal(t, "AWS API Key", decoded["rule_name"])
+	assert.Equal(t, "np.aws.1", decoded["rule_text_id"])
+	assert.Equal(t, result.ResourceRef, decoded["resource_ref"])
+}
+
+func TestRiskFromScanResult_ImpactedResourceID_IncludesFindingID(t *testing.T) {
+	match := &types.Match{
+		RuleID:    "np.aws.1",
+		RuleName:  "AWS API Key",
+		FindingID: "abc123def456",
+	}
+
+	result := secrets.SecretScanResult{
+		ResourceRef: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/myapp",
+		Label:       "appsettings.json",
+		Match:       match,
+	}
+
+	m := &AzureFindSecretsModule{}
+	out := pipeline.New[model.AurelianModel]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, m.riskFromScanResult(result, out))
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	risk := items[0].(output.AurelianRisk)
+	assert.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/myapp:abc123de", risk.ImpactedResourceID)
+	assert.Equal(t, "abc123def456", risk.DeduplicationID)
+	assert.Equal(t, "azure-secret-aws", risk.Name)
+	assert.Equal(t, output.RiskSeverityMedium, risk.Severity)
+}
+
+func TestRiskFromScanResult_ImpactedResourceID_NoFindingID(t *testing.T) {
+	match := &types.Match{
+		RuleID:   "np.aws.1",
+		RuleName: "AWS API Key",
+	}
+
+	result := secrets.SecretScanResult{
+		ResourceRef: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/myvm",
+		Label:       "userdata.sh",
+		Match:       match,
+	}
+
+	m := &AzureFindSecretsModule{}
+	out := pipeline.New[model.AurelianModel]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, m.riskFromScanResult(result, out))
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	risk := items[0].(output.AurelianRisk)
+	assert.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/myvm", risk.ImpactedResourceID, "should use bare ResourceRef when FindingID is empty")
 }


### PR DESCRIPTION
## Summary
- `find_secrets_test.go` called `m.formatSecretRiskName()` and `m.riskSeverityFromMatch()` which were removed from `AzureFindSecretsModule` when logic was consolidated into `pkg/secrets/risk.go`
- Rewrites the test to mirror the comprehensive AWS `find_secrets_test.go` pattern instead of just updating the function calls:
  - Module metadata, supported resource types, and parameter validation
  - `ExtractRuleShortName` and risk name formatting with realistic Titus rule IDs
  - `RiskSeverityFromMatch` for all validation states
  - `buildProofData` structural validation (with and without validation result)
  - Proof JSON round-trip serialization
  - `riskFromScanResult` end-to-end with pipeline (ImpactedResourceID with/without FindingID, DeduplicationID, Name, Severity)

## Test plan
- [x] `go test ./pkg/modules/azure/recon/ -v -count=1` — all 17 tests pass (11 new + 6 pre-existing)

Fixes #95