### PR TITLE
ci: add external-contrib-action v2 for external contribution notifications

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -1,0 +1,28 @@
+name: External Contribution Notify
+
+on:
+  issues:
+    types: [opened, assigned, closed]
+  pull_request_target:
+    types: [opened, assigned, closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: praetorian-inc/external-contrib-action@v2
+        with:
+          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
+          linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
+          linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
+          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          dry-run: "false"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds external-contrib-action v2 workflow to detect and respond to external contributions
- Sends Slack notifications and creates Linear issues on new external issues/PRs
- Posts auto-reply comments on opened, assigned, and closed events
- Validated on augustus before rollout

## Pre-merge checklist
- [ ] Ensure repo secrets are configured: `LINEAR_TEAM_ID`, `LINEAR_ASSIGNEE_ID`, `LINEAR_PARENT_ISSUE_ID`, `SLACK_CHANNEL_ID`, `ORG_MEMBER_CHECK_PAT`, `LINEAR_API_KEY`, `SLACK_BOT_TOKEN`

## Test plan
- [ ] Merge PR
- [ ] Open a test issue from a non-org GitHub account
- [ ] Verify Slack notification, Linear issue, and auto-reply comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)