### PR TITLE
Add AWS recon summary module with Nebula-compatible output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.54.4
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.63.2
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.0
+	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.5
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.202.4
 	github.com/aws/aws-sdk-go-v2/service/efs v1.41.10
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.63.2 h1:9Zc/otv2WzK7gbhXI
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.63.2/go.mod h1:dvfInk3WN/sz8is2m5iN5EFYQzIXcQLaT2UnauE8uL4=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.0 h1:FQQi7oGHGAn3aJJcq0rntRCy3xOfNw7u0FUUm2+6+AU=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.0/go.mod h1:bBgsO3htjygdyPTgT0Fou14A5VAQaLqiJ8YE2SW4NKw=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.5 h1:iNNJ6ZrQO37Xh12XjNncS3fq/11l1TzyZwBWcZMHWkY=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.5/go.mod h1:auLb1gCiI54TM7iUxSYu5MYSimWr0fL6t5/PgxkJOr0=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.202.4 h1:gdFRXlTMgV0+yrhQLAJKb+vX2K32Vw3n2TntDd+8AEM=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.202.4/go.mod h1:nSbxgPGhyI9j/cMVSHUEEtNQzEYeNOkbHnHNeTuQqt0=
 github.com/aws/aws-sdk-go-v2/service/efs v1.41.10 h1:7ixaaFyZ8xXJWPcK3qQKFf1k1HgME9rtCY7S6Unih8I=

--- a/pkg/modules/aws/recon/summary.go
+++ b/pkg/modules/aws/recon/summary.go
@@ -1,0 +1,209 @@
+package recon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+
+	helpers "github.com/praetorian-inc/aurelian/internal/helpers/aws"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+)
+
+func init() {
+	plugin.Register(&AWSSummaryModule{})
+}
+
+type SummaryConfig struct {
+	plugin.AWSReconBase
+	Days int `param:"days" desc:"Number of days to look back for cost data" default:"30" shortcode:"d"`
+}
+
+type AWSSummaryModule struct {
+	SummaryConfig
+}
+
+func (m *AWSSummaryModule) ID() string                { return "summary" }
+func (m *AWSSummaryModule) Name() string              { return "AWS Summary" }
+func (m *AWSSummaryModule) Platform() plugin.Platform { return plugin.PlatformAWS }
+func (m *AWSSummaryModule) Category() plugin.Category { return plugin.CategoryRecon }
+func (m *AWSSummaryModule) OpsecLevel() string        { return "moderate" }
+func (m *AWSSummaryModule) Authors() []string         { return []string{"Praetorian"} }
+
+func (m *AWSSummaryModule) Description() string {
+	return "Use Cost Explorer to summarize the services and regions in use, displaying costs in a markdown table."
+}
+
+func (m *AWSSummaryModule) References() []string {
+	return []string{
+		"https://docs.aws.amazon.com/cost-management/latest/userguide/ce-api.html",
+	}
+}
+
+func (m *AWSSummaryModule) SupportedResourceTypes() []string {
+	return []string{}
+}
+
+func (m *AWSSummaryModule) Parameters() any {
+	return &m.SummaryConfig
+}
+
+func (m *AWSSummaryModule) Run(cfg plugin.Config, out *pipeline.P[model.AurelianModel]) error {
+	awsCfg, err := helpers.NewAWSConfig(helpers.AWSConfigInput{
+		Region:     "us-east-1",
+		Profile:    m.Profile,
+		ProfileDir: m.ProfileDir,
+	})
+	if err != nil {
+		return fmt.Errorf("summary: load AWS config: %w", err)
+	}
+
+	client := costexplorer.NewFromConfig(awsCfg)
+	ctx := context.TODO()
+
+	days := m.Days
+	if days <= 0 {
+		days = 30
+	}
+
+	now := time.Now()
+	endDate := now.Format("2006-01-02")
+	startDate := now.AddDate(0, 0, -days).Format("2006-01-02")
+
+	slog.Info("querying Cost Explorer", "start", startDate, "end", endDate)
+
+	result, err := client.GetCostAndUsage(ctx, &costexplorer.GetCostAndUsageInput{
+		TimePeriod: &cetypes.DateInterval{
+			Start: &startDate,
+			End:   &endDate,
+		},
+		Granularity: cetypes.GranularityMonthly,
+		Metrics:     []string{"BlendedCost"},
+		GroupBy: []cetypes.GroupDefinition{
+			{Type: cetypes.GroupDefinitionTypeDimension, Key: strPtr("SERVICE")},
+			{Type: cetypes.GroupDefinitionTypeDimension, Key: strPtr("REGION")},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("summary: Cost Explorer GetCostAndUsage: %w", err)
+	}
+
+	serviceRegions := make(map[string]map[string]float64)
+	grandTotal := 0.0
+
+	for _, rbt := range result.ResultsByTime {
+		for _, group := range rbt.Groups {
+			if len(group.Keys) < 2 {
+				continue
+			}
+			service := cleanServiceName(group.Keys[0])
+			region := group.Keys[1]
+			if service == "" || region == "" {
+				continue
+			}
+
+			var cost float64
+			if metric, ok := group.Metrics["BlendedCost"]; ok && metric.Amount != nil {
+				fmt.Sscanf(*metric.Amount, "%f", &cost)
+			}
+
+			if serviceRegions[service] == nil {
+				serviceRegions[service] = make(map[string]float64)
+			}
+			serviceRegions[service][region] += cost
+			grandTotal += cost
+		}
+	}
+
+	slog.Info("cost summary", "services", len(serviceRegions), "total", fmt.Sprintf("$%.2f", grandTotal))
+
+	if cfg.Verbose {
+		printSummaryTable(serviceRegions, grandTotal)
+	}
+
+	out.Send(&output.AWSCostSummary{
+		Services:  serviceRegions,
+		TotalCost: grandTotal,
+		Days:      days,
+	})
+	return nil
+}
+
+func cleanServiceName(name string) string {
+	name = strings.ReplaceAll(name, "Amazon ", "")
+	name = strings.ReplaceAll(name, "AWS ", "")
+	return name
+}
+
+func strPtr(s string) *string { return &s }
+
+func printSummaryTable(serviceRegions map[string]map[string]float64, grandTotal float64) {
+	// Collect all regions
+	regionSet := make(map[string]bool)
+	for _, regions := range serviceRegions {
+		for r := range regions {
+			regionSet[r] = true
+		}
+	}
+	var regions []string
+	for r := range regionSet {
+		regions = append(regions, r)
+	}
+	sort.Strings(regions)
+
+	// Sort services
+	var services []string
+	for s := range serviceRegions {
+		services = append(services, s)
+	}
+	sort.Strings(services)
+
+	// Print header
+	fmt.Printf("\n%-40s", "Service")
+	for _, r := range regions {
+		fmt.Printf("  %-16s", r)
+	}
+	fmt.Printf("  %-12s\n", "Total")
+	fmt.Println(strings.Repeat("-", 40+18*len(regions)+14))
+
+	// Print rows
+	for _, svc := range services {
+		svcTotal := 0.0
+		fmt.Printf("%-40s", svc)
+		for _, r := range regions {
+			cost := serviceRegions[svc][r]
+			svcTotal += cost
+			if cost > 0.01 {
+				fmt.Printf("  $%-15.2f", cost)
+			} else {
+				fmt.Printf("  %-16s", "-")
+			}
+		}
+		fmt.Printf("  $%-11.2f\n", svcTotal)
+	}
+
+	fmt.Println(strings.Repeat("-", 40+18*len(regions)+14))
+	fmt.Printf("%-40s", "TOTAL")
+	totalByRegion := make(map[string]float64)
+	for _, regions := range serviceRegions {
+		for r, cost := range regions {
+			totalByRegion[r] += cost
+		}
+	}
+	for _, r := range regions {
+		if totalByRegion[r] > 0.01 {
+			fmt.Printf("  $%-15.2f", totalByRegion[r])
+		} else {
+			fmt.Printf("  %-16s", "-")
+		}
+	}
+	fmt.Printf("  $%-11.2f\n\n", grandTotal)
+}

--- a/pkg/modules/aws/recon/summary.go
+++ b/pkg/modules/aws/recon/summary.go
@@ -96,7 +96,9 @@ func (m *AWSSummaryModule) Run(cfg plugin.Config, out *pipeline.P[model.Aurelian
 		return fmt.Errorf("summary: Cost Explorer GetCostAndUsage: %w", err)
 	}
 
+	// Parse cost data into service -> region -> cost map.
 	serviceRegions := make(map[string]map[string]float64)
+	regionSet := make(map[string]bool)
 	grandTotal := 0.0
 
 	for _, rbt := range result.ResultsByTime {
@@ -119,22 +121,80 @@ func (m *AWSSummaryModule) Run(cfg plugin.Config, out *pipeline.P[model.Aurelian
 				serviceRegions[service] = make(map[string]float64)
 			}
 			serviceRegions[service][region] += cost
+			regionSet[region] = true
 			grandTotal += cost
 		}
 	}
 
 	slog.Info("cost summary", "services", len(serviceRegions), "total", fmt.Sprintf("$%.2f", grandTotal))
 
-	if cfg.Verbose {
-		printSummaryTable(serviceRegions, grandTotal)
+	// Build MarkdownTable output matching Nebula's format.
+	table := buildCostTable(serviceRegions, regionSet, grandTotal, days)
+	out.Send(table)
+	return nil
+}
+
+func buildCostTable(serviceRegions map[string]map[string]float64, regionSet map[string]bool, grandTotal float64, days int) *output.AWSCostSummary {
+	// Sort regions.
+	regions := make([]string, 0, len(regionSet))
+	for r := range regionSet {
+		regions = append(regions, r)
+	}
+	sort.Strings(regions)
+
+	// Sort services.
+	services := make([]string, 0, len(serviceRegions))
+	for s := range serviceRegions {
+		services = append(services, s)
+	}
+	sort.Strings(services)
+
+	// Headers: Service, region1, region2, ..., Total Cost
+	headers := make([]string, 0, len(regions)+2)
+	headers = append(headers, "Service")
+	headers = append(headers, regions...)
+	headers = append(headers, "Total Cost")
+
+	// Rows: one per service + final TOTAL row.
+	rows := make([][]string, 0, len(services)+1)
+	totalByRegion := make(map[string]float64)
+
+	for _, svc := range services {
+		row := make([]string, 0, len(headers))
+		row = append(row, svc)
+		svcTotal := 0.0
+		for _, r := range regions {
+			cost := serviceRegions[svc][r]
+			svcTotal += cost
+			totalByRegion[r] += cost
+			if cost > 0.01 {
+				row = append(row, fmt.Sprintf("$%.2f", cost))
+			} else {
+				row = append(row, "-")
+			}
+		}
+		row = append(row, fmt.Sprintf("$%.2f", svcTotal))
+		rows = append(rows, row)
 	}
 
-	out.Send(&output.AWSCostSummary{
-		Services:  serviceRegions,
-		TotalCost: grandTotal,
-		Days:      days,
-	})
-	return nil
+	// TOTAL row with bold markdown formatting.
+	totalRow := make([]string, 0, len(headers))
+	totalRow = append(totalRow, "**TOTAL**")
+	for _, r := range regions {
+		if totalByRegion[r] > 0.01 {
+			totalRow = append(totalRow, fmt.Sprintf("**$%.2f**", totalByRegion[r]))
+		} else {
+			totalRow = append(totalRow, "-")
+		}
+	}
+	totalRow = append(totalRow, fmt.Sprintf("**$%.2f**", grandTotal))
+	rows = append(rows, totalRow)
+
+	return &output.AWSCostSummary{
+		TableHeading: fmt.Sprintf("# AWS Cost Summary\n\nCost breakdown by service and region (last %d days):\n\n", days),
+		Headers:      headers,
+		Rows:         rows,
+	}
 }
 
 func cleanServiceName(name string) string {
@@ -144,66 +204,3 @@ func cleanServiceName(name string) string {
 }
 
 func strPtr(s string) *string { return &s }
-
-func printSummaryTable(serviceRegions map[string]map[string]float64, grandTotal float64) {
-	// Collect all regions
-	regionSet := make(map[string]bool)
-	for _, regions := range serviceRegions {
-		for r := range regions {
-			regionSet[r] = true
-		}
-	}
-	var regions []string
-	for r := range regionSet {
-		regions = append(regions, r)
-	}
-	sort.Strings(regions)
-
-	// Sort services
-	var services []string
-	for s := range serviceRegions {
-		services = append(services, s)
-	}
-	sort.Strings(services)
-
-	// Print header
-	fmt.Printf("\n%-40s", "Service")
-	for _, r := range regions {
-		fmt.Printf("  %-16s", r)
-	}
-	fmt.Printf("  %-12s\n", "Total")
-	fmt.Println(strings.Repeat("-", 40+18*len(regions)+14))
-
-	// Print rows
-	for _, svc := range services {
-		svcTotal := 0.0
-		fmt.Printf("%-40s", svc)
-		for _, r := range regions {
-			cost := serviceRegions[svc][r]
-			svcTotal += cost
-			if cost > 0.01 {
-				fmt.Printf("  $%-15.2f", cost)
-			} else {
-				fmt.Printf("  %-16s", "-")
-			}
-		}
-		fmt.Printf("  $%-11.2f\n", svcTotal)
-	}
-
-	fmt.Println(strings.Repeat("-", 40+18*len(regions)+14))
-	fmt.Printf("%-40s", "TOTAL")
-	totalByRegion := make(map[string]float64)
-	for _, regions := range serviceRegions {
-		for r, cost := range regions {
-			totalByRegion[r] += cost
-		}
-	}
-	for _, r := range regions {
-		if totalByRegion[r] > 0.01 {
-			fmt.Printf("  $%-15.2f", totalByRegion[r])
-		} else {
-			fmt.Printf("  %-16s", "-")
-		}
-	}
-	fmt.Printf("  $%-11.2f\n\n", grandTotal)
-}

--- a/pkg/modules/aws/recon/summary.go
+++ b/pkg/modules/aws/recon/summary.go
@@ -130,6 +130,10 @@ func (m *AWSSummaryModule) Run(cfg plugin.Config, out *pipeline.P[model.Aurelian
 
 	// Build MarkdownTable output matching Nebula's format.
 	table := buildCostTable(serviceRegions, regionSet, grandTotal, days)
+
+	// Print markdown table to console.
+	cfg.Info("\n%s", table.String())
+
 	out.Send(table)
 	return nil
 }

--- a/pkg/modules/aws/recon/summary_test.go
+++ b/pkg/modules/aws/recon/summary_test.go
@@ -1,0 +1,55 @@
+package recon
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummaryModuleRegistration(t *testing.T) {
+	mod, ok := plugin.Get(plugin.PlatformAWS, plugin.CategoryRecon, "summary")
+	require.True(t, ok, "summary module should be registered")
+	require.NotNil(t, mod)
+}
+
+func TestSummaryModuleMetadata(t *testing.T) {
+	m := &AWSSummaryModule{}
+	assert.Equal(t, "summary", m.ID())
+	assert.Equal(t, "AWS Summary", m.Name())
+	assert.Equal(t, plugin.PlatformAWS, m.Platform())
+	assert.Equal(t, plugin.CategoryRecon, m.Category())
+	assert.Equal(t, "moderate", m.OpsecLevel())
+	assert.NotEmpty(t, m.Description())
+	assert.Contains(t, m.Description(), "Cost Explorer")
+}
+
+func TestSummaryModuleParameters(t *testing.T) {
+	m := &AWSSummaryModule{}
+	params, err := plugin.ParametersFrom(m.Parameters())
+	require.NoError(t, err)
+
+	paramNames := make(map[string]bool)
+	for _, p := range params {
+		paramNames[p.Name] = true
+	}
+
+	assert.True(t, paramNames["profile"], "should have profile param")
+	assert.True(t, paramNames["days"], "should have days param")
+}
+
+func TestCleanServiceName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Amazon EC2", "EC2"},
+		{"AWS Lambda", "Lambda"},
+		{"Amazon Simple Storage Service", "Simple Storage Service"},
+		{"CloudWatch", "CloudWatch"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, cleanServiceName(tt.input))
+	}
+}

--- a/pkg/modules/aws/recon/summary_test.go
+++ b/pkg/modules/aws/recon/summary_test.go
@@ -53,3 +53,53 @@ func TestCleanServiceName(t *testing.T) {
 		assert.Equal(t, tt.want, cleanServiceName(tt.input))
 	}
 }
+
+func TestBuildCostTable(t *testing.T) {
+	serviceRegions := map[string]map[string]float64{
+		"EC2":    {"us-east-1": 43.22, "us-west-2": 12.50},
+		"Lambda": {"us-east-1": 5.10},
+		"S3":     {"us-east-1": 0.005}, // below threshold
+	}
+	regionSet := map[string]bool{
+		"us-east-1": true,
+		"us-west-2": true,
+	}
+	grandTotal := 60.825
+
+	table := buildCostTable(serviceRegions, regionSet, grandTotal, 30)
+
+	// Check heading.
+	assert.Contains(t, table.TableHeading, "AWS Cost Summary")
+	assert.Contains(t, table.TableHeading, "30 days")
+
+	// Check headers: Service, us-east-1, us-west-2, Total Cost
+	require.Len(t, table.Headers, 4)
+	assert.Equal(t, "Service", table.Headers[0])
+	assert.Equal(t, "us-east-1", table.Headers[1])
+	assert.Equal(t, "us-west-2", table.Headers[2])
+	assert.Equal(t, "Total Cost", table.Headers[3])
+
+	// 3 services + 1 TOTAL row = 4 rows.
+	require.Len(t, table.Rows, 4)
+
+	// Services are sorted alphabetically: EC2, Lambda, S3
+	assert.Equal(t, "EC2", table.Rows[0][0])
+	assert.Equal(t, "$43.22", table.Rows[0][1])   // us-east-1
+	assert.Equal(t, "$12.50", table.Rows[0][2])    // us-west-2
+	assert.Equal(t, "$55.72", table.Rows[0][3])    // total
+
+	assert.Equal(t, "Lambda", table.Rows[1][0])
+	assert.Equal(t, "$5.10", table.Rows[1][1])     // us-east-1
+	assert.Equal(t, "-", table.Rows[1][2])          // us-west-2 (no cost)
+	assert.Equal(t, "$5.10", table.Rows[1][3])      // total
+
+	assert.Equal(t, "S3", table.Rows[2][0])
+	assert.Equal(t, "-", table.Rows[2][1])           // us-east-1 (below threshold)
+	assert.Equal(t, "-", table.Rows[2][2])           // us-west-2 (no cost)
+	assert.Equal(t, "$0.01", table.Rows[2][3])       // total (0.005 rounds)
+
+	// TOTAL row with bold markdown.
+	totalRow := table.Rows[3]
+	assert.Equal(t, "**TOTAL**", totalRow[0])
+	assert.Contains(t, totalRow[len(totalRow)-1], "**$")
+}

--- a/pkg/output/aws_cost_summary.go
+++ b/pkg/output/aws_cost_summary.go
@@ -2,16 +2,18 @@ package output
 
 import "github.com/praetorian-inc/aurelian/pkg/model"
 
-// AWSCostSummary represents a Cost Explorer breakdown of services and regions.
+// AWSCostSummary represents a Cost Explorer breakdown formatted as a markdown table,
+// matching Nebula's MarkdownTable output structure.
 type AWSCostSummary struct {
 	model.BaseAurelianModel
 
-	// Services maps service name -> region -> cost.
-	Services map[string]map[string]float64 `json:"services"`
+	// TableHeading is a markdown heading displayed above the table.
+	TableHeading string `json:"TableHeading"`
 
-	// TotalCost is the grand total across all services and regions.
-	TotalCost float64 `json:"total_cost"`
+	// Headers are the column names: ["Service", region1, region2, ..., "Total Cost"].
+	Headers []string `json:"Headers"`
 
-	// Days is the lookback window used.
-	Days int `json:"days"`
+	// Rows contains one slice per service, plus a final TOTAL row.
+	// Each row has len(Headers) entries: service name, per-region cost strings, and row total.
+	Rows [][]string `json:"Rows"`
 }

--- a/pkg/output/aws_cost_summary.go
+++ b/pkg/output/aws_cost_summary.go
@@ -1,6 +1,11 @@
 package output
 
-import "github.com/praetorian-inc/aurelian/pkg/model"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/praetorian-inc/aurelian/pkg/model"
+)
 
 // AWSCostSummary represents a Cost Explorer breakdown formatted as a markdown table,
 // matching Nebula's MarkdownTable output structure.
@@ -16,4 +21,62 @@ type AWSCostSummary struct {
 	// Rows contains one slice per service, plus a final TOTAL row.
 	// Each row has len(Headers) entries: service name, per-region cost strings, and row total.
 	Rows [][]string `json:"Rows"`
+}
+
+// String renders the cost summary as a formatted markdown table.
+func (t *AWSCostSummary) String() string {
+	if len(t.Headers) == 0 {
+		return t.TableHeading
+	}
+
+	// Calculate column widths.
+	widths := make([]int, len(t.Headers))
+	for i, h := range t.Headers {
+		widths[i] = len(h)
+	}
+	for _, row := range t.Rows {
+		for i, cell := range row {
+			if i < len(widths) && len(cell) > widths[i] {
+				widths[i] = len(cell)
+			}
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(t.TableHeading)
+
+	// Header row.
+	for i, h := range t.Headers {
+		if i > 0 {
+			sb.WriteString(" | ")
+		}
+		sb.WriteString(fmt.Sprintf("%-*s", widths[i], h))
+	}
+	sb.WriteByte('\n')
+
+	// Separator row.
+	for i, w := range widths {
+		if i > 0 {
+			sb.WriteString("-|-")
+		}
+		sb.WriteString(strings.Repeat("-", w))
+	}
+	sb.WriteByte('\n')
+
+	// Data rows.
+	for _, row := range t.Rows {
+		for i, cell := range row {
+			if i > 0 {
+				sb.WriteString(" | ")
+			}
+			if i < len(widths) {
+				sb.WriteString(fmt.Sprintf("%-*s", widths[i], cell))
+			} else {
+				sb.WriteString(cell)
+			}
+		}
+		sb.WriteByte('\n')
+	}
+
+	return sb.String()
 }

--- a/pkg/output/aws_cost_summary.go
+++ b/pkg/output/aws_cost_summary.go
@@ -1,0 +1,17 @@
+package output
+
+import "github.com/praetorian-inc/aurelian/pkg/model"
+
+// AWSCostSummary represents a Cost Explorer breakdown of services and regions.
+type AWSCostSummary struct {
+	model.BaseAurelianModel
+
+	// Services maps service name -> region -> cost.
+	Services map[string]map[string]float64 `json:"services"`
+
+	// TotalCost is the grand total across all services and regions.
+	TotalCost float64 `json:"total_cost"`
+
+	// Days is the lookback window used.
+	Days int `json:"days"`
+}


### PR DESCRIPTION
## Summary

- Adds `aws recon summary` module that queries AWS Cost Explorer to produce a service/region cost breakdown
- Output uses `TableHeading`/`Headers`/`Rows` JSON structure matching Nebula's `MarkdownTable` format
- Renders formatted markdown table to console during execution
- Includes unit tests for module registration, metadata, parameters, `cleanServiceName`, and `buildCostTable`

## Nebula Parity

| Feature | Nebula | Aurelian | Match? |
|---|---|---|---|
| `--days` (default 30) | Yes | Yes | :white_check_mark: |
| `--profile` / `-p` | Yes | Yes | :white_check_mark: |
| `--profile-dir` | Yes | Yes | :white_check_mark: |
| `--opsec_level` | Yes | Yes | :white_check_mark: |
| Output dir flag | `--output` / `-o` | `--output-dir` | :white_check_mark: (same concept) |
| Output file flag | `--filename` / `-f` | `--output-file` / `-f` | :white_check_mark: (same concept) |
| JSON format (`TableHeading/Headers/Rows`) | Yes | Yes | :white_check_mark: |
| Console markdown table | Yes | Yes | :white_check_mark: |
| Cost Explorer SERVICE+REGION grouping | Yes | Yes | :white_check_mark: |
| Bold `**TOTAL**` row | Yes | Yes | :white_check_mark: |
| `--regions` / `-r` | Yes | No | :x: (Cost Explorer is global; not applicable) |
| `--cache-*` flags | Yes | No | :x: (framework-level feature, not summary-specific) |

**Differences explained:** `--regions` and `--cache-*` are Nebula framework features (`AWSCommonRecon` and `CachingAWSClient`), not summary-specific logic. Cost Explorer is a global service that returns data for all regions regardless of which region you query from, so `--regions` has no effect on summary results.

## Test plan

- [ ] `go test ./pkg/modules/aws/recon/ -run TestSummary` — unit tests pass
- [ ] `go test ./pkg/modules/aws/recon/ -run TestBuildCostTable` — table construction tests pass
- [ ] `go run . aws recon summary --profile <profile>` — produces markdown table on console + JSON file
- [ ] Verify JSON output matches Nebula's `MarkdownTable` structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)