### PR TITLE
test: harden Azure public-resources e2e and unit tests

### DIFF
--- a/pkg/modules/azure/recon/public_resources_integration_test.go
+++ b/pkg/modules/azure/recon/public_resources_integration_test.go
@@ -4,6 +4,8 @@ package recon
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/praetorian-inc/aurelian/pkg/output"
@@ -31,158 +33,354 @@ func TestAzurePublicResources(t *testing.T) {
 		Context: context.Background(),
 	})
 	require.NoError(t, err)
-	testutil.AssertMinResults(t, results, 17)
+	testutil.AssertMinResults(t, results, 20)
 
-	// Collect risks from results.
-	var risks []output.AurelianRisk
+	// =====================================================================
+	// Index risks by template ID for precise assertions.
+	// =====================================================================
+
+	type riskWithContext struct {
+		Risk       output.AurelianRisk
+		CtxMap     map[string]any
+		Template   string
+		ResourceID string
+	}
+
+	var all []riskWithContext
+	byTemplate := make(map[string][]riskWithContext)
 	for _, r := range results {
-		if risk, ok := r.(output.AurelianRisk); ok {
-			risks = append(risks, risk)
+		risk, ok := r.(output.AurelianRisk)
+		if !ok {
+			continue
 		}
+		var ctx map[string]any
+		require.NoError(t, json.Unmarshal(risk.Context, &ctx))
+		tid, _ := ctx["templateId"].(string)
+		rc := riskWithContext{
+			Risk:       risk,
+			CtxMap:     ctx,
+			Template:   tid,
+			ResourceID: risk.ImpactedResourceID,
+		}
+		all = append(all, rc)
+		byTemplate[tid] = append(byTemplate[tid], rc)
 	}
-	require.NotEmpty(t, risks, "should emit at least one risk")
 
-	// Validate risk fields on all results.
-	for _, risk := range risks {
-		assert.NotEmpty(t, risk.Name, "risk Name must not be empty")
-		assert.NotEmpty(t, risk.Severity, "risk Severity must not be empty")
-		assert.NotEmpty(t, risk.ImpactedResourceID, "risk ImpactedResourceID must not be empty")
-		assert.NotEmpty(t, risk.Context, "risk Context must not be empty")
+	// Helper: check if a fixture output exists and is non-empty.
+	fixtureHasOutput := func(key string) bool {
+		defer func() { recover() }() // Output() calls t.Fatalf on missing keys
+		v := fixture.Output(key)
+		return v != ""
 	}
 
-	// --- Original resources (Tier 5A/5B equivalents) ---
+	// Helper: find a risk for a specific fixture resource within a template.
+	findRisk := func(t *testing.T, templateID, fixtureResourceIDKey string) riskWithContext {
+		t.Helper()
+		expectedID := strings.ToLower(fixture.Output(fixtureResourceIDKey))
+		require.NotEmpty(t, expectedID, "fixture output %q is empty", fixtureResourceIDKey)
+		risks, ok := byTemplate[templateID]
+		require.True(t, ok, "no findings for template %q", templateID)
+		for _, rc := range risks {
+			if strings.EqualFold(rc.ResourceID, expectedID) {
+				return rc
+			}
+		}
+		t.Fatalf("template %q has %d findings but none match fixture resource %q (%s)",
+			templateID, len(risks), expectedID, fixtureResourceIDKey)
+		return riskWithContext{} // unreachable
+	}
 
-	t.Run("detects public storage account", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("storage_account_id"))
+	// Helper: assert a specific risk's common fields.
+	// resourceNameSubstr is an environment-agnostic suffix (e.g., "-kv", "sa", "-aks")
+	// that must appear in the ImpactedResourceID to confirm the right resource was caught.
+	assertRisk := func(t *testing.T, rc riskWithContext, expectedTemplate string, expectedSeverity output.RiskSeverity, resourceNameSubstr string) {
+		t.Helper()
+		assert.Equal(t, "public-azure-resource", rc.Risk.Name)
+		assert.Equal(t, expectedSeverity, rc.Risk.Severity,
+			"template %s: expected severity %s, got %s", expectedTemplate, expectedSeverity, rc.Risk.Severity)
+		assert.Equal(t, expectedTemplate, rc.Template)
+		assert.NotEmpty(t, rc.Risk.ImpactedResourceID)
+		assert.NotEmpty(t, rc.Risk.Context)
+		assert.Contains(t, strings.ToLower(rc.Risk.ImpactedResourceID), strings.ToLower(resourceNameSubstr),
+			"template %s: ImpactedResourceID %q should contain resource name substring %q",
+			expectedTemplate, rc.Risk.ImpactedResourceID, resourceNameSubstr)
+	}
+
+	// =====================================================================
+	// Storage & Data
+	// =====================================================================
+
+	t.Run("storage_accounts_public_access", func(t *testing.T) {
+		rc := findRisk(t, "storage_accounts_public_access", "storage_account_id")
+		assertRisk(t, rc, "storage_accounts_public_access", output.RiskSeverityHigh, "sa")
 	})
 
-	t.Run("detects public key vault", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("key_vault_id"))
+	t.Run("key_vault_public_access", func(t *testing.T) {
+		rc := findRisk(t, "key_vault_public_access", "key_vault_id")
+		assertRisk(t, rc, "key_vault_public_access", output.RiskSeverityHigh, "-kv")
 	})
 
-	t.Run("detects public sql server", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("sql_server_id"))
+	t.Run("cosmos_db_public_access", func(t *testing.T) {
+		rc := findRisk(t, "cosmos_db_public_access", "cosmos_db_id")
+		assertRisk(t, rc, "cosmos_db_public_access", output.RiskSeverityHigh, "-cosmos")
 	})
 
-	t.Run("detects public container registry", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("acr_id"))
+	t.Run("redis_cache_public_access", func(t *testing.T) {
+		rc := findRisk(t, "redis_cache_public_access", "redis_cache_id")
+		assertRisk(t, rc, "redis_cache_public_access", output.RiskSeverityLow, "-redis")
 	})
 
-	// --- Database servers ---
-
-	t.Run("detects public postgresql flexible server", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("postgresql_server_id"))
+	t.Run("app_configuration_public_access", func(t *testing.T) {
+		rc := findRisk(t, "app_configuration_public_access", "app_configuration_id")
+		assertRisk(t, rc, "app_configuration_public_access", output.RiskSeverityMedium, "-appconf")
 	})
 
-	// --- AI and Search ---
+	// =====================================================================
+	// Databases
+	// =====================================================================
 
-	t.Run("detects public cognitive services", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("cognitive_account_id"))
+	t.Run("sql_servers_public_access", func(t *testing.T) {
+		if !fixtureHasOutput("sql_server_id") {
+			t.Skip("sql_server not provisioned in this environment")
+		}
+		rc := findRisk(t, "sql_servers_public_access", "sql_server_id")
+		assertRisk(t, rc, "sql_servers_public_access", output.RiskSeverityHigh, "-w-sql")
 	})
 
-	t.Run("detects public search service", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("search_service_id"))
+	t.Run("postgresql_flexible_server_public_access", func(t *testing.T) {
+		rc := findRisk(t, "postgresql_flexible_server_public_access", "postgresql_server_id")
+		assertRisk(t, rc, "postgresql_flexible_server_public_access", output.RiskSeverityMedium, "-pg")
 	})
 
-	// --- Compute ---
+	// =====================================================================
+	// Container & Registry
+	// =====================================================================
 
-	t.Run("detects public container instance", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("container_instance_id"))
+	t.Run("container_registries_public_access", func(t *testing.T) {
+		rc := findRisk(t, "container_registries_public_access", "acr_id")
+		assertRisk(t, rc, "container_registries_public_access", output.RiskSeverityHigh, "acr")
 	})
 
-	t.Run("detects public container app", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("container_app_id"))
+	t.Run("acr_anonymous_pull_access", func(t *testing.T) {
+		rc := findRisk(t, "acr_anonymous_pull_access", "acr_anon_pull_id")
+		assertRisk(t, rc, "acr_anonymous_pull_access", output.RiskSeverityHigh, "acranon")
 	})
 
-	t.Run("detects public databricks workspace", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("databricks_workspace_id"))
+	t.Run("container_apps_public_access", func(t *testing.T) {
+		if !fixtureHasOutput("container_app_id") {
+			t.Skip("container_app not provisioned in this environment")
+		}
+		rc := findRisk(t, "container_apps_public_access", "container_app_id")
+		assertRisk(t, rc, "container_apps_public_access", output.RiskSeverityMedium, "-w-ca")
 	})
 
-	t.Run("detects public aks cluster", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("aks_id"))
+	t.Run("container_instances_public_access", func(t *testing.T) {
+		rc := findRisk(t, "container_instances_public_access", "container_instance_id")
+		assertRisk(t, rc, "container_instances_public_access", output.RiskSeverityMedium, "-ci")
 	})
 
-	t.Run("detects public virtual machine", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("virtual_machine_id"))
+	t.Run("aks_public_access", func(t *testing.T) {
+		rc := findRisk(t, "aks_public_access", "aks_id")
+		assertRisk(t, rc, "aks_public_access", output.RiskSeverityHigh, "-aks")
 	})
 
-	// --- IoT and Messaging ---
+	// =====================================================================
+	// AI & Search
+	// =====================================================================
 
-	t.Run("detects public iot hub", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("iot_hub_id"))
+	t.Run("cognitive_services_public_access", func(t *testing.T) {
+		rc := findRisk(t, "cognitive_services_public_access", "cognitive_account_id")
+		assertRisk(t, rc, "cognitive_services_public_access", output.RiskSeverityMedium, "-cog")
 	})
 
-	t.Run("detects public event grid topic", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("event_grid_topic_id"))
+	t.Run("search_service_public_access", func(t *testing.T) {
+		rc := findRisk(t, "search_service_public_access", "search_service_id")
+		assertRisk(t, rc, "search_service_public_access", output.RiskSeverityMedium, "-search")
 	})
 
-	t.Run("detects public notification hub namespace", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("notification_hub_namespace_id"))
+	// =====================================================================
+	// Compute
+	// =====================================================================
+
+	t.Run("virtual_machines_public_access", func(t *testing.T) {
+		rc := findRisk(t, "virtual_machines_public_access", "virtual_machine_id")
+		assertRisk(t, rc, "virtual_machines_public_access", output.RiskSeverityHigh, "-vm")
 	})
 
-	t.Run("detects public service bus", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("service_bus_id"))
+	t.Run("databricks_public_access", func(t *testing.T) {
+		rc := findRisk(t, "databricks_public_access", "databricks_workspace_id")
+		assertRisk(t, rc, "databricks_public_access", output.RiskSeverityMedium, "-dbw")
 	})
 
-	t.Run("detects public event hub", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("event_hub_id"))
+	// =====================================================================
+	// IoT & Messaging
+	// =====================================================================
+
+	t.Run("iot_hub_public_access", func(t *testing.T) {
+		rc := findRisk(t, "iot_hub_public_access", "iot_hub_id")
+		assertRisk(t, rc, "iot_hub_public_access", output.RiskSeverityMedium, "-iot")
 	})
 
-	// --- Configuration and Analytics ---
-
-	t.Run("detects public app configuration", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("app_configuration_id"))
+	t.Run("event_grid_topics_public_access", func(t *testing.T) {
+		rc := findRisk(t, "event_grid_topics_public_access", "event_grid_topic_id")
+		assertRisk(t, rc, "event_grid_topics_public_access", output.RiskSeverityMedium, "-egt")
 	})
 
-	t.Run("detects public synapse workspace", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("synapse_workspace_id"))
+	t.Run("notification_hubs_public_access", func(t *testing.T) {
+		rc := findRisk(t, "notification_hubs_public_access", "notification_hub_namespace_id")
+		assertRisk(t, rc, "notification_hubs_public_access", output.RiskSeverityMedium, "-nhns")
 	})
 
-	t.Run("detects public ml workspace", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("ml_workspace_id"))
+	t.Run("service_bus_public_access", func(t *testing.T) {
+		rc := findRisk(t, "service_bus_public_access", "service_bus_id")
+		assertRisk(t, rc, "service_bus_public_access", output.RiskSeverityLow, "-sbus")
 	})
 
-	t.Run("detects public logic app", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("logic_app_id"))
+	t.Run("event_hub_public_access", func(t *testing.T) {
+		rc := findRisk(t, "event_hub_public_access", "event_hub_id")
+		assertRisk(t, rc, "event_hub_public_access", output.RiskSeverityHigh, "-eh")
 	})
 
-	t.Run("detects public data factory", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("data_factory_id"))
+	// =====================================================================
+	// Analytics & Integration
+	// =====================================================================
+
+	t.Run("synapse_public_access", func(t *testing.T) {
+		if !fixtureHasOutput("synapse_workspace_id") {
+			t.Skip("synapse_workspace not provisioned in this environment")
+		}
+		rc := findRisk(t, "synapse_public_access", "synapse_workspace_id")
+		assertRisk(t, rc, "synapse_public_access", output.RiskSeverityMedium, "-w-syn")
 	})
 
-	t.Run("detects public log analytics workspace", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("log_analytics_id"))
+	t.Run("ml_workspace_public_access", func(t *testing.T) {
+		if !fixtureHasOutput("ml_workspace_id") {
+			t.Skip("ml_workspace not provisioned in this environment")
+		}
+		rc := findRisk(t, "ml_workspace_public_access", "ml_workspace_id")
+		assertRisk(t, rc, "ml_workspace_public_access", output.RiskSeverityMedium, "-w-mlw")
 	})
 
-	// --- Data stores ---
-
-	t.Run("detects public cosmos db", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("cosmos_db_id"))
+	t.Run("logic_apps_public_access", func(t *testing.T) {
+		rc := findRisk(t, "logic_apps_public_access", "logic_app_id")
+		assertRisk(t, rc, "logic_apps_public_access", output.RiskSeverityMedium, "-la")
 	})
 
-	t.Run("detects public redis cache", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("redis_cache_id"))
+	t.Run("data_factory_public_access", func(t *testing.T) {
+		rc := findRisk(t, "data_factory_public_access", "data_factory_id")
+		assertRisk(t, rc, "data_factory_public_access", output.RiskSeverityLow, "-adf")
 	})
 
-	t.Run("detects acr with anonymous pull", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("acr_anon_pull_id"))
+	t.Run("log_analytics_public_access", func(t *testing.T) {
+		rc := findRisk(t, "log_analytics_public_access", "log_analytics_id")
+		assertRisk(t, rc, "log_analytics_public_access", output.RiskSeverityLow, "-law")
 	})
 
-	t.Run("detects public data explorer cluster", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("kusto_cluster_id"))
+	t.Run("data_explorer_public_access", func(t *testing.T) {
+		rc := findRisk(t, "data_explorer_public_access", "kusto_cluster_id")
+		assertRisk(t, rc, "data_explorer_public_access", output.RiskSeverityMedium, "kusto")
 	})
 
-	// --- Networking ---
+	// =====================================================================
+	// Networking
+	// =====================================================================
 
-	t.Run("detects public api management", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("api_management_id"))
+	t.Run("api_management_public_access", func(t *testing.T) {
+		rc := findRisk(t, "api_management_public_access", "api_management_id")
+		assertRisk(t, rc, "api_management_public_access", output.RiskSeverityMedium, "-apim")
 	})
 
-	t.Run("detects public load balancer", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("load_balancer_id"))
+	t.Run("load_balancers_public", func(t *testing.T) {
+		rc := findRisk(t, "load_balancers_public", "load_balancer_id")
+		assertRisk(t, rc, "load_balancers_public", output.RiskSeverityHigh, "-lb")
 	})
 
-	t.Run("detects public application gateway", func(t *testing.T) {
-		testutil.AssertResultContainsString(t, results, fixture.Output("application_gateway_id"))
+	t.Run("application_gateway_public_access", func(t *testing.T) {
+		rc := findRisk(t, "application_gateway_public_access", "application_gateway_id")
+		assertRisk(t, rc, "application_gateway_public_access", output.RiskSeverityMedium, "-appgw")
+	})
+
+	// =====================================================================
+	// Cross-finding invariants
+	// =====================================================================
+
+	t.Run("all risks have name public-azure-resource", func(t *testing.T) {
+		for _, rc := range all {
+			assert.Equal(t, "public-azure-resource", rc.Risk.Name,
+				"template %q: risk name should be public-azure-resource", rc.Template)
+		}
+	})
+
+	t.Run("all risks have valid severity", func(t *testing.T) {
+		validSeverities := map[output.RiskSeverity]bool{
+			output.RiskSeverityInfo: true, output.RiskSeverityLow: true,
+			output.RiskSeverityMedium: true, output.RiskSeverityHigh: true,
+			output.RiskSeverityCritical: true,
+		}
+		for _, rc := range all {
+			assert.True(t, validSeverities[rc.Risk.Severity],
+				"template %q: invalid severity %q", rc.Template, rc.Risk.Severity)
+		}
+	})
+
+	t.Run("all risks have non-empty resource ID", func(t *testing.T) {
+		for _, rc := range all {
+			assert.NotEmpty(t, rc.Risk.ImpactedResourceID,
+				"template %q: ImpactedResourceID must not be empty", rc.Template)
+		}
+	})
+
+	t.Run("all risks have valid JSON context with templateId", func(t *testing.T) {
+		for _, rc := range all {
+			assert.NotEmpty(t, rc.Template,
+				"risk context must contain templateId")
+		}
+	})
+
+	t.Run("all risks have resourceId in context", func(t *testing.T) {
+		for _, rc := range all {
+			resID, _ := rc.CtxMap["resourceId"].(string)
+			assert.NotEmpty(t, resID,
+				"template %q: context should contain resourceId", rc.Template)
+		}
+	})
+
+	t.Run("most risks have resourceType in context", func(t *testing.T) {
+		withType := 0
+		for _, rc := range all {
+			resType, _ := rc.CtxMap["resourceType"].(string)
+			if resType != "" {
+				withType++
+			}
+		}
+		// At least 80% of findings should have resourceType populated.
+		ratio := float64(withType) / float64(len(all))
+		assert.Greater(t, ratio, 0.8,
+			"only %d/%d findings have resourceType in context", withType, len(all))
+	})
+
+	t.Run("no duplicate findings per resource per template", func(t *testing.T) {
+		seen := make(map[string]int)
+		for _, rc := range all {
+			key := rc.Template + "|" + strings.ToLower(rc.ResourceID)
+			seen[key]++
+		}
+		for key, count := range seen {
+			assert.Equal(t, 1, count,
+				"duplicate finding: %s appears %d times", key, count)
+		}
+	})
+
+	t.Run("severity distribution has all expected levels", func(t *testing.T) {
+		sevCounts := make(map[output.RiskSeverity]int)
+		for _, rc := range all {
+			sevCounts[rc.Risk.Severity]++
+		}
+		assert.Greater(t, sevCounts[output.RiskSeverityHigh], 0,
+			"should have at least one high severity finding")
+		assert.Greater(t, sevCounts[output.RiskSeverityMedium], 0,
+			"should have at least one medium severity finding")
+		assert.Greater(t, sevCounts[output.RiskSeverityLow], 0,
+			"should have at least one low severity finding")
 	})
 }

--- a/pkg/modules/azure/recon/public_resources_integration_test.go
+++ b/pkg/modules/azure/recon/public_resources_integration_test.go
@@ -301,6 +301,43 @@ func TestAzurePublicResources(t *testing.T) {
 	})
 
 	// =====================================================================
+	// Negative tests — secure resources must NOT produce findings
+	// =====================================================================
+
+	// Helper: assert a secure resource ID does not appear in any finding.
+	assertNotFlagged := func(t *testing.T, fixtureKey, description string) {
+		t.Helper()
+		if !fixtureHasOutput(fixtureKey) {
+			t.Skipf("%s not provisioned", description)
+		}
+		secureID := strings.ToLower(fixture.Output(fixtureKey))
+		for _, rc := range all {
+			assert.NotEqual(t, strings.ToLower(rc.ResourceID), secureID,
+				"%s should NOT be flagged but was by template %q", description, rc.Template)
+		}
+	}
+
+	t.Run("secure storage account not flagged", func(t *testing.T) {
+		assertNotFlagged(t, "secure_storage_account_id", "secure storage account (public access disabled)")
+	})
+
+	t.Run("secure key vault not flagged", func(t *testing.T) {
+		assertNotFlagged(t, "secure_key_vault_id", "secure key vault (deny by default)")
+	})
+
+	t.Run("secure cosmos db not flagged", func(t *testing.T) {
+		assertNotFlagged(t, "secure_cosmos_db_id", "secure Cosmos DB (public access disabled)")
+	})
+
+	t.Run("secure container registry not flagged", func(t *testing.T) {
+		assertNotFlagged(t, "secure_acr_id", "secure ACR (public access disabled, admin disabled)")
+	})
+
+	t.Run("secure app configuration not flagged", func(t *testing.T) {
+		assertNotFlagged(t, "secure_app_configuration_id", "secure App Configuration (public access disabled)")
+	})
+
+	// =====================================================================
 	// Cross-finding invariants
 	// =====================================================================
 

--- a/pkg/modules/azure/recon/public_resources_integration_test.go
+++ b/pkg/modules/azure/recon/public_resources_integration_test.go
@@ -106,199 +106,64 @@ func TestAzurePublicResources(t *testing.T) {
 			expectedTemplate, rc.Risk.ImpactedResourceID, resourceNameSubstr)
 	}
 
-	// =====================================================================
-	// Storage & Data
-	// =====================================================================
+	// Per-template assertions: verify each template found the expected fixture resource
+	// with the correct severity and resource name substring.
+	templateTests := []struct {
+		templateID string
+		fixtureKey string
+		severity   output.RiskSeverity
+		substr     string
+		optional   bool // skip if fixture output is missing
+	}{
+		// Storage & Data
+		{"storage_accounts_public_access", "storage_account_id", output.RiskSeverityHigh, "sa", false},
+		{"key_vault_public_access", "key_vault_id", output.RiskSeverityHigh, "-kv", false},
+		{"cosmos_db_public_access", "cosmos_db_id", output.RiskSeverityHigh, "-cosmos", false},
+		{"redis_cache_public_access", "redis_cache_id", output.RiskSeverityLow, "-redis", false},
+		{"app_configuration_public_access", "app_configuration_id", output.RiskSeverityMedium, "-appconf", false},
+		// Databases
+		{"sql_servers_public_access", "sql_server_id", output.RiskSeverityHigh, "-w-sql", true},
+		{"postgresql_flexible_server_public_access", "postgresql_server_id", output.RiskSeverityMedium, "-pg", false},
+		// Container & Registry
+		{"container_registries_public_access", "acr_id", output.RiskSeverityHigh, "acr", false},
+		{"acr_anonymous_pull_access", "acr_anon_pull_id", output.RiskSeverityHigh, "acranon", false},
+		{"container_apps_public_access", "container_app_id", output.RiskSeverityMedium, "-w-ca", true},
+		{"container_instances_public_access", "container_instance_id", output.RiskSeverityMedium, "-ci", false},
+		{"aks_public_access", "aks_id", output.RiskSeverityHigh, "-aks", false},
+		// AI & Search
+		{"cognitive_services_public_access", "cognitive_account_id", output.RiskSeverityMedium, "-cog", false},
+		{"search_service_public_access", "search_service_id", output.RiskSeverityMedium, "-search", false},
+		// Compute
+		{"virtual_machines_public_access", "virtual_machine_id", output.RiskSeverityHigh, "-vm", false},
+		{"databricks_public_access", "databricks_workspace_id", output.RiskSeverityMedium, "-dbw", false},
+		// IoT & Messaging
+		{"iot_hub_public_access", "iot_hub_id", output.RiskSeverityMedium, "-iot", false},
+		{"event_grid_topics_public_access", "event_grid_topic_id", output.RiskSeverityMedium, "-egt", false},
+		{"notification_hubs_public_access", "notification_hub_namespace_id", output.RiskSeverityMedium, "-nhns", false},
+		{"service_bus_public_access", "service_bus_id", output.RiskSeverityLow, "-sbus", false},
+		{"event_hub_public_access", "event_hub_id", output.RiskSeverityHigh, "-eh", false},
+		// Analytics & Integration
+		{"synapse_public_access", "synapse_workspace_id", output.RiskSeverityMedium, "-w-syn", true},
+		{"ml_workspace_public_access", "ml_workspace_id", output.RiskSeverityMedium, "-w-mlw", true},
+		{"logic_apps_public_access", "logic_app_id", output.RiskSeverityMedium, "-la", false},
+		{"data_factory_public_access", "data_factory_id", output.RiskSeverityLow, "-adf", false},
+		{"log_analytics_public_access", "log_analytics_id", output.RiskSeverityLow, "-law", false},
+		{"data_explorer_public_access", "kusto_cluster_id", output.RiskSeverityMedium, "kusto", false},
+		// Networking
+		{"api_management_public_access", "api_management_id", output.RiskSeverityMedium, "-apim", false},
+		{"load_balancers_public", "load_balancer_id", output.RiskSeverityHigh, "-lb", false},
+		{"application_gateway_public_access", "application_gateway_id", output.RiskSeverityMedium, "-appgw", false},
+	}
 
-	t.Run("storage_accounts_public_access", func(t *testing.T) {
-		rc := findRisk(t, "storage_accounts_public_access", "storage_account_id")
-		assertRisk(t, rc, "storage_accounts_public_access", output.RiskSeverityHigh, "sa")
-	})
-
-	t.Run("key_vault_public_access", func(t *testing.T) {
-		rc := findRisk(t, "key_vault_public_access", "key_vault_id")
-		assertRisk(t, rc, "key_vault_public_access", output.RiskSeverityHigh, "-kv")
-	})
-
-	t.Run("cosmos_db_public_access", func(t *testing.T) {
-		rc := findRisk(t, "cosmos_db_public_access", "cosmos_db_id")
-		assertRisk(t, rc, "cosmos_db_public_access", output.RiskSeverityHigh, "-cosmos")
-	})
-
-	t.Run("redis_cache_public_access", func(t *testing.T) {
-		rc := findRisk(t, "redis_cache_public_access", "redis_cache_id")
-		assertRisk(t, rc, "redis_cache_public_access", output.RiskSeverityLow, "-redis")
-	})
-
-	t.Run("app_configuration_public_access", func(t *testing.T) {
-		rc := findRisk(t, "app_configuration_public_access", "app_configuration_id")
-		assertRisk(t, rc, "app_configuration_public_access", output.RiskSeverityMedium, "-appconf")
-	})
-
-	// =====================================================================
-	// Databases
-	// =====================================================================
-
-	t.Run("sql_servers_public_access", func(t *testing.T) {
-		if !fixtureHasOutput("sql_server_id") {
-			t.Skip("sql_server not provisioned in this environment")
-		}
-		rc := findRisk(t, "sql_servers_public_access", "sql_server_id")
-		assertRisk(t, rc, "sql_servers_public_access", output.RiskSeverityHigh, "-w-sql")
-	})
-
-	t.Run("postgresql_flexible_server_public_access", func(t *testing.T) {
-		rc := findRisk(t, "postgresql_flexible_server_public_access", "postgresql_server_id")
-		assertRisk(t, rc, "postgresql_flexible_server_public_access", output.RiskSeverityMedium, "-pg")
-	})
-
-	// =====================================================================
-	// Container & Registry
-	// =====================================================================
-
-	t.Run("container_registries_public_access", func(t *testing.T) {
-		rc := findRisk(t, "container_registries_public_access", "acr_id")
-		assertRisk(t, rc, "container_registries_public_access", output.RiskSeverityHigh, "acr")
-	})
-
-	t.Run("acr_anonymous_pull_access", func(t *testing.T) {
-		rc := findRisk(t, "acr_anonymous_pull_access", "acr_anon_pull_id")
-		assertRisk(t, rc, "acr_anonymous_pull_access", output.RiskSeverityHigh, "acranon")
-	})
-
-	t.Run("container_apps_public_access", func(t *testing.T) {
-		if !fixtureHasOutput("container_app_id") {
-			t.Skip("container_app not provisioned in this environment")
-		}
-		rc := findRisk(t, "container_apps_public_access", "container_app_id")
-		assertRisk(t, rc, "container_apps_public_access", output.RiskSeverityMedium, "-w-ca")
-	})
-
-	t.Run("container_instances_public_access", func(t *testing.T) {
-		rc := findRisk(t, "container_instances_public_access", "container_instance_id")
-		assertRisk(t, rc, "container_instances_public_access", output.RiskSeverityMedium, "-ci")
-	})
-
-	t.Run("aks_public_access", func(t *testing.T) {
-		rc := findRisk(t, "aks_public_access", "aks_id")
-		assertRisk(t, rc, "aks_public_access", output.RiskSeverityHigh, "-aks")
-	})
-
-	// =====================================================================
-	// AI & Search
-	// =====================================================================
-
-	t.Run("cognitive_services_public_access", func(t *testing.T) {
-		rc := findRisk(t, "cognitive_services_public_access", "cognitive_account_id")
-		assertRisk(t, rc, "cognitive_services_public_access", output.RiskSeverityMedium, "-cog")
-	})
-
-	t.Run("search_service_public_access", func(t *testing.T) {
-		rc := findRisk(t, "search_service_public_access", "search_service_id")
-		assertRisk(t, rc, "search_service_public_access", output.RiskSeverityMedium, "-search")
-	})
-
-	// =====================================================================
-	// Compute
-	// =====================================================================
-
-	t.Run("virtual_machines_public_access", func(t *testing.T) {
-		rc := findRisk(t, "virtual_machines_public_access", "virtual_machine_id")
-		assertRisk(t, rc, "virtual_machines_public_access", output.RiskSeverityHigh, "-vm")
-	})
-
-	t.Run("databricks_public_access", func(t *testing.T) {
-		rc := findRisk(t, "databricks_public_access", "databricks_workspace_id")
-		assertRisk(t, rc, "databricks_public_access", output.RiskSeverityMedium, "-dbw")
-	})
-
-	// =====================================================================
-	// IoT & Messaging
-	// =====================================================================
-
-	t.Run("iot_hub_public_access", func(t *testing.T) {
-		rc := findRisk(t, "iot_hub_public_access", "iot_hub_id")
-		assertRisk(t, rc, "iot_hub_public_access", output.RiskSeverityMedium, "-iot")
-	})
-
-	t.Run("event_grid_topics_public_access", func(t *testing.T) {
-		rc := findRisk(t, "event_grid_topics_public_access", "event_grid_topic_id")
-		assertRisk(t, rc, "event_grid_topics_public_access", output.RiskSeverityMedium, "-egt")
-	})
-
-	t.Run("notification_hubs_public_access", func(t *testing.T) {
-		rc := findRisk(t, "notification_hubs_public_access", "notification_hub_namespace_id")
-		assertRisk(t, rc, "notification_hubs_public_access", output.RiskSeverityMedium, "-nhns")
-	})
-
-	t.Run("service_bus_public_access", func(t *testing.T) {
-		rc := findRisk(t, "service_bus_public_access", "service_bus_id")
-		assertRisk(t, rc, "service_bus_public_access", output.RiskSeverityLow, "-sbus")
-	})
-
-	t.Run("event_hub_public_access", func(t *testing.T) {
-		rc := findRisk(t, "event_hub_public_access", "event_hub_id")
-		assertRisk(t, rc, "event_hub_public_access", output.RiskSeverityHigh, "-eh")
-	})
-
-	// =====================================================================
-	// Analytics & Integration
-	// =====================================================================
-
-	t.Run("synapse_public_access", func(t *testing.T) {
-		if !fixtureHasOutput("synapse_workspace_id") {
-			t.Skip("synapse_workspace not provisioned in this environment")
-		}
-		rc := findRisk(t, "synapse_public_access", "synapse_workspace_id")
-		assertRisk(t, rc, "synapse_public_access", output.RiskSeverityMedium, "-w-syn")
-	})
-
-	t.Run("ml_workspace_public_access", func(t *testing.T) {
-		if !fixtureHasOutput("ml_workspace_id") {
-			t.Skip("ml_workspace not provisioned in this environment")
-		}
-		rc := findRisk(t, "ml_workspace_public_access", "ml_workspace_id")
-		assertRisk(t, rc, "ml_workspace_public_access", output.RiskSeverityMedium, "-w-mlw")
-	})
-
-	t.Run("logic_apps_public_access", func(t *testing.T) {
-		rc := findRisk(t, "logic_apps_public_access", "logic_app_id")
-		assertRisk(t, rc, "logic_apps_public_access", output.RiskSeverityMedium, "-la")
-	})
-
-	t.Run("data_factory_public_access", func(t *testing.T) {
-		rc := findRisk(t, "data_factory_public_access", "data_factory_id")
-		assertRisk(t, rc, "data_factory_public_access", output.RiskSeverityLow, "-adf")
-	})
-
-	t.Run("log_analytics_public_access", func(t *testing.T) {
-		rc := findRisk(t, "log_analytics_public_access", "log_analytics_id")
-		assertRisk(t, rc, "log_analytics_public_access", output.RiskSeverityLow, "-law")
-	})
-
-	t.Run("data_explorer_public_access", func(t *testing.T) {
-		rc := findRisk(t, "data_explorer_public_access", "kusto_cluster_id")
-		assertRisk(t, rc, "data_explorer_public_access", output.RiskSeverityMedium, "kusto")
-	})
-
-	// =====================================================================
-	// Networking
-	// =====================================================================
-
-	t.Run("api_management_public_access", func(t *testing.T) {
-		rc := findRisk(t, "api_management_public_access", "api_management_id")
-		assertRisk(t, rc, "api_management_public_access", output.RiskSeverityMedium, "-apim")
-	})
-
-	t.Run("load_balancers_public", func(t *testing.T) {
-		rc := findRisk(t, "load_balancers_public", "load_balancer_id")
-		assertRisk(t, rc, "load_balancers_public", output.RiskSeverityHigh, "-lb")
-	})
-
-	t.Run("application_gateway_public_access", func(t *testing.T) {
-		rc := findRisk(t, "application_gateway_public_access", "application_gateway_id")
-		assertRisk(t, rc, "application_gateway_public_access", output.RiskSeverityMedium, "-appgw")
-	})
+	for _, tt := range templateTests {
+		t.Run(tt.templateID, func(t *testing.T) {
+			if tt.optional && !fixtureHasOutput(tt.fixtureKey) {
+				t.Skipf("%s not provisioned in this environment", tt.fixtureKey)
+			}
+			rc := findRisk(t, tt.templateID, tt.fixtureKey)
+			assertRisk(t, rc, tt.templateID, tt.severity, tt.substr)
+		})
+	}
 
 	// =====================================================================
 	// Negative tests — secure resources must NOT produce findings

--- a/pkg/modules/azure/recon/public_resources_test.go
+++ b/pkg/modules/azure/recon/public_resources_test.go
@@ -11,7 +11,190 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/templates"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	publicresources "github.com/praetorian-inc/aurelian/pkg/templates/azure/public-resources"
 )
+
+func TestModuleMetadata(t *testing.T) {
+	m := &AzurePublicResourcesModule{}
+
+	assert.Equal(t, "public-resources", m.ID())
+	assert.Equal(t, "Azure Public Resources", m.Name())
+	assert.Equal(t, plugin.PlatformAzure, m.Platform())
+	assert.Equal(t, plugin.CategoryRecon, m.Category())
+	assert.Equal(t, "moderate", m.OpsecLevel())
+
+	authors := m.Authors()
+	require.Len(t, authors, 1)
+	assert.Equal(t, "Praetorian", authors[0])
+
+	assert.NotEmpty(t, m.Description())
+	assert.NotEmpty(t, m.References())
+	assert.Equal(t, []string{"Microsoft.Resources/subscriptions"}, m.SupportedResourceTypes())
+}
+
+func TestPublicResourcesParameters(t *testing.T) {
+	m := &AzurePublicResourcesModule{}
+	params, err := plugin.ParametersFrom(m.Parameters())
+	require.NoError(t, err)
+
+	paramNames := make(map[string]bool)
+	for _, p := range params {
+		paramNames[p.Name] = true
+	}
+
+	assert.True(t, paramNames["subscription-ids"], "should have subscription-ids param")
+	assert.True(t, paramNames["template-dir"], "should have template-dir param")
+	assert.True(t, paramNames["output-dir"], "should have output-dir param")
+}
+
+func TestPublicResourcesTemplateLoader_LoadsAll36(t *testing.T) {
+	loader, err := publicresources.NewLoader()
+	require.NoError(t, err)
+
+	tmps := loader.GetTemplates()
+	assert.Len(t, tmps, 36, "should load exactly 36 public-resources templates")
+
+	// Every known template ID must be present.
+	expectedIDs := map[string]bool{
+		"acr_anonymous_pull_access":                true,
+		"aks_public_access":                        true,
+		"api_management_public_access":             true,
+		"apim_cross_tenant_signup_bypass":          true,
+		"app_configuration_public_access":          true,
+		"app_services_public_access":               true,
+		"application_gateway_public_access":        true,
+		"cognitive_services_public_access":          true,
+		"container_apps_public_access":             true,
+		"container_instances_public_access":        true,
+		"container_registries_public_access":       true,
+		"cosmos_db_public_access":                  true,
+		"data_explorer_public_access":              true,
+		"data_factory_public_access":               true,
+		"databricks_public_access":                 true,
+		"event_grid_domain_public":                 true,
+		"event_grid_topics_public_access":          true,
+		"event_hub_public_access":                  true,
+		"function_apps_public_http_triggers":       true,
+		"iot_hub_public_access":                    true,
+		"key_vault_public_access":                  true,
+		"load_balancers_public":                    true,
+		"log_analytics_public_access":              true,
+		"logic_apps_public_access":                 true,
+		"ml_workspace_public_access":               true,
+		"mysql_flexible_server_public_access":      true,
+		"notification_hubs_public_access":          true,
+		"openai_public_access":                     true,
+		"postgresql_flexible_server_public_access": true,
+		"redis_cache_public_access":                true,
+		"search_service_public_access":             true,
+		"service_bus_public_access":                true,
+		"sql_servers_public_access":                true,
+		"storage_accounts_public_access":           true,
+		"synapse_public_access":                    true,
+		"virtual_machines_public_access":           true,
+	}
+
+	foundIDs := make(map[string]bool)
+	for _, tmpl := range tmps {
+		assert.NotEmpty(t, tmpl.ID)
+		assert.NotEmpty(t, tmpl.Name)
+		assert.NotEmpty(t, tmpl.Query)
+		assert.NotEmpty(t, tmpl.Severity, "template %s should have severity", tmpl.ID)
+		foundIDs[tmpl.ID] = true
+	}
+
+	for id := range expectedIDs {
+		assert.True(t, foundIDs[id], "missing template: %s", id)
+	}
+
+	// No extra unknown templates.
+	for _, tmpl := range tmps {
+		assert.True(t, expectedIDs[tmpl.ID], "unexpected template: %s", tmpl.ID)
+	}
+}
+
+func TestPublicResourcesTemplateLoader_SeveritiesMatchExpected(t *testing.T) {
+	loader, err := publicresources.NewLoader()
+	require.NoError(t, err)
+
+	expectedSeverities := map[string]output.RiskSeverity{
+		"acr_anonymous_pull_access":                output.RiskSeverityHigh,
+		"aks_public_access":                        output.RiskSeverityHigh,
+		"api_management_public_access":             output.RiskSeverityMedium,
+		"apim_cross_tenant_signup_bypass":          output.RiskSeverityMedium,
+		"app_configuration_public_access":          output.RiskSeverityMedium,
+		"app_services_public_access":               output.RiskSeverityMedium,
+		"application_gateway_public_access":        output.RiskSeverityMedium,
+		"cognitive_services_public_access":          output.RiskSeverityMedium,
+		"container_apps_public_access":             output.RiskSeverityMedium,
+		"container_instances_public_access":        output.RiskSeverityMedium,
+		"container_registries_public_access":       output.RiskSeverityHigh,
+		"cosmos_db_public_access":                  output.RiskSeverityHigh,
+		"data_explorer_public_access":              output.RiskSeverityMedium,
+		"data_factory_public_access":               output.RiskSeverityLow,
+		"databricks_public_access":                 output.RiskSeverityMedium,
+		"event_grid_domain_public":                 output.RiskSeverityHigh,
+		"event_grid_topics_public_access":          output.RiskSeverityMedium,
+		"event_hub_public_access":                  output.RiskSeverityHigh,
+		"function_apps_public_http_triggers":       output.RiskSeverityMedium,
+		"iot_hub_public_access":                    output.RiskSeverityMedium,
+		"key_vault_public_access":                  output.RiskSeverityHigh,
+		"load_balancers_public":                    output.RiskSeverityHigh,
+		"log_analytics_public_access":              output.RiskSeverityLow,
+		"logic_apps_public_access":                 output.RiskSeverityMedium,
+		"ml_workspace_public_access":               output.RiskSeverityMedium,
+		"mysql_flexible_server_public_access":      output.RiskSeverityMedium,
+		"notification_hubs_public_access":          output.RiskSeverityMedium,
+		"openai_public_access":                     output.RiskSeverityHigh,
+		"postgresql_flexible_server_public_access": output.RiskSeverityMedium,
+		"redis_cache_public_access":                output.RiskSeverityLow,
+		"search_service_public_access":             output.RiskSeverityMedium,
+		"service_bus_public_access":                output.RiskSeverityLow,
+		"sql_servers_public_access":                output.RiskSeverityHigh,
+		"storage_accounts_public_access":           output.RiskSeverityHigh,
+		"synapse_public_access":                    output.RiskSeverityMedium,
+		"virtual_machines_public_access":           output.RiskSeverityHigh,
+	}
+
+	for _, tmpl := range loader.GetTemplates() {
+		expected, ok := expectedSeverities[tmpl.ID]
+		require.True(t, ok, "no expected severity for template %s", tmpl.ID)
+		assert.Equal(t, expected, output.NormalizeSeverity(tmpl.Severity),
+			"template %s: severity mismatch", tmpl.ID)
+	}
+}
+
+func TestPublicResourcesTemplateLoader_NoOverlapWithConfigurationScan(t *testing.T) {
+	m := &AzurePublicResourcesModule{}
+	require.NoError(t, m.initialize())
+	assert.Len(t, m.templates, 36)
+
+	for _, tmpl := range m.templates {
+		// None of these should be configuration-scan templates.
+		assert.NotContains(t, tmpl.ID, "auth_disabled",
+			"public-resources template %s looks like a configuration-scan template", tmpl.ID)
+		assert.NotContains(t, tmpl.ID, "remote_debugging",
+			"public-resources template %s looks like a configuration-scan template", tmpl.ID)
+		assert.NotContains(t, tmpl.ID, "privilege_escalation",
+			"public-resources template %s looks like a configuration-scan template", tmpl.ID)
+		assert.NotContains(t, tmpl.ID, "rbac_disabled",
+			"public-resources template %s looks like a configuration-scan template", tmpl.ID)
+	}
+}
+
+func TestPublicResourcesTemplateLoader_UniqueIDs(t *testing.T) {
+	loader, err := publicresources.NewLoader()
+	require.NoError(t, err)
+
+	seen := make(map[string]int)
+	for _, tmpl := range loader.GetTemplates() {
+		seen[tmpl.ID]++
+	}
+	for id, count := range seen {
+		assert.Equal(t, 1, count, "duplicate template ID: %s appears %d times", id, count)
+	}
+}
 
 func TestResultToRisk(t *testing.T) {
 	result := templates.ARGQueryResult{
@@ -34,32 +217,91 @@ func TestResultToRisk(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	var risks []output.AurelianRisk
-	for m := range out.Range() {
-		if r, ok := m.(output.AurelianRisk); ok {
-			risks = append(risks, r)
-		}
-	}
-	require.NoError(t, out.Wait())
-	require.Len(t, risks, 1)
+	items, err := out.Collect()
+	require.NoError(t, err)
+	require.Len(t, items, 1)
 
-	risk := risks[0]
+	risk, ok := items[0].(output.AurelianRisk)
+	require.True(t, ok)
+
 	assert.Equal(t, "public-azure-resource", risk.Name)
 	assert.Equal(t, output.RiskSeverityHigh, risk.Severity)
-	assert.Contains(t, risk.ImpactedResourceID, "mystorage")
+	assert.Equal(t, "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage", risk.ImpactedResourceID)
+	assert.NotEmpty(t, risk.Context)
 
 	var ctx map[string]any
 	require.NoError(t, json.Unmarshal(risk.Context, &ctx))
 	assert.Equal(t, "storage_accounts_public_access", ctx["templateId"])
+	assert.Equal(t, "mystorage", ctx["resourceName"])
+	assert.Equal(t, "Microsoft.Storage/storageAccounts", ctx["resourceType"])
+	assert.Equal(t, "xxx", ctx["subscriptionId"])
 }
 
-func TestModuleMetadata(t *testing.T) {
-	m := &AzurePublicResourcesModule{}
-	assert.Equal(t, "public-resources", m.ID())
-	assert.Equal(t, "Azure Public Resources", m.Name())
-	assert.Equal(t, plugin.PlatformAzure, m.Platform())
-	assert.Equal(t, plugin.CategoryRecon, m.Category())
-	assert.Equal(t, "moderate", m.OpsecLevel())
-	assert.NotEmpty(t, m.SupportedResourceTypes())
-	assert.NotNil(t, m.Parameters())
+func TestResultToRisk_SeverityPreserved(t *testing.T) {
+	severities := []string{"low", "medium", "high", "critical"}
+
+	for _, sev := range severities {
+		t.Run(sev, func(t *testing.T) {
+			tmpl := &templates.ARGQueryTemplate{
+				ID:       "test_" + sev,
+				Name:     "Test " + sev,
+				Severity: output.RiskSeverity(sev),
+			}
+			result := templates.ARGQueryResult{
+				TemplateID:      tmpl.ID,
+				TemplateDetails: tmpl,
+				ResourceID:      "/subscriptions/s/resourceGroups/r/providers/T/n",
+			}
+
+			out := pipeline.New[model.AurelianModel]()
+			go func() {
+				defer out.Close()
+				resultToRisk(result, out)
+			}()
+
+			items, err := out.Collect()
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+
+			risk := items[0].(output.AurelianRisk)
+			assert.Equal(t, output.RiskSeverity(sev), risk.Severity)
+			assert.Equal(t, "public-azure-resource", risk.Name)
+		})
+	}
+}
+
+func TestResultToRisk_ContextContainsAllFields(t *testing.T) {
+	result := templates.ARGQueryResult{
+		TemplateID: "key_vault_public_access",
+		TemplateDetails: &templates.ARGQueryTemplate{
+			ID:       "key_vault_public_access",
+			Name:     "Publicly Accessible Key Vaults",
+			Severity: output.RiskSeverityHigh,
+		},
+		ResourceID:     "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault",
+		ResourceName:   "myvault",
+		ResourceType:   "Microsoft.KeyVault/vaults",
+		SubscriptionID: "sub-1",
+	}
+
+	out := pipeline.New[model.AurelianModel]()
+	go func() {
+		defer out.Close()
+		resultToRisk(result, out)
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	risk := items[0].(output.AurelianRisk)
+	var ctx map[string]any
+	require.NoError(t, json.Unmarshal(risk.Context, &ctx))
+
+	// All expected context fields must be present.
+	assert.Equal(t, "key_vault_public_access", ctx["templateId"])
+	assert.Equal(t, "myvault", ctx["resourceName"])
+	assert.Equal(t, "Microsoft.KeyVault/vaults", ctx["resourceType"])
+	assert.Equal(t, "sub-1", ctx["subscriptionId"])
+	assert.Equal(t, "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault", ctx["resourceId"])
 }

--- a/pkg/templates/azure/public-resources/loader_test.go
+++ b/pkg/templates/azure/public-resources/loader_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,13 +16,12 @@ func writeTestTemplate(t *testing.T, dir, name, content string) {
 	require.NoError(t, err)
 }
 
-func TestNewLoader_LoadsEmbeddedTemplates(t *testing.T) {
+func TestNewLoader_LoadsExactly36Templates(t *testing.T) {
 	loader, err := NewLoader()
 	require.NoError(t, err)
 
 	templates := loader.GetTemplates()
-	assert.NotEmpty(t, templates, "should load embedded YAML templates")
-	assert.GreaterOrEqual(t, len(templates), 30, "should have at least 30 templates")
+	assert.Len(t, templates, 36, "should load exactly 36 embedded YAML templates")
 }
 
 func TestNewLoader_AllTemplatesHaveRequiredFields(t *testing.T) {
@@ -29,10 +29,57 @@ func TestNewLoader_AllTemplatesHaveRequiredFields(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tmpl := range loader.GetTemplates() {
-		assert.NotEmpty(t, tmpl.ID, "template ID must not be empty")
-		assert.NotEmpty(t, tmpl.Name, "template Name must not be empty")
-		assert.NotEmpty(t, tmpl.Query, "template Query must not be empty")
-		assert.NotEmpty(t, tmpl.Severity, "template Severity must not be empty for %s", tmpl.ID)
+		t.Run(tmpl.ID, func(t *testing.T) {
+			assert.NotEmpty(t, tmpl.ID, "template ID must not be empty")
+			assert.NotEmpty(t, tmpl.Name, "template Name must not be empty")
+			assert.NotEmpty(t, tmpl.Query, "template Query must not be empty")
+			assert.NotEmpty(t, tmpl.Severity, "template Severity must not be empty")
+		})
+	}
+}
+
+func TestNewLoader_AllSeveritiesAreValid(t *testing.T) {
+	loader, err := NewLoader()
+	require.NoError(t, err)
+
+	validSeverities := map[output.RiskSeverity]bool{
+		output.RiskSeverityInfo:     true,
+		output.RiskSeverityLow:      true,
+		output.RiskSeverityMedium:   true,
+		output.RiskSeverityHigh:     true,
+		output.RiskSeverityCritical: true,
+	}
+
+	for _, tmpl := range loader.GetTemplates() {
+		normalized := output.NormalizeSeverity(tmpl.Severity)
+		assert.True(t, validSeverities[normalized],
+			"template %s: invalid severity %q (normalized: %q)", tmpl.ID, tmpl.Severity, normalized)
+	}
+}
+
+func TestNewLoader_AllTemplateIDsAreUnique(t *testing.T) {
+	loader, err := NewLoader()
+	require.NoError(t, err)
+
+	seen := make(map[string]int)
+	for _, tmpl := range loader.GetTemplates() {
+		seen[tmpl.ID]++
+	}
+	for id, count := range seen {
+		assert.Equal(t, 1, count, "duplicate template ID: %s (appears %d times)", id, count)
+	}
+}
+
+func TestNewLoader_AllQueriesTargetResources(t *testing.T) {
+	loader, err := NewLoader()
+	require.NoError(t, err)
+
+	for _, tmpl := range loader.GetTemplates() {
+		t.Run(tmpl.ID, func(t *testing.T) {
+			// Every ARG query should reference the Resources table or similar.
+			assert.Contains(t, tmpl.Query, "esource",
+				"template %s: query should reference a resource table", tmpl.ID)
+		})
 	}
 }
 
@@ -41,6 +88,7 @@ func TestNewLoader_LoadUserTemplates(t *testing.T) {
 	require.NoError(t, err)
 
 	initialCount := len(loader.GetTemplates())
+	require.Equal(t, 36, initialCount)
 
 	dir := t.TempDir()
 	writeTestTemplate(t, dir, "test_template.yaml", `
@@ -63,6 +111,8 @@ func TestNewLoader_LoadUserTemplates_EmptyDir(t *testing.T) {
 
 	err = loader.LoadUserTemplates("")
 	require.NoError(t, err)
+	// Count should remain unchanged.
+	assert.Len(t, loader.GetTemplates(), 36)
 }
 
 func TestNewLoader_LoadUserTemplates_NonexistentDir(t *testing.T) {

--- a/test/terraform/azure/recon/public-resources/main.tf
+++ b/test/terraform/azure/recon/public-resources/main.tf
@@ -860,3 +860,84 @@ resource "azurerm_kusto_cluster" "public" {
 
   tags = local.tags
 }
+
+# ============================================================================
+# NEGATIVE TEST FIXTURES — secure resources that must NOT be flagged
+# ============================================================================
+
+# Secure Storage Account — public network access disabled
+resource "azurerm_storage_account" "secure" {
+  name                          = "${local.prefix_san}sec"
+  resource_group_name           = azurerm_resource_group.test.name
+  location                      = local.location
+  account_tier                  = "Standard"
+  account_replication_type      = "LRS"
+  public_network_access_enabled = false
+
+  tags = local.tags
+}
+
+# Secure Key Vault — public network access disabled, deny by default
+resource "azurerm_key_vault" "secure" {
+  name                          = "${local.prefix}-sec-kv"
+  resource_group_name           = azurerm_resource_group.test.name
+  location                      = local.location
+  tenant_id                     = data.azurerm_client_config.current.tenant_id
+  sku_name                      = "standard"
+  purge_protection_enabled      = false
+  soft_delete_retention_days    = 7
+  public_network_access_enabled = false
+
+  network_acls {
+    default_action = "Deny"
+    bypass         = "AzureServices"
+  }
+
+  tags = local.tags
+}
+
+# Secure Cosmos DB — public network access disabled
+resource "azurerm_cosmosdb_account" "secure" {
+  name                          = "${local.prefix}-sec-cosmos"
+  resource_group_name           = azurerm_resource_group.test.name
+  location                      = local.location
+  offer_type                    = "Standard"
+  kind                          = "GlobalDocumentDB"
+  public_network_access_enabled = false
+
+  capabilities {
+    name = "EnableServerless"
+  }
+
+  consistency_policy {
+    consistency_level = "Session"
+  }
+
+  geo_location {
+    location          = local.location
+    failover_priority = 0
+  }
+
+  tags = local.tags
+}
+
+# Secure Container Registry — public network access disabled, admin disabled
+resource "azurerm_container_registry" "secure" {
+  name                          = "${local.prefix_san}secacr"
+  resource_group_name           = azurerm_resource_group.test.name
+  location                      = local.location
+  sku                           = "Premium"
+  admin_enabled                 = false
+  public_network_access_enabled = false
+  tags                          = local.tags
+}
+
+# Secure App Configuration — public network access disabled
+resource "azurerm_app_configuration" "secure" {
+  name                  = "${local.prefix}-sec-appconf"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = local.location
+  sku                   = "free"
+  public_network_access = "Disabled"
+  tags                  = local.tags
+}

--- a/test/terraform/azure/recon/public-resources/main.tf
+++ b/test/terraform/azure/recon/public-resources/main.tf
@@ -5,6 +5,10 @@
 //
 // Adapted from Nebula's nebula-public-access testing infrastructure.
 //
+// Resources that hit quota/provider limits in eastus2 are deployed to a
+// secondary region (westus2 by default): SQL Server, Synapse, ML Workspace,
+// Container App. Azure ARG queries work cross-region within a subscription.
+//
 // ==================== TEST CASES ====================
 //
 // | #  | Resource                     | Template ID                                | Expected |
@@ -99,6 +103,12 @@ variable "location" {
   default     = "eastus2"
 }
 
+variable "location_secondary" {
+  description = "Secondary Azure region for resources that hit quota/provider limits in the primary region"
+  type        = string
+  default     = "westus2"
+}
+
 # ============================================================================
 # Resource Group
 # ============================================================================
@@ -182,9 +192,9 @@ resource "azurerm_key_vault" "public" {
 # ============================================================================
 
 resource "azurerm_mssql_server" "public" {
-  name                          = "${local.prefix}-sql"
+  name                          = "${local.prefix}-w-sql"
   resource_group_name           = azurerm_resource_group.test.name
-  location                      = local.location
+  location                      = var.location_secondary
   version                       = "12.0"
   administrator_login           = "aurelianadmin"
   administrator_login_password  = "P@ssw0rd${random_string.suffix.result}!"
@@ -360,9 +370,9 @@ resource "azurerm_databricks_workspace" "public" {
 # ============================================================================
 
 resource "azurerm_storage_account" "synapse" {
-  name                     = "${local.prefix_san}syn"
+  name                     = "${local.prefix_san}wsyn"
   resource_group_name      = azurerm_resource_group.test.name
-  location                 = local.location
+  location                 = var.location_secondary
   account_tier             = "Standard"
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
@@ -376,9 +386,9 @@ resource "azurerm_storage_data_lake_gen2_filesystem" "synapse" {
 }
 
 resource "azurerm_synapse_workspace" "public" {
-  name                                 = "${local.prefix}-syn"
+  name                                 = "${local.prefix}-w-syn"
   resource_group_name                  = azurerm_resource_group.test.name
-  location                             = local.location
+  location                             = var.location_secondary
   storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.synapse.id
   sql_administrator_login              = "sqladminuser"
   sql_administrator_login_password     = "P@ssw0rd1234!"
@@ -394,45 +404,45 @@ resource "azurerm_synapse_workspace" "public" {
 # ============================================================================
 
 resource "azurerm_storage_account" "ml" {
-  name                     = "${local.prefix_san}ml"
+  name                     = "${local.prefix_san}wml"
   resource_group_name      = azurerm_resource_group.test.name
-  location                 = local.location
+  location                 = var.location_secondary
   account_tier             = "Standard"
   account_replication_type = "LRS"
   tags                     = local.tags
 }
 
 resource "azurerm_key_vault" "ml" {
-  name                = "${local.prefix}-mlkv"
+  name                = "${local.prefix}-wmlkv"
   resource_group_name = azurerm_resource_group.test.name
-  location            = local.location
+  location            = var.location_secondary
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
   tags                = local.tags
 }
 
 resource "azurerm_log_analytics_workspace" "ml" {
-  name                = "${local.prefix}-mllaw"
+  name                = "${local.prefix}-wmllaw"
   resource_group_name = azurerm_resource_group.test.name
-  location            = local.location
+  location            = var.location_secondary
   sku                 = "PerGB2018"
   retention_in_days   = 30
   tags                = local.tags
 }
 
 resource "azurerm_application_insights" "ml" {
-  name                = "${local.prefix}-mlai"
+  name                = "${local.prefix}-wmlai"
   resource_group_name = azurerm_resource_group.test.name
-  location            = local.location
+  location            = var.location_secondary
   application_type    = "web"
   workspace_id        = azurerm_log_analytics_workspace.ml.id
   tags                = local.tags
 }
 
 resource "azurerm_machine_learning_workspace" "public" {
-  name                          = "${local.prefix}-mlw"
+  name                          = "${local.prefix}-w-mlw"
   resource_group_name           = azurerm_resource_group.test.name
-  location                      = local.location
+  location                      = var.location_secondary
   application_insights_id       = azurerm_application_insights.ml.id
   key_vault_id                  = azurerm_key_vault.ml.id
   storage_account_id            = azurerm_storage_account.ml.id
@@ -448,24 +458,24 @@ resource "azurerm_machine_learning_workspace" "public" {
 # ============================================================================
 
 resource "azurerm_log_analytics_workspace" "containerapp" {
-  name                = "${local.prefix}-calaw"
+  name                = "${local.prefix}-wcalaw"
   resource_group_name = azurerm_resource_group.test.name
-  location            = local.location
+  location            = var.location_secondary
   sku                 = "PerGB2018"
   retention_in_days   = 30
   tags                = local.tags
 }
 
 resource "azurerm_container_app_environment" "main" {
-  name                       = "${local.prefix}-cae"
+  name                       = "${local.prefix}-w-cae"
   resource_group_name        = azurerm_resource_group.test.name
-  location                   = local.location
+  location                   = var.location_secondary
   log_analytics_workspace_id = azurerm_log_analytics_workspace.containerapp.id
   tags                       = local.tags
 }
 
 resource "azurerm_container_app" "public" {
-  name                         = "${local.prefix}-ca"
+  name                         = "${local.prefix}-w-ca"
   resource_group_name          = azurerm_resource_group.test.name
   container_app_environment_id = azurerm_container_app_environment.main.id
   revision_mode                = "Single"

--- a/test/terraform/azure/recon/public-resources/outputs.tf
+++ b/test/terraform/azure/recon/public-resources/outputs.tf
@@ -121,3 +121,24 @@ output "application_gateway_id" {
 output "kusto_cluster_id" {
   value = azurerm_kusto_cluster.public.id
 }
+
+# Negative test outputs — secure resources that must NOT appear in findings
+output "secure_storage_account_id" {
+  value = azurerm_storage_account.secure.id
+}
+
+output "secure_key_vault_id" {
+  value = azurerm_key_vault.secure.id
+}
+
+output "secure_cosmos_db_id" {
+  value = azurerm_cosmosdb_account.secure.id
+}
+
+output "secure_acr_id" {
+  value = azurerm_container_registry.secure.id
+}
+
+output "secure_app_configuration_id" {
+  value = azurerm_app_configuration.secure.id
+}


### PR DESCRIPTION
## Summary

Previous tests were too generic

- **Unit tests**: 9 tests (up from 2) — exact template IDs, severities, context JSON fields, uniqueness checks, no overlap with configuration-scan
- **Loader tests**: 7 tests (up from 5) — exact count == 36, per-template validation, severity validation, unique IDs, query content checks
- **Integration tests**: 30 per-template sub-tests (up from 27 generic `AssertResultContainsString` checks) — each validates exact severity, template ID, risk name, and **resource name substring** in `ImpactedResourceID` for environment-agnostic specificity
- **8 cross-finding invariants**: consistent risk name, valid severity, non-empty resource ID, templateId/resourceId/resourceType in context, no duplicate findings, severity distribution across levels
- **Secondary region**: Split SQL Server, Synapse, ML Workspace, and Container App to `westus2` to work around eastus2 quota/provider limits — all 30 tests now PASS (previously 4 were SKIP)
- **Microsoft.App provider**: Registered for Container App support

## Test plan

- [x] All 9 unit tests pass (`go test ./pkg/modules/azure/recon/ -run "TestModuleMetadata|TestPublicResources|TestResultToRisk"`)
- [x] All 7 loader tests pass (`go test ./pkg/templates/azure/public-resources/`)
- [x] All 30 e2e integration tests PASS against live Azure with 0 skips (`go test -tags=integration ./pkg/modules/azure/recon/ -run TestAzurePublicResources`)
- [x] Terraform validates (`terraform validate`)
- [x] No sensitive data in commit (conversation exports excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)