### PR TITLE
feat(aws): add Redshift public access detection

### DIFF
--- a/pkg/aws/publicaccess/resource_evaluator.go
+++ b/pkg/aws/publicaccess/resource_evaluator.go
@@ -28,15 +28,16 @@ type evaluator func(resource *output.AWSResource, awsCfg aws.Config, accountID s
 // evaluators maps resource types to their evaluation functions.
 func (e *ResourceEvaluator) evaluators() map[string]evaluator {
 	return map[string]evaluator{
-		"AWS::EC2::Instance":     e.evaluateEC2,
-		"AWS::RDS::DBInstance":   e.evaluateRDS,
-		"AWS::Cognito::UserPool": e.evaluateCognito,
-		"AWS::Lambda::Function":  e.evaluateLambda,
-		"AWS::S3::Bucket":        e.evaluateS3,
-		"AWS::SNS::Topic":        e.evaluateSNS,
-		"AWS::SQS::Queue":        e.evaluateSQS,
-		"AWS::EFS::FileSystem":   e.evaluateEFS,
-		"AWS::EC2::Image":        e.evaluateEC2Image,
+		"AWS::EC2::Instance":      e.evaluateEC2,
+		"AWS::RDS::DBInstance":    e.evaluateRDS,
+		"AWS::Redshift::Cluster":  e.evaluateRedshift,
+		"AWS::Cognito::UserPool":  e.evaluateCognito,
+		"AWS::Lambda::Function":   e.evaluateLambda,
+		"AWS::S3::Bucket":         e.evaluateS3,
+		"AWS::SNS::Topic":         e.evaluateSNS,
+		"AWS::SQS::Queue":         e.evaluateSQS,
+		"AWS::EFS::FileSystem":    e.evaluateEFS,
+		"AWS::EC2::Image":         e.evaluateEC2Image,
 	}
 }
 
@@ -52,6 +53,7 @@ func SupportedResourceTypes() []string {
 		"AWS::EFS::FileSystem",
 		"AWS::Cognito::UserPool",
 		"AWS::RDS::DBInstance",
+		"AWS::Redshift::Cluster",
 		"AWS::EC2::Image",
 	}
 }
@@ -179,6 +181,19 @@ func (e *ResourceEvaluator) evaluateRDS(resource *output.AWSResource, _ aws.Conf
 		IsPublic: true,
 		EvaluationReasons: []string{
 			"RDS instance is publicly accessible (PubliclyAccessible=true)",
+		},
+	}
+}
+
+func (e *ResourceEvaluator) evaluateRedshift(resource *output.AWSResource, _ aws.Config, _ string) *PublicAccessResult {
+	isPublic, _ := resource.Properties["IsPubliclyAccessible"].(bool)
+	if !isPublic {
+		return nil
+	}
+	return &PublicAccessResult{
+		IsPublic: true,
+		EvaluationReasons: []string{
+			"Redshift cluster is publicly accessible (PubliclyAccessible=true)",
 		},
 	}
 }

--- a/pkg/aws/publicaccess/resource_evaluator_test.go
+++ b/pkg/aws/publicaccess/resource_evaluator_test.go
@@ -18,7 +18,7 @@ func newTestEvaluator() *ResourceEvaluator {
 
 func TestSupportedResourceTypes(t *testing.T) {
 	types := SupportedResourceTypes()
-	assert.Len(t, types, 9)
+	assert.Len(t, types, 10)
 
 	e := newTestEvaluator()
 	registry := e.evaluators()
@@ -421,6 +421,39 @@ func TestEvaluateCore_RDS_Private(t *testing.T) {
 	resource := &output.AWSResource{
 		ResourceType: "AWS::RDS::DBInstance",
 		ResourceID:   "mydb-private",
+		Region:       "us-east-1",
+		Properties:   map[string]any{"IsPubliclyAccessible": false},
+	}
+
+	results := collectCore(e, resource)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, output.AccessLevelPrivate, results[0].AWSResource.AccessLevel)
+	assert.False(t, results[0].IsPublic)
+}
+
+func TestEvaluateCore_Redshift_Public(t *testing.T) {
+	e := newTestEvaluator()
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Redshift::Cluster",
+		ResourceID:   "my-cluster-public",
+		Region:       "us-east-1",
+		Properties:   map[string]any{"IsPubliclyAccessible": true},
+	}
+
+	results := collectCore(e, resource)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, output.AccessLevelPublic, results[0].AWSResource.AccessLevel)
+	assert.True(t, results[0].IsPublic)
+	assert.Contains(t, results[0].EvaluationReasons[0], "Redshift cluster is publicly accessible")
+}
+
+func TestEvaluateCore_Redshift_Private(t *testing.T) {
+	e := newTestEvaluator()
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Redshift::Cluster",
+		ResourceID:   "my-cluster-private",
 		Region:       "us-east-1",
 		Properties:   map[string]any{"IsPubliclyAccessible": false},
 	}

--- a/pkg/modules/aws/enrichers/redshift.go
+++ b/pkg/modules/aws/enrichers/redshift.go
@@ -1,0 +1,22 @@
+package enrichers
+
+import (
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+)
+
+func init() {
+	plugin.RegisterEnricher("AWS::Redshift::Cluster", enrichRedshiftClusterWrapper)
+}
+
+func enrichRedshiftClusterWrapper(cfg plugin.EnricherConfig, r *output.AWSResource) error {
+	return EnrichRedshiftCluster(cfg, r)
+}
+
+// EnrichRedshiftCluster normalizes the PubliclyAccessible property from
+// CloudControl into a consistent IsPubliclyAccessible boolean.
+func EnrichRedshiftCluster(cfg plugin.EnricherConfig, r *output.AWSResource) error {
+	publiclyAccessible, _ := r.Properties["PubliclyAccessible"].(bool)
+	r.Properties["IsPubliclyAccessible"] = publiclyAccessible
+	return nil
+}

--- a/pkg/modules/aws/enrichers/redshift_test.go
+++ b/pkg/modules/aws/enrichers/redshift_test.go
@@ -1,0 +1,52 @@
+package enrichers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/praetorian-inc/aurelian/pkg/modules/aws/enrichers"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrichRedshiftCluster_PubliclyAccessible(t *testing.T) {
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Redshift::Cluster",
+		ResourceID:   "my-cluster",
+		Properties:   map[string]any{"PubliclyAccessible": true},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichRedshiftCluster(cfg, resource)
+	require.NoError(t, err)
+	assert.True(t, resource.Properties["IsPubliclyAccessible"].(bool))
+}
+
+func TestEnrichRedshiftCluster_NotPubliclyAccessible(t *testing.T) {
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Redshift::Cluster",
+		ResourceID:   "my-cluster",
+		Properties:   map[string]any{"PubliclyAccessible": false},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichRedshiftCluster(cfg, resource)
+	require.NoError(t, err)
+	assert.False(t, resource.Properties["IsPubliclyAccessible"].(bool))
+}
+
+func TestEnrichRedshiftCluster_MissingProperty(t *testing.T) {
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Redshift::Cluster",
+		ResourceID:   "my-cluster",
+		Properties:   map[string]any{},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichRedshiftCluster(cfg, resource)
+	require.NoError(t, err)
+	assert.False(t, resource.Properties["IsPubliclyAccessible"].(bool))
+}


### PR DESCRIPTION
## Summary
- Add `AWS::Redshift::Cluster` support to the `public-resources` module
- Enricher normalizes `PubliclyAccessible` property from CloudControl
- Evaluator flags clusters with `PubliclyAccessible=true` as public

## Files
- `pkg/modules/aws/enrichers/redshift.go` — enricher (same pattern as RDS)
- `pkg/modules/aws/enrichers/redshift_test.go` — 3 unit tests
- `pkg/aws/publicaccess/resource_evaluator.go` — evaluator + registration
- `pkg/aws/publicaccess/resource_evaluator_test.go` — 2 evaluator tests

## Test plan
- [x] Enricher unit tests (public, private, missing property)
- [x] Evaluator unit tests (public → AccessLevelPublic, private → AccessLevelPrivate)
- [x] All existing evaluator tests pass (count updated 9→10)
- [x] Live tested against firing range (ra3.large single-node, PubliclyAccessible=false correctly identified as private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)