### PR TITLE
feat: add SSM document enumerator with Owner=Self filtering

### DIFF
--- a/pkg/aws/enumeration/enumerator.go
+++ b/pkg/aws/enumeration/enumerator.go
@@ -51,6 +51,7 @@ func NewEnumerator(opts plugin.AWSCommonRecon) *Enumerator {
 	e.Register(iamEnum.UserEnumerator())
 
 	e.Register(NewEC2ImageEnumerator(opts, provider))
+	e.Register(NewSSMDocumentEnumerator(opts, provider))
 
 	return e
 }

--- a/pkg/aws/enumeration/enumerator_test.go
+++ b/pkg/aws/enumeration/enumerator_test.go
@@ -73,6 +73,26 @@ func TestEnumerator_List_InvalidIdentifier(t *testing.T) {
 	require.Contains(t, err.Error(), "identifier must be either an ARN or CloudControl resource type")
 }
 
+func TestEnumerator_enumerateByType_DispatchesSSMToRegisteredEnumerator(t *testing.T) {
+	mock := &mockResourceEnumerator{resourceType: "AWS::SSM::Document"}
+	e := &Enumerator{
+		enumerators: map[string]ResourceEnumerator{"AWS::SSM::Document": mock},
+		cc:          &CloudControlEnumerator{},
+	}
+
+	out := pipeline.New[output.AWSResource]()
+	go func() {
+		for range out.Range() {
+		}
+	}()
+
+	err := e.listByType("AWS::SSM::Document", out)
+	out.Close()
+
+	require.NoError(t, err)
+	require.True(t, mock.enumerateAllCalled)
+}
+
 func TestEnumerator_EnumerateByARN_FallbackOnSentinel(t *testing.T) {
 	mock := &mockResourceEnumerator{
 		resourceType: "AWS::S3::Bucket",

--- a/pkg/aws/enumeration/ssm_document_enumerator.go
+++ b/pkg/aws/enumeration/ssm_document_enumerator.go
@@ -1,0 +1,141 @@
+package enumeration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
+)
+
+// SSMDocumentEnumerator enumerates SSM documents owned by the account using the
+// native SSM SDK, filtering to Owner=Self to exclude AWS-managed and third-party
+// documents.
+type SSMDocumentEnumerator struct {
+	plugin.AWSCommonRecon
+	provider *AWSConfigProvider
+}
+
+func NewSSMDocumentEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider) *SSMDocumentEnumerator {
+	return &SSMDocumentEnumerator{
+		AWSCommonRecon: opts,
+		provider:       provider,
+	}
+}
+
+func (e *SSMDocumentEnumerator) ResourceType() string {
+	return "AWS::SSM::Document"
+}
+
+func (e *SSMDocumentEnumerator) EnumerateAll(out *pipeline.P[output.AWSResource]) error {
+	if len(e.Regions) == 0 {
+		return fmt.Errorf("no regions configured")
+	}
+
+	accountID, err := e.provider.GetAccountID(e.Regions[0])
+	if err != nil {
+		return fmt.Errorf("get account ID: %w", err)
+	}
+
+	actor := ratelimit.NewCrossRegionActor(e.Concurrency)
+	return actor.ActInRegions(e.Regions, func(region string) error {
+		return e.listDocumentsInRegion(region, accountID, out)
+	})
+}
+
+func (e *SSMDocumentEnumerator) EnumerateByARN(arn string, out *pipeline.P[output.AWSResource]) error {
+	parsed, err := awsarn.Parse(arn)
+	if err != nil {
+		return fmt.Errorf("parse ARN %q: %w", arn, err)
+	}
+
+	docName, ok := strings.CutPrefix(parsed.Resource, "document/")
+	if !ok {
+		return fmt.Errorf("invalid SSM document ARN resource: %q", parsed.Resource)
+	}
+
+	if parsed.Region == "" {
+		return fmt.Errorf("SSM document ARN missing region: %q", arn)
+	}
+
+	cfg, err := e.provider.GetAWSConfig(parsed.Region)
+	if err != nil {
+		return fmt.Errorf("create SSM client for %s: %w", parsed.Region, err)
+	}
+	client := ssm.NewFromConfig(*cfg)
+
+	result, err := client.DescribeDocument(context.Background(), &ssm.DescribeDocumentInput{
+		Name: aws.String(docName),
+	})
+	if err != nil {
+		return fmt.Errorf("describe document %s: %w", docName, err)
+	}
+
+	doc := result.Document
+	out.Send(output.AWSResource{
+		ResourceType: "AWS::SSM::Document",
+		ResourceID:   aws.ToString(doc.Name),
+		ARN:          fmt.Sprintf("arn:aws:ssm:%s:%s:document/%s", parsed.Region, parsed.AccountID, aws.ToString(doc.Name)),
+		AccountRef:   parsed.AccountID,
+		Region:       parsed.Region,
+		DisplayName:  aws.ToString(doc.Name),
+		Properties: map[string]any{
+			"Name":            aws.ToString(doc.Name),
+			"Owner":           aws.ToString(doc.Owner),
+			"DocumentVersion": aws.ToString(doc.DocumentVersion),
+			"DocumentType":    string(doc.DocumentType),
+		},
+	})
+	return nil
+}
+
+func (e *SSMDocumentEnumerator) listDocumentsInRegion(region, accountID string, out *pipeline.P[output.AWSResource]) error {
+	cfg, err := e.provider.GetAWSConfig(region)
+	if err != nil {
+		return fmt.Errorf("create SSM client for %s: %w", region, err)
+	}
+	client := ssm.NewFromConfig(*cfg)
+
+	paginator := ssm.NewListDocumentsPaginator(client, &ssm.ListDocumentsInput{
+		Filters: []ssmtypes.DocumentKeyValuesFilter{
+			{
+				Key:    aws.String("Owner"),
+				Values: []string{"Self"},
+			},
+		},
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.Background())
+		if err != nil {
+			return fmt.Errorf("list documents in %s: %w", region, err)
+		}
+
+		for _, doc := range page.DocumentIdentifiers {
+			name := aws.ToString(doc.Name)
+			out.Send(output.AWSResource{
+				ResourceType: "AWS::SSM::Document",
+				ResourceID:   name,
+				ARN:          fmt.Sprintf("arn:aws:ssm:%s:%s:document/%s", region, accountID, name),
+				AccountRef:   accountID,
+				Region:       region,
+				DisplayName:  name,
+				Properties: map[string]any{
+					"Name":            name,
+					"Owner":           aws.ToString(doc.Owner),
+					"DocumentVersion": aws.ToString(doc.DocumentVersion),
+					"DocumentType":    string(doc.DocumentType),
+				},
+			})
+		}
+	}
+
+	return nil
+}

--- a/pkg/aws/enumeration/ssm_document_enumerator_test.go
+++ b/pkg/aws/enumeration/ssm_document_enumerator_test.go
@@ -1,0 +1,21 @@
+package enumeration
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSMDocumentEnumerator_ResourceType(t *testing.T) {
+	provider := NewAWSConfigProvider(plugin.AWSCommonRecon{
+		Regions:     []string{"us-east-1"},
+		Concurrency: 2,
+	})
+	enum := NewSSMDocumentEnumerator(plugin.AWSCommonRecon{
+		Regions:     []string{"us-east-1"},
+		Concurrency: 2,
+	}, provider)
+
+	assert.Equal(t, "AWS::SSM::Document", enum.ResourceType())
+}

--- a/pkg/modules/aws/recon/find_secrets.go
+++ b/pkg/modules/aws/recon/find_secrets.go
@@ -61,7 +61,6 @@ func (m *AWSFindSecretsModule) SupportedResourceTypes() []string {
 		"AWS::SSM::Document",
 		"AWS::StepFunctions::StateMachine",
 		// TODO: AWS::ECR::Repository — container image scanning deferred to follow-up PR.
-		// TODO: add collection module for AWS::SSM::Document
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `SSMDocumentEnumerator` using the native SSM `ListDocuments` API with `Owner=Self` filter, replacing the unfiltered CloudControl fallback that returned all SSM documents (including AWS-managed ones like `AWS-DetachEBSVolume`)
- Registers the new enumerator in the dispatcher so `AWS::SSM::Document` routes to it instead of CloudControl
- Removes the stale TODO in `find_secrets.go`

## Test plan
- [x] Unit test: `TestSSMDocumentEnumerator_ResourceType` passes
- [x] Unit test: `TestEnumerator_enumerateByType_DispatchesSSMToRegisteredEnumerator` passes
- [x] All existing enumeration and find-secrets unit tests pass
- [x] Full project builds clean
- [x] Integration test: `go test ./pkg/modules/aws/recon/ -tags=integration -run "TestAWSFindSecrets/detects_secret_in_SSM_Document" -v`