### PR TITLE
feat(secrets): integrate titus ignore patterns and default ruleset

### DIFF
--- a/docs/aurelian_aws_recon_find-secrets.md
+++ b/docs/aurelian_aws_recon_find-secrets.md
@@ -13,6 +13,7 @@ aurelian aws recon find-secrets [flags]
       --db-path string                 Path for Titus SQLite database
       --disabled-titus-rules strings   Rule IDs to exclude from scanning
   -h, --help                           help for find-secrets
+      --ignore-file string             Path to gitignore-style file for skipping paths; empty uses titus defaults
       --max-events int                 Max log events per log group (default 10000)
       --max-streams int                Max streams to sample per log group (default 10)
       --opsec_level string             Operational security level for AWS operations (default "none")
@@ -22,6 +23,7 @@ aurelian aws recon find-secrets [flags]
   -r, --regions strings                AWS regions to scan (default [all])
   -a, --resource-arn strings           AWS target resource ARN
   -t, --resource-type strings          AWS Cloud Control resource type (default [all])
+      --ruleset string                 Titus ruleset to apply; empty string disables ruleset filtering (default "default")
       --validate                       Validate detected secrets against their source APIs
 ```
 

--- a/docs/aurelian_azure_recon_find-secrets.md
+++ b/docs/aurelian_azure_recon_find-secrets.md
@@ -13,8 +13,10 @@ aurelian azure recon find-secrets [flags]
       --db-path string                 Path for Titus SQLite database
       --disabled-titus-rules strings   Rule IDs to exclude from scanning
   -h, --help                           help for find-secrets
+      --ignore-file string             Path to gitignore-style file for skipping paths; empty uses titus defaults
       --max-cosmos-doc-size int        Max individual Cosmos document size in bytes (default 1048576)
       --output-dir string              Base output directory (default "aurelian-output")
+      --ruleset string                 Titus ruleset to apply; empty string disables ruleset filtering (default "default")
   -s, --subscription-ids strings       Azure subscription ID(s) or 'all' to enumerate all accessible subscriptions (default [all])
       --validate                       Validate detected secrets against their source APIs
 ```

--- a/docs/aurelian_gcp_recon_find-secrets.md
+++ b/docs/aurelian_gcp_recon_find-secrets.md
@@ -15,11 +15,13 @@ aurelian gcp recon find-secrets [flags]
       --disabled-titus-rules strings   Rule IDs to exclude from scanning
       --folder-id strings              GCP folder IDs
   -h, --help                           help for find-secrets
+      --ignore-file string             Path to gitignore-style file for skipping paths; empty uses titus defaults
       --include-sys-projects           Include system projects
   -o, --org-id strings                 GCP organization IDs
       --output-dir string              Base output directory (default "aurelian-output")
   -p, --project-id strings             GCP project IDs
   -t, --resource-type strings          Resource types to enumerate (default [all])
+      --ruleset string                 Titus ruleset to apply; empty string disables ruleset filtering (default "default")
       --validate                       Validate detected secrets against their source APIs
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0
 	github.com/muesli/termenv v0.16.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.4
-	github.com/praetorian-inc/titus v1.1.3
+	github.com/praetorian-inc/titus v1.1.7
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/neo4j v0.40.0
@@ -178,6 +178,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/praetorian-inc/titus v1.1.3 h1:SzyCRBh4nqRqPtvzYV4ARrEPzS1bM1fsQfB4osWG0O0=
-github.com/praetorian-inc/titus v1.1.3/go.mod h1:i2tQG3iJmoi00n8dBE32g50wc/LkIVUV02PHhdC0c3s=
+github.com/praetorian-inc/titus v1.1.7 h1:nm8XD04b+eqFObbdwVbN1nkciN1MI6fhn73upywEaqA=
+github.com/praetorian-inc/titus v1.1.7/go.mod h1:i2tQG3iJmoi00n8dBE32g50wc/LkIVUV02PHhdC0c3s=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -429,6 +429,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shirou/gopsutil/v4 v4.25.6 h1:kLysI2JsKorfaFPcYmcJqbzROzsBWEOAtw6A7dIfqXs=
@@ -451,6 +453,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=

--- a/pkg/aws/extraction/extract_lambda.go
+++ b/pkg/aws/extraction/extract_lambda.go
@@ -80,7 +80,9 @@ func extractLambda(ctx extractContext, r output.AWSResource, out *pipeline.P[out
 				return nil
 			}
 
-			out.Send(output.ScanInputFromAWSResource(r, f.Name, content))
+			si := output.ScanInputFromAWSResource(r, f.Name, content)
+			si.PathFilterable = true
+			out.Send(si)
 			return nil
 		})
 	}

--- a/pkg/output/scan_input.go
+++ b/pkg/output/scan_input.go
@@ -19,6 +19,11 @@ type ScanInput struct {
 
 	// Label describes what this content is (e.g. "UserData", "handler.py", "template.yaml").
 	Label string
+
+	// PathFilterable indicates Label is a filesystem path eligible for ignore-pattern filtering.
+	// Set to true only when Label is an archive-relative or filesystem path (e.g. Lambda ZIP entries).
+	// Leave false for semantic labels like "UserData" or "ECS Task Definition".
+	PathFilterable bool
 }
 
 // ScanInputFromAWSResource creates a ScanInput by mapping common fields from an AWSResource.

--- a/pkg/secrets/scanner.go
+++ b/pkg/secrets/scanner.go
@@ -7,15 +7,17 @@ import (
 
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/titus/pkg/enum/ignore"
 	"github.com/praetorian-inc/titus/pkg/types"
 	"github.com/praetorian-inc/titus/pkg/validator"
 )
 
 // SecretScanner provides an object-oriented interface for scanning content for secrets.
 type SecretScanner struct {
-	ps       *persistentScanner
-	validate bool
-	engine   *validator.Engine
+	ps         *persistentScanner
+	validate   bool
+	engine     *validator.Engine
+	ignorePath func(string) bool
 }
 
 // SecretScanResult represents a secret detection result emitted by the scanner.
@@ -30,12 +32,20 @@ type SecretScanResult struct {
 
 // Start creates a new persistent scanner and stores it as a field.
 func (s *SecretScanner) Start(cfg ScannerConfig) error {
-	ps, err := newPersistentScanner(cfg.DBPath, cfg.DisabledTitusRules)
+	ps, err := newPersistentScanner(cfg.DBPath, cfg.Ruleset, cfg.DisabledTitusRules)
 	if err != nil {
 		return fmt.Errorf("failed to create Titus scanner: %w", err)
 	}
+
+	ig, err := ignore.CompilePatterns(cfg.IgnoreFile)
+	if err != nil {
+		ps.close()
+		return fmt.Errorf("failed to compile ignore patterns: %w", err)
+	}
+
 	s.ps = ps
 	s.validate = cfg.Validate
+	s.ignorePath = ig.MatchesPath
 
 	if cfg.Validate {
 		s.engine = validator.NewDefaultEngine(4)
@@ -68,6 +78,11 @@ func (s *SecretScanner) DBPath() string {
 // Scan is a pipeline-compatible method that scans a ScanInput for secrets
 // and sends SecretScanResult values to the output pipeline.
 func (s *SecretScanner) Scan(input output.ScanInput, out *pipeline.P[SecretScanResult]) error {
+	if input.PathFilterable && s.ignorePath != nil && s.ignorePath(input.Label) {
+		slog.Debug("skipping ignored path", "label", input.Label, "resource", input.ResourceID)
+		return nil
+	}
+
 	blobID := types.ComputeBlobID(input.Content)
 	provenance := types.FileProvenance{FilePath: input.Label}
 

--- a/pkg/secrets/scanner_integration_test.go
+++ b/pkg/secrets/scanner_integration_test.go
@@ -1,0 +1,217 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Integration tests verify that titus rule behavior (EXAMPLE exclusion) and
+// ignore pattern filtering (botocore examples) work end-to-end through the
+// Aurelian scanner pipeline.
+
+// ---------------------------------------------------------------------------
+// EXAMPLE key exclusion — titus pattern_requirements.ignore_if_contains
+// ---------------------------------------------------------------------------
+
+func TestIntegration_ExampleAWSKeysExcluded(t *testing.T) {
+	s := startScanner(t)
+
+	// The EXAMPLE exclusion (pattern_requirements.ignore_if_contains) applies
+	// to the AWS-specific rules (np.aws.*). We verify that EXAMPLE access key
+	// IDs produce no np.aws.* matches.
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "AKIA EXAMPLE key",
+			content: "aws_access_key_id=AKIAIOSFODNN7EXAMPLE",
+		},
+		{
+			name:    "ASIA EXAMPLE session key",
+			content: "aws_access_key_id=ASIADEADEXAMPLEEEEEE",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := pipeline.New[SecretScanResult]()
+			go func() {
+				defer out.Close()
+				require.NoError(t, s.Scan(output.ScanInput{
+					Content:      []byte(tc.content),
+					ResourceID:   "arn:aws:lambda:us-east-1:123456789012:function:demo",
+					ResourceType: "AWS::Lambda::Function",
+					Region:       "us-east-1",
+					AccountID:    "123456789012",
+					Label:        "config/credentials",
+				}, out))
+			}()
+			items, err := out.Collect()
+			require.NoError(t, err)
+
+			for _, item := range items {
+				assert.NotContains(t, item.Match.RuleID, "np.aws.",
+					"EXAMPLE key must not trigger AWS rules, but got %s", item.Match.RuleID)
+			}
+		})
+	}
+}
+
+func TestIntegration_RealAWSKeysDetected(t *testing.T) {
+	s := startScanner(t)
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "AKIA non-example key",
+			content: "aws_access_key_id=AKIADEADBEEFDEADBEEF",
+		},
+		{
+			name:    "secret key non-example",
+			content: "aws_secret_access_key=abcdefghijklmnopqrstuvwxyz0123456789ABCD",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := pipeline.New[SecretScanResult]()
+			go func() {
+				defer out.Close()
+				require.NoError(t, s.Scan(output.ScanInput{
+					Content:      []byte(tc.content),
+					ResourceID:   "arn:aws:lambda:us-east-1:123456789012:function:demo",
+					ResourceType: "AWS::Lambda::Function",
+					Region:       "us-east-1",
+					AccountID:    "123456789012",
+					Label:        "config/credentials",
+				}, out))
+			}()
+			items, err := out.Collect()
+			require.NoError(t, err)
+			assert.NotEmpty(t, items, "non-EXAMPLE keys must produce findings")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Botocore example file ignore — ignore.conf: **/botocore/data/**/examples-1.json
+// ---------------------------------------------------------------------------
+
+func TestIntegration_BotocoreExampleFilesIgnored(t *testing.T) {
+	s := startScanner(t)
+
+	// Real-world botocore paths that appear inside Lambda ZIPs with vendored
+	// Python dependencies. These contain example AWS keys that would otherwise
+	// trigger false positives.
+	ignoredPaths := []string{
+		"botocore/data/kms/2014-11-01/examples-1.json",
+		"botocore/data/s3/2006-03-01/examples-1.json",
+		"botocore/data/iam/2010-05-08/examples-1.json",
+		"lib/python3.11/site-packages/botocore/data/sts/2011-06-15/examples-1.json",
+		"vendor/botocore/data/ec2/2016-11-15/examples-1.json",
+	}
+
+	// Content that would normally match if not ignored.
+	content := []byte(`{"examples":{"AssumeRole":[{"input":{"RoleArn":"arn:aws:iam::123456789012:role/demo","RoleSessionName":"test"},"output":{"Credentials":{"AccessKeyId":"AKIADEADBEEFDEADBEEF","SecretAccessKey":"abcdefghijklmnopqrstuvwxyz0123456789ABCD"}}}]}`)
+
+	for _, path := range ignoredPaths {
+		t.Run(path, func(t *testing.T) {
+			out := pipeline.New[SecretScanResult]()
+			go func() {
+				defer out.Close()
+				require.NoError(t, s.Scan(output.ScanInput{
+					Content:        content,
+					ResourceID:     "arn:aws:lambda:us-east-1:123456789012:function:demo",
+					ResourceType:   "AWS::Lambda::Function",
+					Region:         "us-east-1",
+					AccountID:      "123456789012",
+					Label:          path,
+					PathFilterable: true,
+				}, out))
+			}()
+			items, err := out.Collect()
+			require.NoError(t, err)
+			assert.Empty(t, items, "botocore example file %s must be ignored", path)
+		})
+	}
+}
+
+func TestIntegration_BotocoreServiceFilesNotIgnored(t *testing.T) {
+	s := startScanner(t)
+
+	// Service files at non-vendored paths (no site-packages prefix) should NOT
+	// be ignored — only examples-1.json is excluded by the botocore pattern.
+	// Note: paths under **/site-packages/botocore/** ARE ignored by the
+	// vendored SDK pattern, so we only test non-vendored botocore paths here.
+	allowedPaths := []string{
+		"botocore/data/kms/2014-11-01/service-2.json",
+		"botocore/data/s3/2006-03-01/paginators-1.json",
+	}
+
+	content := []byte(`{"AccessKeyId":"AKIADEADBEEFDEADBEEF","SecretAccessKey":"abcdefghijklmnopqrstuvwxyz0123456789ABCD"}`)
+
+	for _, path := range allowedPaths {
+		t.Run(path, func(t *testing.T) {
+			out := pipeline.New[SecretScanResult]()
+			go func() {
+				defer out.Close()
+				require.NoError(t, s.Scan(output.ScanInput{
+					Content:        content,
+					ResourceID:     "arn:aws:lambda:us-east-1:123456789012:function:demo",
+					ResourceType:   "AWS::Lambda::Function",
+					Region:         "us-east-1",
+					AccountID:      "123456789012",
+					Label:          path,
+					PathFilterable: true,
+				}, out))
+			}()
+			items, err := out.Collect()
+			require.NoError(t, err)
+			assert.NotEmpty(t, items, "botocore service file %s must NOT be ignored", path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Vendored SDK ignore patterns
+// ---------------------------------------------------------------------------
+
+func TestIntegration_VendoredSDKPathsIgnored(t *testing.T) {
+	s := startScanner(t)
+
+	ignoredPaths := []string{
+		"site-packages/botocore/auth.py",
+		"site-packages/boto3/session.py",
+		"node_modules/@aws-sdk/client-s3/dist/index.js",
+	}
+
+	content := []byte(`aws_secret_access_key=abcdefghijklmnopqrstuvwxyz0123456789ABCD`)
+
+	for _, path := range ignoredPaths {
+		t.Run(path, func(t *testing.T) {
+			out := pipeline.New[SecretScanResult]()
+			go func() {
+				defer out.Close()
+				require.NoError(t, s.Scan(output.ScanInput{
+					Content:        content,
+					ResourceID:     "arn:aws:lambda:us-east-1:123456789012:function:demo",
+					ResourceType:   "AWS::Lambda::Function",
+					Region:         "us-east-1",
+					AccountID:      "123456789012",
+					Label:          path,
+					PathFilterable: true,
+				}, out))
+			}()
+			items, err := out.Collect()
+			require.NoError(t, err)
+			assert.Empty(t, items, "vendored SDK path %s must be ignored", path)
+		})
+	}
+}

--- a/pkg/secrets/scanner_params.go
+++ b/pkg/secrets/scanner_params.go
@@ -10,6 +10,8 @@ type ScannerConfig struct {
 	DBPath             string   `param:"db-path" desc:"Path for Titus SQLite database"`
 	DisabledTitusRules []string `param:"disabled-titus-rules" desc:"Rule IDs to exclude from scanning"`
 	Validate           bool     `param:"validate" desc:"Validate detected secrets against their source APIs" default:"false"`
+	IgnoreFile         string   `param:"ignore-file" desc:"Path to gitignore-style file for skipping paths; empty uses titus defaults" default:""`
+	Ruleset            string   `param:"ruleset" desc:"Titus ruleset to apply; empty string disables ruleset filtering" default:"default"`
 }
 
 // DefaultDBPath returns the default database path for the given output directory.

--- a/pkg/secrets/scanner_test.go
+++ b/pkg/secrets/scanner_test.go
@@ -168,7 +168,7 @@ func TestScanContent(t *testing.T) {
 
 	s := startScanner(t)
 
-	content := []byte("aws_access_key_id=AKIAIOSFODNN7EXAMPLE")
+	content := []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF")
 	blobID := types.ComputeBlobID(content)
 	provenance := types.FileProvenance{FilePath: "test/credentials.txt"}
 
@@ -255,7 +255,7 @@ func TestClose(t *testing.T) {
 func TestScanContent_FindingID_PopulatedOnCachedPath(t *testing.T) {
 	s := startScanner(t)
 
-	content := []byte("aws_access_key_id=AKIAIOSFODNN7EXAMPLE")
+	content := []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF")
 	blobID := types.ComputeBlobID(content)
 	provenance := types.FileProvenance{FilePath: "test/credentials.txt"}
 
@@ -337,7 +337,7 @@ func TestFindingsCreation(t *testing.T) {
 
 	s := startScanner(t)
 
-	content := []byte("aws_access_key_id=AKIAIOSFODNN7EXAMPLE")
+	content := []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF")
 	blobID := types.ComputeBlobID(content)
 	provenance := types.FileProvenance{FilePath: "test/credentials.txt"}
 
@@ -365,11 +365,11 @@ func TestFindingsDeduplication(t *testing.T) {
 	s := startScanner(t)
 
 	// Same secret in two different files (different blobs via different provenance)
-	content1 := []byte("aws_access_key_id=AKIAIOSFODNN7EXAMPLE")
+	content1 := []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF")
 	blobID1 := types.ComputeBlobID(content1)
 	provenance1 := types.FileProvenance{FilePath: "file1/credentials.txt"}
 
-	content2 := []byte("aws_access_key_id=AKIAIOSFODNN7EXAMPLE")
+	content2 := []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF")
 	blobID2 := types.ComputeBlobID(content2)
 	provenance2 := types.FileProvenance{FilePath: "file2/credentials.txt"}
 
@@ -387,4 +387,161 @@ func TestFindingsDeduplication(t *testing.T) {
 	findings, err := s.ps.store.GetFindings()
 	require.NoError(t, err, "GetFindings should succeed")
 	assert.Len(t, findings, 1, "should have exactly 1 deduplicated finding")
+}
+
+// ---------------------------------------------------------------------------
+// Ignore pattern tests
+// ---------------------------------------------------------------------------
+
+func TestSecretScanner_ScanSkipsIgnoredPathFilterableInputs(t *testing.T) {
+	s := startScanner(t)
+
+	input := output.ScanInput{
+		Content:        []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF"),
+		ResourceID:     "arn:aws:lambda:us-east-1:123456789012:function:demo",
+		ResourceType:   "AWS::Lambda::Function",
+		Region:         "us-east-1",
+		AccountID:      "123456789012",
+		Label:          "node_modules/@aws-sdk/client-s3/dist/credentials.js",
+		PathFilterable: true,
+	}
+
+	out := pipeline.New[SecretScanResult]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, s.Scan(input, out))
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	assert.Empty(t, items, "scan results should be empty for ignored path-filterable input")
+}
+
+func TestSecretScanner_ScanDoesNotFilterNonPathFilterableInputs(t *testing.T) {
+	s := startScanner(t)
+
+	input := output.ScanInput{
+		Content:        []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF"),
+		ResourceID:     "arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:1",
+		ResourceType:   "AWS::ECS::TaskDefinition",
+		Region:         "us-east-1",
+		AccountID:      "123456789012",
+		Label:          "package-lock.json",
+		PathFilterable: false,
+	}
+
+	out := pipeline.New[SecretScanResult]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, s.Scan(input, out))
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	assert.NotEmpty(t, items, "non-PathFilterable input must not be filtered even if label matches ignore pattern")
+}
+
+func TestSecretScanner_ScanAllowsNonIgnoredPathFilterableInputs(t *testing.T) {
+	s := startScanner(t)
+
+	input := output.ScanInput{
+		Content:        []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF"),
+		ResourceID:     "arn:aws:lambda:us-east-1:123456789012:function:demo",
+		ResourceType:   "AWS::Lambda::Function",
+		Region:         "us-east-1",
+		AccountID:      "123456789012",
+		Label:          "src/handler.py",
+		PathFilterable: true,
+	}
+
+	out := pipeline.New[SecretScanResult]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, s.Scan(input, out))
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	assert.NotEmpty(t, items, "scan results should not be empty for allowed path")
+}
+
+func TestSecretScanner_CustomIgnoreFileReplacesDefaults(t *testing.T) {
+	ignoreFile := filepath.Join(t.TempDir(), "custom.conf")
+	require.NoError(t, os.WriteFile(ignoreFile, []byte("src/**\n"), 0o644))
+
+	dbPath := filepath.Join(t.TempDir(), "titus.db")
+	var s SecretScanner
+	require.NoError(t, s.Start(ScannerConfig{DBPath: dbPath, IgnoreFile: ignoreFile}))
+	t.Cleanup(func() { s.Close() })
+
+	srcInput := output.ScanInput{
+		Content:        []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF"),
+		ResourceID:     "arn:aws:lambda:us-east-1:123456789012:function:demo",
+		ResourceType:   "AWS::Lambda::Function",
+		Region:         "us-east-1",
+		AccountID:      "123456789012",
+		Label:          "src/handler.py",
+		PathFilterable: true,
+	}
+
+	out := pipeline.New[SecretScanResult]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, s.Scan(srcInput, out))
+	}()
+	items, err := out.Collect()
+	require.NoError(t, err)
+	assert.Empty(t, items, "src/ should be ignored by custom pattern")
+
+	nodeInput := output.ScanInput{
+		Content:        []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF"),
+		ResourceID:     "arn:aws:lambda:us-east-1:123456789012:function:demo",
+		ResourceType:   "AWS::Lambda::Function",
+		Region:         "us-east-1",
+		AccountID:      "123456789012",
+		Label:          "node_modules/@aws-sdk/client-s3/dist/credentials.js",
+		PathFilterable: true,
+	}
+
+	out2 := pipeline.New[SecretScanResult]()
+	go func() {
+		defer out2.Close()
+		require.NoError(t, s.Scan(nodeInput, out2))
+	}()
+	items2, err := out2.Collect()
+	require.NoError(t, err)
+	assert.NotEmpty(t, items2, "node_modules should NOT be ignored when custom file replaces defaults")
+}
+
+func TestSecretScanner_ScanSkipsMultipleIgnoredPaths(t *testing.T) {
+	s := startScanner(t)
+
+	ignoredLabels := []string{
+		"node_modules/@aws-sdk/client-s3/index.js",
+		"package-lock.json",
+		"vendor/bundle.min.js",
+		"lib/python3.11/site-packages/botocore/auth.py",
+		"go.sum",
+	}
+
+	for _, label := range ignoredLabels {
+		t.Run(label, func(t *testing.T) {
+			out := pipeline.New[SecretScanResult]()
+			go func() {
+				defer out.Close()
+				require.NoError(t, s.Scan(output.ScanInput{
+					Content:        []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF"),
+					ResourceID:     "arn:aws:lambda:us-east-1:123456789012:function:demo",
+					ResourceType:   "AWS::Lambda::Function",
+					Region:         "us-east-1",
+					AccountID:      "123456789012",
+					Label:          label,
+					PathFilterable: true,
+				}, out))
+			}()
+			items, err := out.Collect()
+			require.NoError(t, err)
+			assert.Empty(t, items, "expected %s to be ignored", label)
+		})
+	}
 }

--- a/pkg/secrets/titus.go
+++ b/pkg/secrets/titus.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"fmt"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/praetorian-inc/aurelian/pkg/utils"
@@ -21,8 +22,9 @@ type persistentScanner struct {
 
 // newPersistentScanner creates a new persistent Titus scanner.
 // The caller is responsible for providing a valid dbPath.
-// Any rules whose IDs appear in disabledRules are excluded from scanning.
-func newPersistentScanner(dbPath string, disabledRules []string) (*persistentScanner, error) {
+// If rulesetID is non-empty, only rules in that ruleset are loaded.
+// Any rules whose IDs appear in disabledRules are then excluded.
+func newPersistentScanner(dbPath string, rulesetID string, disabledRules []string) (*persistentScanner, error) {
 	if err := utils.EnsureDirectoryExists(filepath.Dir(dbPath)); err != nil {
 		return nil, fmt.Errorf("failed to create database directory: %w", err)
 	}
@@ -37,6 +39,22 @@ func newPersistentScanner(dbPath string, disabledRules []string) (*persistentSca
 	if err != nil {
 		s.Close()
 		return nil, fmt.Errorf("failed to load builtin rules: %w", err)
+	}
+
+	// Apply ruleset filter if specified.
+	if rulesetID != "" {
+		rulesets, err := loader.LoadBuiltinRulesets()
+		if err != nil {
+			s.Close()
+			return nil, fmt.Errorf("failed to load builtin rulesets: %w", err)
+		}
+		rs := rule.FindRuleset(rulesets, rulesetID)
+		if rs == nil {
+			s.Close()
+			return nil, fmt.Errorf("ruleset %q not found", rulesetID)
+		}
+		allRules = rule.ApplyRuleset(allRules, rs)
+		slog.Info("applied ruleset", "ruleset", rulesetID, "rules", len(allRules))
 	}
 
 	disabled := make(map[string]bool, len(disabledRules))


### PR DESCRIPTION
## Summary
- Integrates titus v1.1.7 ignore patterns into the secret scanner to skip noisy paths (vendored SDKs, lockfiles, minified JS, botocore example files) during Lambda code scanning
- Adds `PathFilterable` field to `ScanInput` so only archive-extracted paths (Lambda ZIP entries) are filtered — semantic labels like `"UserData"` or `"ECS Task Definition"` are never matched against ignore patterns
- Applies titus default ruleset to scope scanning to the curated rule set instead of running all ~400+ rules
- Adds `IgnoreFile` and `Ruleset` params to `ScannerConfig` for operator override

## Test plan
- [x] Unit tests for PathFilterable filtering (ignored, not-ignored, non-filterable bypass)
- [x] Unit test for custom ignore file replacing defaults
- [x] Integration tests for botocore `examples-1.json` file ignoring
- [x] Integration tests for vendored SDK paths (`site-packages/botocore/**`, `node_modules/@aws-sdk/**`)
- [x] Integration tests for AWS EXAMPLE key exclusion (`np.aws.*` rules)
- [x] Integration tests for real AWS key detection
- [x] All existing scanner tests pass with updated test key