### PR TITLE
feat(secrets): enrich provenance with full cloud context

### DIFF
--- a/docs/superpowers/specs/2026-03-18-find-secrets-provenance-design.md
+++ b/docs/superpowers/specs/2026-03-18-find-secrets-provenance-design.md
@@ -1,0 +1,256 @@
+# Find-Secrets Provenance Enrichment
+
+## Problem
+
+The find-secrets module stores provenance in the Titus SQLite DB as `FileProvenance{FilePath: label}`. This is a git/filesystem-oriented type that only carries a single path string. For cloud resources, critical context is lost:
+
+- **CloudWatch Logs**: Label is `"log-event:{eventId}"` — an opaque ID with no log stream name. Users cannot determine which stream produced the finding without separate API calls.
+- **All services**: The Titus DB contains no ARN, region, account ID, platform, or resource type. The only provenance visible in `titus explore` is the label string.
+
+Rich cloud context exists in the Aurelian proof JSON output, but never reaches the Titus DB.
+
+## Solution
+
+Switch from `FileProvenance` to `ExtendedProvenance` across all three platforms (AWS, Azure, GCP). `ExtendedProvenance` stores a `map[string]any` payload in the Titus DB, carrying full cloud context. Consolidate the triplicated `buildProofData`/`riskFromScanResult` functions into the `secrets` package via methods on `SecretScanResult`.
+
+The `titus explore` TUI will be updated separately to render `ExtendedProvenance` payloads.
+
+## Design
+
+### 1. Add `Platform` field to `ScanInput`
+
+```go
+// pkg/output/scan_input.go
+type ScanInput struct {
+    Content        []byte
+    ResourceID     string
+    ResourceType   string
+    Region         string
+    AccountID      string
+    Label          string
+    PathFilterable bool
+    Platform       string // NEW: "aws", "azure", or "gcp"
+}
+```
+
+Set in each constructor:
+
+```go
+func ScanInputFromAWSResource(r AWSResource, label string, content []byte) ScanInput {
+    return ScanInput{
+        Content:      content,
+        ResourceID:   r.ARN,
+        ResourceType: r.ResourceType,
+        Region:       r.Region,
+        AccountID:    r.AccountRef,
+        Label:        label,
+        Platform:     "aws",
+    }
+}
+// Same pattern for ScanInputFromAzureResource ("azure") and ScanInputFromGCPResource ("gcp")
+```
+
+### 2. Add `Platform` field to `SecretScanResult`
+
+```go
+// pkg/secrets/scanner.go
+type SecretScanResult struct {
+    ResourceRef  string       `json:"resource_ref"`
+    ResourceType string       `json:"resource_type"`
+    Region       string       `json:"region"`
+    AccountID    string       `json:"account_id"`
+    Label        string       `json:"label"`
+    Platform     string       `json:"platform"` // NEW
+    Match        *types.Match `json:"match"`
+}
+```
+
+Populated in `toScanResult` from `input.Platform`.
+
+### 3. Switch to `ExtendedProvenance`
+
+In `SecretScanner.Scan` (`pkg/secrets/scanner.go`):
+
+```go
+// Before
+provenance := types.FileProvenance{FilePath: input.Label}
+
+// After
+provenance := types.ExtendedProvenance{
+    Payload: map[string]any{
+        "platform":      input.Platform,
+        "resource_id":   input.ResourceID,
+        "resource_type": input.ResourceType,
+        "region":        input.Region,
+        "account_id":    input.AccountID,
+        "subresource":   input.Label,
+    },
+}
+```
+
+The payload is stored as JSON in the SQLite `path` column by the existing `AddProvenance` code path (sqlite.go:185-188).
+
+### 4. Consolidate proof/risk logic into `secrets` package
+
+Move the triplicated `buildProofData` and `riskFromScanResult` into the `secrets` package as methods on `SecretScanResult`:
+
+```go
+// pkg/secrets/risk.go
+
+// proofData constructs proof JSON matching Guard's secrets proof format.
+func (r SecretScanResult) proofData() map[string]any {
+    proof := map[string]any{
+        "finding_id":   r.Match.FindingID,
+        "rule_name":    r.Match.RuleName,
+        "rule_text_id": r.Match.RuleID,
+        "resource_ref": r.ResourceRef,
+        "num_matches":  1,
+        "matches": []map[string]any{
+            {
+                "provenance": []map[string]any{
+                    {
+                        "kind":          "cloud_resource",
+                        "platform":      r.Platform,
+                        "resource_id":   r.ResourceRef,
+                        "resource_type": r.ResourceType,
+                        "region":        r.Region,
+                        "account_id":    r.AccountID,
+                        "first_commit": map[string]any{
+                            "blob_path": r.Label,
+                        },
+                    },
+                },
+                "snippet": map[string]string{
+                    "before":   string(r.Match.Snippet.Before),
+                    "matching": string(r.Match.Snippet.Matching),
+                    "after":    string(r.Match.Snippet.After),
+                },
+                "location": map[string]any{
+                    "offset_span": map[string]any{
+                        "start": r.Match.Location.Offset.Start,
+                        "end":   r.Match.Location.Offset.End,
+                    },
+                    "source_span": map[string]any{
+                        "start": map[string]any{
+                            "line":   r.Match.Location.Source.Start.Line,
+                            "column": r.Match.Location.Source.Start.Column,
+                        },
+                        "end": map[string]any{
+                            "line":   r.Match.Location.Source.End.Line,
+                            "column": r.Match.Location.Source.End.Column,
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    if r.Match.ValidationResult != nil {
+        proof["validation"] = map[string]any{
+            "status":     string(r.Match.ValidationResult.Status),
+            "confidence": r.Match.ValidationResult.Confidence,
+            "message":    r.Match.ValidationResult.Message,
+        }
+    }
+
+    return proof
+}
+
+// ToRisk converts a scan result into an AurelianRisk with marshalled proof.
+func (r SecretScanResult) ToRisk() (output.AurelianRisk, error) {
+    proofBytes, err := json.MarshalIndent(r.proofData(), "", "  ")
+    if err != nil {
+        return output.AurelianRisk{}, fmt.Errorf("marshalling proof: %w", err)
+    }
+    return newSecretRisk(r, proofBytes), nil
+}
+
+// RiskFromScanResult is a pipeline-compatible function that converts
+// SecretScanResult to AurelianRisk and sends it to the output pipeline.
+func RiskFromScanResult(result SecretScanResult, out *pipeline.P[model.AurelianModel]) error {
+    risk, err := result.ToRisk()
+    if err != nil {
+        slog.Warn("failed to build risk", "resource", result.ResourceRef, "error", err)
+        return nil
+    }
+    out.Send(risk)
+    return nil
+}
+```
+
+`NewSecretRisk` becomes unexported `newSecretRisk` since callers now use `ToRisk()` or `RiskFromScanResult`. The `platform` parameter is removed — it reads from `r.Platform`.
+
+### 5. Simplify per-module find_secrets.go
+
+Each module deletes its local `buildProofData` and `riskFromScanResult`, replacing the pipeline wiring:
+
+```go
+// Before (in each module)
+pipeline.Pipe(scanned, riskFromScanResult, out)
+
+// After (all modules)
+pipeline.Pipe(scanned, secrets.RiskFromScanResult, out)
+```
+
+### 6. Fix CloudWatch Logs label
+
+In `pkg/aws/extraction/extract_logs.go`, `extractLogStream`:
+
+```go
+// Before
+label := "log-event"
+if event.EventId != nil {
+    label = "log-event:" + *event.EventId
+}
+
+// After
+label := streamName
+```
+
+The stream name combined with the log group ARN (in `resource_id`) provides sufficient provenance to locate the source. EventIds are not directly queryable via AWS APIs and add no actionable value.
+
+### 7. Remove legacy Go pattern
+
+In `pkg/aws/extraction/extract_lambda.go:66`, remove the unnecessary `f := f` loop variable copy (Go 1.22+ has per-iteration scoping; project is on Go 1.25.3).
+
+## ExtendedProvenance Payload Schema
+
+Consistent across all platforms:
+
+| Field | Type | Description | Example (AWS) | Example (Azure) | Example (GCP) |
+|---|---|---|---|---|---|
+| `platform` | string | Cloud provider | `"aws"` | `"azure"` | `"gcp"` |
+| `resource_id` | string | Full resource identifier | `arn:aws:logs:...` | `/subscriptions/.../vm` | `projects/.../instances/...` |
+| `resource_type` | string | Cloud-native type | `AWS::Logs::LogGroup` | `Microsoft.Compute/virtualMachines` | `compute.googleapis.com/Instance` |
+| `region` | string | Geographic location | `us-east-1` | `eastus` | `us-central1-a` |
+| `account_id` | string | Account scope | `123456789012` | subscription UUID | project ID |
+| `subresource` | string | Location within resource | `my-stream-name` | `WebApp AppSettings` | `metadata/startup-script` |
+
+## Migration / Backward Compatibility
+
+- **Existing Titus DBs**: `BlobExists` check in `scanContent` means previously-scanned blobs retain their `file`-type provenance rows. New blobs get `extended`-type rows. This is a gradual migration — mixed types coexist safely.
+- **Existing annotations**: Annotations are keyed by finding ID and match structural ID, not by provenance type. Annotations on existing findings are unaffected.
+- **Proof JSON output**: The schema is identical — downstream consumers (Guard, reports) see no change. The `platform` field was already hardcoded per-module; now it comes from `SecretScanResult.Platform`.
+- **titus explore TUI**: `ExtendedProvenance` currently has no render case in the type switch (details.go:183-206) and is silently skipped. The `File:` line will be absent for new findings until the TUI is updated. This is the accepted trade-off — TUI changes are a separate effort.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `pkg/output/scan_input.go` | Add `Platform` field; set in all three `ScanInputFrom*` helpers |
+| `pkg/secrets/scanner.go` | Add `Platform` to `SecretScanResult` and `toScanResult`; switch to `ExtendedProvenance` |
+| `pkg/secrets/risk.go` | Add `proofData()` method, `ToRisk()` method, `RiskFromScanResult` function; unexport `newSecretRisk`; remove `platform` param |
+| `pkg/modules/aws/recon/find_secrets.go` | Delete `buildProofData`, `riskFromScanResult`; use `secrets.RiskFromScanResult` |
+| `pkg/modules/gcp/recon/find_secrets.go` | Delete `buildProofData`, `riskFromScanResult`; use `secrets.RiskFromScanResult` |
+| `pkg/modules/azure/recon/find_secrets.go` | Delete `buildProofData`, `riskFromScanResult` (method on module); use `secrets.RiskFromScanResult` |
+| `pkg/aws/extraction/extract_logs.go` | Change label from `"log-event:" + eventId` to `streamName` |
+| `pkg/aws/extraction/extract_lambda.go` | Remove `f := f` loop variable copy |
+| `pkg/modules/aws/recon/find_secrets_test.go` | Update tests to use `secrets.RiskFromScanResult` / `ToRisk()` |
+| `pkg/modules/azure/recon/find_secrets_test.go` | Update tests to use `secrets.RiskFromScanResult` / `ToRisk()` |
+| `pkg/modules/gcp/recon/find_secrets_test.go` | Update tests (if they test proof building) |
+
+## Out of Scope
+
+- `titus explore` TUI rendering of `ExtendedProvenance` (separate effort)
+- Step Functions execution ARN enrichment (current label `execution:{name}` is adequate)
+- Lambda version qualifier (returns `$LATEST` which is not actionable)

--- a/pkg/aws/extraction/extract_lambda.go
+++ b/pkg/aws/extraction/extract_lambda.go
@@ -63,7 +63,6 @@ func extractLambda(ctx extractContext, r output.AWSResource, out *pipeline.P[out
 			continue
 		}
 
-		f := f
 		g.Go(func() error {
 			rc, err := f.Open()
 			if err != nil {

--- a/pkg/aws/extraction/extract_logs.go
+++ b/pkg/aws/extraction/extract_logs.go
@@ -85,11 +85,7 @@ func extractLogStream(
 
 		for _, event := range eventsResp.Events {
 			if event.Message != nil && *event.Message != "" {
-				label := "log-event"
-				if event.EventId != nil {
-					label = "log-event:" + *event.EventId
-				}
-				out.Send(output.ScanInputFromAWSResource(r, label, []byte(*event.Message)))
+				out.Send(output.ScanInputFromAWSResource(r, streamName, []byte(*event.Message)))
 				eventCount++
 			}
 		}

--- a/pkg/modules/aws/recon/find_secrets.go
+++ b/pkg/modules/aws/recon/find_secrets.go
@@ -1,7 +1,6 @@
 package recon
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/pkg/secrets"
-	"github.com/praetorian-inc/titus/pkg/types"
 )
 
 func init() {
@@ -113,7 +111,7 @@ func (m *AWSFindSecretsModule) Run(cfg plugin.Config, out *pipeline.P[model.Aure
 	pipeline.Pipe(extracted, s.Scan, scanned, &pipeline.PipeOpts{
 		Progress: cfg.Log.ProgressFunc("scanning for secrets"),
 	})
-	pipeline.Pipe(scanned, riskFromScanResult, out)
+	pipeline.Pipe(scanned, secrets.RiskFromScanResult, out)
 
 	if err := out.Wait(); err != nil {
 		return err
@@ -122,74 +120,3 @@ func (m *AWSFindSecretsModule) Run(cfg plugin.Config, out *pipeline.P[model.Aure
 	return nil
 }
 
-func riskFromScanResult(result secrets.SecretScanResult, out *pipeline.P[model.AurelianModel]) error {
-	proof := buildProofData(result, result.Match)
-	proofBytes, err := json.MarshalIndent(proof, "", "  ")
-	if err != nil {
-		slog.Warn("failed to marshal proof", "resource", result.ResourceRef, "error", err)
-		return nil
-	}
-
-	out.Send(secrets.NewSecretRisk(result, "aws", proofBytes))
-	return nil
-}
-
-// buildProofData constructs proof JSON matching Guard's secrets proof format.
-// Includes provenance with cloud resource context so the UI can render findings.
-func buildProofData(result secrets.SecretScanResult, match *types.Match) map[string]interface{} {
-	proof := map[string]interface{}{
-		"finding_id":   match.FindingID,
-		"rule_name":    match.RuleName,
-		"rule_text_id": match.RuleID,
-		"resource_ref": result.ResourceRef,
-		"num_matches":  1,
-		"matches": []map[string]interface{}{
-			{
-				"provenance": []map[string]interface{}{
-					{
-						"kind":          "cloud_resource",
-						"platform":      "aws",
-						"resource_id":   result.ResourceRef,
-						"resource_type": result.ResourceType,
-						"region":        result.Region,
-						"account_id":    result.AccountID,
-						"first_commit": map[string]interface{}{
-							"blob_path": result.Label,
-						},
-					},
-				},
-				"snippet": map[string]string{
-					"before":   string(match.Snippet.Before),
-					"matching": string(match.Snippet.Matching),
-					"after":    string(match.Snippet.After),
-				},
-				"location": map[string]interface{}{
-					"offset_span": map[string]interface{}{
-						"start": match.Location.Offset.Start,
-						"end":   match.Location.Offset.End,
-					},
-					"source_span": map[string]interface{}{
-						"start": map[string]interface{}{
-							"line":   match.Location.Source.Start.Line,
-							"column": match.Location.Source.Start.Column,
-						},
-						"end": map[string]interface{}{
-							"line":   match.Location.Source.End.Line,
-							"column": match.Location.Source.End.Column,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	if match.ValidationResult != nil {
-		proof["validation"] = map[string]interface{}{
-			"status":     string(match.ValidationResult.Status),
-			"confidence": match.ValidationResult.Confidence,
-			"message":    match.ValidationResult.Message,
-		}
-	}
-
-	return proof
-}

--- a/pkg/modules/aws/recon/find_secrets_test.go
+++ b/pkg/modules/aws/recon/find_secrets_test.go
@@ -126,7 +126,7 @@ func TestRiskSeverityFromMatch(t *testing.T) {
 	})
 }
 
-func TestBuildProofData(t *testing.T) {
+func TestToRisk_ProofData(t *testing.T) {
 	match := &types.Match{
 		RuleID:    "np.aws.1",
 		RuleName:  "AWS API Key",
@@ -150,39 +150,55 @@ func TestBuildProofData(t *testing.T) {
 		ResourceType: "AWS::Lambda::Function",
 		Region:       "us-east-1",
 		AccountID:    "123",
+		Platform:     "aws",
 		Label:        "handler.py",
+		Match:        match,
 	}
-	proof := buildProofData(result, match)
+
+	risk, err := result.ToRisk()
+	require.NoError(t, err)
+
+	var proof map[string]any
+	require.NoError(t, json.Unmarshal(risk.Context, &proof))
 
 	assert.Equal(t, "abc123def456", proof["finding_id"])
 	assert.Equal(t, "AWS API Key", proof["rule_name"])
 	assert.Equal(t, "np.aws.1", proof["rule_text_id"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123:function:demo", proof["resource_ref"])
-	assert.Equal(t, 1, proof["num_matches"])
+	assert.Equal(t, float64(1), proof["num_matches"])
 
-	matches := proof["matches"].([]map[string]interface{})
+	matches := proof["matches"].([]any)
 	require.Len(t, matches, 1)
 
-	snippet := matches[0]["snippet"].(map[string]string)
+	m0 := matches[0].(map[string]any)
+	snippet := m0["snippet"].(map[string]any)
 	assert.Equal(t, "key=", snippet["before"])
 	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", snippet["matching"])
 	assert.Equal(t, "\n", snippet["after"])
 
-	location := matches[0]["location"].(map[string]interface{})
-	offsetSpan := location["offset_span"].(map[string]interface{})
-	assert.Equal(t, int64(4), offsetSpan["start"])
-	assert.Equal(t, int64(24), offsetSpan["end"])
+	location := m0["location"].(map[string]any)
+	offsetSpan := location["offset_span"].(map[string]any)
+	assert.Equal(t, float64(4), offsetSpan["start"])
+	assert.Equal(t, float64(24), offsetSpan["end"])
 
-	sourceSpan := location["source_span"].(map[string]interface{})
-	start := sourceSpan["start"].(map[string]interface{})
-	assert.Equal(t, 1, start["line"])
-	assert.Equal(t, 5, start["column"])
+	sourceSpan := location["source_span"].(map[string]any)
+	start := sourceSpan["start"].(map[string]any)
+	assert.Equal(t, float64(1), start["line"])
+	assert.Equal(t, float64(5), start["column"])
+
+	provenance := m0["provenance"].([]any)
+	require.Len(t, provenance, 1)
+	prov := provenance[0].(map[string]any)
+	assert.Equal(t, "cloud", prov["kind"])
+	assert.Equal(t, "aws", prov["platform"])
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123:function:demo", prov["resource_id"])
+	assert.Equal(t, "AWS::Lambda::Function", prov["resource_type"])
 
 	_, hasValidation := proof["validation"]
 	assert.False(t, hasValidation, "no validation when ValidationResult is nil")
 }
 
-func TestBuildProofData_WithValidation(t *testing.T) {
+func TestToRisk_WithValidation(t *testing.T) {
 	match := &types.Match{
 		RuleID:    "np.aws.1",
 		RuleName:  "AWS API Key",
@@ -197,17 +213,24 @@ func TestBuildProofData_WithValidation(t *testing.T) {
 	result := secrets.SecretScanResult{
 		ResourceRef:  "arn:aws:s3:::bucket",
 		ResourceType: "AWS::S3::Bucket",
+		Platform:     "aws",
 		Label:        "config.yaml",
+		Match:        match,
 	}
-	proof := buildProofData(result, match)
 
-	validation := proof["validation"].(map[string]interface{})
+	risk, err := result.ToRisk()
+	require.NoError(t, err)
+
+	var proof map[string]any
+	require.NoError(t, json.Unmarshal(risk.Context, &proof))
+
+	validation := proof["validation"].(map[string]any)
 	assert.Equal(t, string(types.StatusValid), validation["status"])
 	assert.Equal(t, 0.95, validation["confidence"])
 	assert.Equal(t, "Key is active", validation["message"])
 }
 
-func TestBuildRiskContextRoundTrip(t *testing.T) {
+func TestToRisk_RoundTrip(t *testing.T) {
 	match := &types.Match{
 		RuleID:    "np.aws.1",
 		RuleName:  "AWS API Key",
@@ -231,15 +254,16 @@ func TestBuildRiskContextRoundTrip(t *testing.T) {
 		ResourceType: "AWS::Lambda::Function",
 		Region:       "us-east-1",
 		AccountID:    "123456789012",
+		Platform:     "aws",
 		Label:        "index.js",
+		Match:        match,
 	}
-	proof := buildProofData(result, match)
-	proofBytes, err := json.MarshalIndent(proof, "", "  ")
+
+	risk, err := result.ToRisk()
 	require.NoError(t, err)
 
-	var decoded map[string]interface{}
-	err = json.Unmarshal(proofBytes, &decoded)
-	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(risk.Context, &decoded))
 
 	assert.Equal(t, "abc123def456", decoded["finding_id"])
 	assert.Equal(t, "AWS API Key", decoded["rule_name"])
@@ -249,13 +273,14 @@ func TestBuildRiskContextRoundTrip(t *testing.T) {
 
 func TestRiskFromScanResult_ImpactedResourceID_IncludesFindingID(t *testing.T) {
 	match := &types.Match{
-		RuleID:   "np.aws.1",
-		RuleName: "AWS API Key",
+		RuleID:    "np.aws.1",
+		RuleName:  "AWS API Key",
 		FindingID: "abc123def456",
 	}
 
 	result := secrets.SecretScanResult{
 		ResourceRef: "arn:aws:lambda:us-east-1:123:function:demo",
+		Platform:    "aws",
 		Label:       "main.py",
 		Match:       match,
 	}
@@ -263,7 +288,7 @@ func TestRiskFromScanResult_ImpactedResourceID_IncludesFindingID(t *testing.T) {
 	out := pipeline.New[model.AurelianModel]()
 	go func() {
 		defer out.Close()
-		require.NoError(t, riskFromScanResult(result, out))
+		require.NoError(t, secrets.RiskFromScanResult(result, out))
 	}()
 
 	items, err := out.Collect()
@@ -285,6 +310,7 @@ func TestRiskFromScanResult_ImpactedResourceID_NoFindingID(t *testing.T) {
 
 	result := secrets.SecretScanResult{
 		ResourceRef: "i-08da3f571f1346176",
+		Platform:    "aws",
 		Label:       "user-data",
 		Match:       match,
 	}
@@ -292,7 +318,7 @@ func TestRiskFromScanResult_ImpactedResourceID_NoFindingID(t *testing.T) {
 	out := pipeline.New[model.AurelianModel]()
 	go func() {
 		defer out.Close()
-		require.NoError(t, riskFromScanResult(result, out))
+		require.NoError(t, secrets.RiskFromScanResult(result, out))
 	}()
 
 	items, err := out.Collect()

--- a/pkg/modules/azure/recon/find_secrets.go
+++ b/pkg/modules/azure/recon/find_secrets.go
@@ -1,7 +1,6 @@
 package recon
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/pkg/secrets"
-	"github.com/praetorian-inc/titus/pkg/types"
 )
 
 func init() {
@@ -129,7 +127,7 @@ func (m *AzureFindSecretsModule) Run(_ plugin.Config, out *pipeline.P[model.Aure
 	// Scan extracted content and convert results to risks.
 	scanned := pipeline.New[secrets.SecretScanResult]()
 	pipeline.Pipe(extracted, s.Scan, scanned)
-	pipeline.Pipe(scanned, m.riskFromScanResult, out)
+	pipeline.Pipe(scanned, secrets.RiskFromScanResult, out)
 
 	return out.Wait()
 }
@@ -181,72 +179,3 @@ func (m *AzureFindSecretsModule) toListerInput(sub azuretypes.SubscriptionInfo, 
 	return nil
 }
 
-func (m *AzureFindSecretsModule) riskFromScanResult(result secrets.SecretScanResult, out *pipeline.P[model.AurelianModel]) error {
-	proof := m.buildProofData(result, result.Match)
-	proofBytes, err := json.MarshalIndent(proof, "", "  ")
-	if err != nil {
-		slog.Warn("failed to marshal proof", "resource", result.ResourceRef, "error", err)
-		return nil
-	}
-
-	out.Send(secrets.NewSecretRisk(result, "azure", proofBytes))
-	return nil
-}
-
-func (m *AzureFindSecretsModule) buildProofData(result secrets.SecretScanResult, match *types.Match) map[string]interface{} {
-	proof := map[string]interface{}{
-		"finding_id":   match.FindingID,
-		"rule_name":    match.RuleName,
-		"rule_text_id": match.RuleID,
-		"resource_ref": result.ResourceRef,
-		"num_matches":  1,
-		"matches": []map[string]interface{}{
-			{
-				"provenance": []map[string]interface{}{
-					{
-						"kind":          "cloud_resource",
-						"platform":      "azure",
-						"resource_id":   result.ResourceRef,
-						"resource_type": result.ResourceType,
-						"region":        result.Region,
-						"account_id":    result.AccountID,
-						"first_commit": map[string]interface{}{
-							"blob_path": result.Label,
-						},
-					},
-				},
-				"snippet": map[string]string{
-					"before":   string(match.Snippet.Before),
-					"matching": string(match.Snippet.Matching),
-					"after":    string(match.Snippet.After),
-				},
-				"location": map[string]interface{}{
-					"offset_span": map[string]interface{}{
-						"start": match.Location.Offset.Start,
-						"end":   match.Location.Offset.End,
-					},
-					"source_span": map[string]interface{}{
-						"start": map[string]interface{}{
-							"line":   match.Location.Source.Start.Line,
-							"column": match.Location.Source.Start.Column,
-						},
-						"end": map[string]interface{}{
-							"line":   match.Location.Source.End.Line,
-							"column": match.Location.Source.End.Column,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	if match.ValidationResult != nil {
-		proof["validation"] = map[string]interface{}{
-			"status":     string(match.ValidationResult.Status),
-			"confidence": match.ValidationResult.Confidence,
-			"message":    match.ValidationResult.Message,
-		}
-	}
-
-	return proof
-}

--- a/pkg/modules/azure/recon/find_secrets_test.go
+++ b/pkg/modules/azure/recon/find_secrets_test.go
@@ -114,7 +114,7 @@ func TestRiskSeverityFromMatch(t *testing.T) {
 	})
 }
 
-func TestBuildProofData(t *testing.T) {
+func TestToRisk_ProofData(t *testing.T) {
 	match := &types.Match{
 		RuleID:    "np.aws.1",
 		RuleName:  "AWS API Key",
@@ -138,41 +138,48 @@ func TestBuildProofData(t *testing.T) {
 		ResourceType: "Microsoft.Web/sites",
 		Region:       "eastus",
 		AccountID:    "00000000-0000-0000-0000-000000000000",
+		Platform:     "azure",
 		Label:        "appsettings.json",
+		Match:        match,
 	}
 
-	m := &AzureFindSecretsModule{}
-	proof := m.buildProofData(result, match)
+	risk, err := result.ToRisk()
+	require.NoError(t, err)
+
+	var proof map[string]any
+	require.NoError(t, json.Unmarshal(risk.Context, &proof))
 
 	assert.Equal(t, "abc123def456", proof["finding_id"])
 	assert.Equal(t, "AWS API Key", proof["rule_name"])
 	assert.Equal(t, "np.aws.1", proof["rule_text_id"])
 	assert.Equal(t, result.ResourceRef, proof["resource_ref"])
-	assert.Equal(t, 1, proof["num_matches"])
+	assert.Equal(t, float64(1), proof["num_matches"])
 
-	matches := proof["matches"].([]map[string]interface{})
+	matches := proof["matches"].([]any)
 	require.Len(t, matches, 1)
 
-	snippet := matches[0]["snippet"].(map[string]string)
+	m0 := matches[0].(map[string]any)
+	snippet := m0["snippet"].(map[string]any)
 	assert.Equal(t, "key=", snippet["before"])
 	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", snippet["matching"])
 	assert.Equal(t, "\n", snippet["after"])
 
-	location := matches[0]["location"].(map[string]interface{})
-	offsetSpan := location["offset_span"].(map[string]interface{})
-	assert.Equal(t, int64(4), offsetSpan["start"])
-	assert.Equal(t, int64(24), offsetSpan["end"])
+	location := m0["location"].(map[string]any)
+	offsetSpan := location["offset_span"].(map[string]any)
+	assert.Equal(t, float64(4), offsetSpan["start"])
+	assert.Equal(t, float64(24), offsetSpan["end"])
 
-	sourceSpan := location["source_span"].(map[string]interface{})
-	start := sourceSpan["start"].(map[string]interface{})
-	assert.Equal(t, 1, start["line"])
-	assert.Equal(t, 5, start["column"])
+	provenance := m0["provenance"].([]any)
+	require.Len(t, provenance, 1)
+	prov := provenance[0].(map[string]any)
+	assert.Equal(t, "cloud", prov["kind"])
+	assert.Equal(t, "azure", prov["platform"])
 
 	_, hasValidation := proof["validation"]
 	assert.False(t, hasValidation, "no validation when ValidationResult is nil")
 }
 
-func TestBuildProofData_WithValidation(t *testing.T) {
+func TestToRisk_WithValidation(t *testing.T) {
 	match := &types.Match{
 		RuleID:    "np.aws.1",
 		RuleName:  "AWS API Key",
@@ -187,19 +194,24 @@ func TestBuildProofData_WithValidation(t *testing.T) {
 	result := secrets.SecretScanResult{
 		ResourceRef:  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/myaccount",
 		ResourceType: "Microsoft.Storage/storageAccounts",
+		Platform:     "azure",
 		Label:        "connection-string",
+		Match:        match,
 	}
 
-	m := &AzureFindSecretsModule{}
-	proof := m.buildProofData(result, match)
+	risk, err := result.ToRisk()
+	require.NoError(t, err)
 
-	validation := proof["validation"].(map[string]interface{})
+	var proof map[string]any
+	require.NoError(t, json.Unmarshal(risk.Context, &proof))
+
+	validation := proof["validation"].(map[string]any)
 	assert.Equal(t, string(types.StatusValid), validation["status"])
 	assert.Equal(t, 0.95, validation["confidence"])
 	assert.Equal(t, "Key is active", validation["message"])
 }
 
-func TestBuildRiskContextRoundTrip(t *testing.T) {
+func TestToRisk_RoundTrip(t *testing.T) {
 	match := &types.Match{
 		RuleID:    "np.aws.1",
 		RuleName:  "AWS API Key",
@@ -223,17 +235,16 @@ func TestBuildRiskContextRoundTrip(t *testing.T) {
 		ResourceType: "Microsoft.Compute/virtualMachines",
 		Region:       "eastus",
 		AccountID:    "00000000-0000-0000-0000-000000000000",
+		Platform:     "azure",
 		Label:        "userdata.sh",
+		Match:        match,
 	}
 
-	m := &AzureFindSecretsModule{}
-	proof := m.buildProofData(result, match)
-	proofBytes, err := json.MarshalIndent(proof, "", "  ")
+	risk, err := result.ToRisk()
 	require.NoError(t, err)
 
-	var decoded map[string]interface{}
-	err = json.Unmarshal(proofBytes, &decoded)
-	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(risk.Context, &decoded))
 
 	assert.Equal(t, "abc123def456", decoded["finding_id"])
 	assert.Equal(t, "AWS API Key", decoded["rule_name"])
@@ -250,15 +261,15 @@ func TestRiskFromScanResult_ImpactedResourceID_IncludesFindingID(t *testing.T) {
 
 	result := secrets.SecretScanResult{
 		ResourceRef: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/myapp",
+		Platform:    "azure",
 		Label:       "appsettings.json",
 		Match:       match,
 	}
 
-	m := &AzureFindSecretsModule{}
 	out := pipeline.New[model.AurelianModel]()
 	go func() {
 		defer out.Close()
-		require.NoError(t, m.riskFromScanResult(result, out))
+		require.NoError(t, secrets.RiskFromScanResult(result, out))
 	}()
 
 	items, err := out.Collect()
@@ -280,15 +291,15 @@ func TestRiskFromScanResult_ImpactedResourceID_NoFindingID(t *testing.T) {
 
 	result := secrets.SecretScanResult{
 		ResourceRef: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/myvm",
+		Platform:    "azure",
 		Label:       "userdata.sh",
 		Match:       match,
 	}
 
-	m := &AzureFindSecretsModule{}
 	out := pipeline.New[model.AurelianModel]()
 	go func() {
 		defer out.Close()
-		require.NoError(t, m.riskFromScanResult(result, out))
+		require.NoError(t, secrets.RiskFromScanResult(result, out))
 	}()
 
 	items, err := out.Collect()

--- a/pkg/modules/gcp/recon/find_secrets.go
+++ b/pkg/modules/gcp/recon/find_secrets.go
@@ -1,7 +1,6 @@
 package recon
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/pkg/secrets"
-	"github.com/praetorian-inc/titus/pkg/types"
 )
 
 func init() {
@@ -112,7 +110,7 @@ func (m *GCPFindSecretsModule) Run(_ plugin.Config, out *pipeline.P[model.Aureli
 	// Scan for secrets.
 	scanned := pipeline.New[secrets.SecretScanResult]()
 	pipeline.Pipe(extracted, s.Scan, scanned)
-	pipeline.Pipe(scanned, riskFromScanResult, out)
+	pipeline.Pipe(scanned, secrets.RiskFromScanResult, out)
 
 	return out.Wait()
 }
@@ -124,72 +122,3 @@ func splitHierarchyResources(res output.GCPResource, p *pipeline.P[string]) erro
 	return nil
 }
 
-func riskFromScanResult(result secrets.SecretScanResult, out *pipeline.P[model.AurelianModel]) error {
-	proof := buildProofData(result, result.Match)
-	proofBytes, err := json.MarshalIndent(proof, "", "  ")
-	if err != nil {
-		slog.Warn("failed to marshal proof", "resource", result.ResourceRef, "error", err)
-		return nil
-	}
-
-	out.Send(secrets.NewSecretRisk(result, "gcp", proofBytes))
-	return nil
-}
-
-func buildProofData(result secrets.SecretScanResult, match *types.Match) map[string]any {
-	proof := map[string]any{
-		"finding_id":   match.FindingID,
-		"rule_name":    match.RuleName,
-		"rule_text_id": match.RuleID,
-		"resource_ref": result.ResourceRef,
-		"num_matches":  1,
-		"matches": []map[string]any{
-			{
-				"provenance": []map[string]any{
-					{
-						"kind":          "cloud_resource",
-						"platform":      "gcp",
-						"resource_id":   result.ResourceRef,
-						"resource_type": result.ResourceType,
-						"region":        result.Region,
-						"account_id":    result.AccountID,
-						"first_commit": map[string]any{
-							"blob_path": result.Label,
-						},
-					},
-				},
-				"snippet": map[string]string{
-					"before":   string(match.Snippet.Before),
-					"matching": string(match.Snippet.Matching),
-					"after":    string(match.Snippet.After),
-				},
-				"location": map[string]any{
-					"offset_span": map[string]any{
-						"start": match.Location.Offset.Start,
-						"end":   match.Location.Offset.End,
-					},
-					"source_span": map[string]any{
-						"start": map[string]any{
-							"line":   match.Location.Source.Start.Line,
-							"column": match.Location.Source.Start.Column,
-						},
-						"end": map[string]any{
-							"line":   match.Location.Source.End.Line,
-							"column": match.Location.Source.End.Column,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	if match.ValidationResult != nil {
-		proof["validation"] = map[string]any{
-			"status":     string(match.ValidationResult.Status),
-			"confidence": match.ValidationResult.Confidence,
-			"message":    match.ValidationResult.Message,
-		}
-	}
-
-	return proof
-}

--- a/pkg/output/scan_input.go
+++ b/pkg/output/scan_input.go
@@ -1,23 +1,26 @@
 package output
 
-// ScanInput represents extracted content from an AWS resource ready for secret scanning.
+// ScanInput represents extracted content from a cloud resource ready for secret scanning.
 type ScanInput struct {
 	// Content is the raw bytes to scan for secrets.
 	Content []byte
 
-	// ResourceID is the AWS ARN of the source resource.
+	// ResourceID is the unique identifier for the source resource (ARN, Azure resource ID, or GCP resource name).
 	ResourceID string
 
-	// ResourceType is the AWS Cloud Control type (e.g. "AWS::Lambda::Function").
+	// ResourceType is the cloud-native resource type (e.g. "AWS::Lambda::Function").
 	ResourceType string
 
-	// Region is the AWS region where the resource lives.
+	// Region is the region or location where the resource lives.
 	Region string
 
-	// AccountID is the AWS account ID that owns the resource.
+	// AccountID is the account scope (AWS account ID, Azure subscription ID, or GCP project ID).
 	AccountID string
 
-	// Label describes what this content is (e.g. "UserData", "handler.py", "template.yaml").
+	// Platform is the cloud provider: "aws", "azure", or "gcp".
+	Platform string
+
+	// Label describes the sub-location within the resource (e.g. "handler.py", "WebApp AppSettings", stream name).
 	Label string
 
 	// PathFilterable indicates Label is a filesystem path eligible for ignore-pattern filtering.
@@ -34,6 +37,7 @@ func ScanInputFromAWSResource(r AWSResource, label string, content []byte) ScanI
 		ResourceType: r.ResourceType,
 		Region:       r.Region,
 		AccountID:    r.AccountRef,
+		Platform:     "aws",
 		Label:        label,
 	}
 }
@@ -46,6 +50,7 @@ func ScanInputFromAzureResource(r AzureResource, label string, content []byte) S
 		ResourceType: r.ResourceType,
 		Region:       r.Location,
 		AccountID:    r.SubscriptionID,
+		Platform:     "azure",
 		Label:        label,
 	}
 }
@@ -58,6 +63,7 @@ func ScanInputFromGCPResource(r GCPResource, label string, content []byte) ScanI
 		ResourceType: r.ResourceType,
 		Region:       r.Location,
 		AccountID:    r.ProjectID,
+		Platform:     "gcp",
 		Label:        label,
 	}
 }

--- a/pkg/secrets/risk.go
+++ b/pkg/secrets/risk.go
@@ -1,16 +1,97 @@
 package secrets
 
 import (
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
+	"github.com/praetorian-inc/aurelian/pkg/model"
 	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/titus/pkg/types"
 )
 
-// NewSecretRisk constructs an AurelianRisk from a scan result and pre-marshalled proof bytes.
-// The platform prefix (e.g. "aws", "gcp", "azure") is used to form the risk name.
-func NewSecretRisk(result SecretScanResult, platform string, proofBytes []byte) output.AurelianRisk {
+// proofData constructs proof JSON matching Guard's secrets proof format.
+func (r SecretScanResult) proofData() map[string]any {
+	proof := map[string]any{
+		"finding_id":   r.Match.FindingID,
+		"rule_name":    r.Match.RuleName,
+		"rule_text_id": r.Match.RuleID,
+		"resource_ref": r.ResourceRef,
+		"num_matches":  1,
+		"matches": []map[string]any{
+			{
+				"provenance": []map[string]any{
+					{
+						"kind":          "cloud",
+						"platform":      r.Platform,
+						"resource_id":   r.ResourceRef,
+						"resource_type": r.ResourceType,
+						"region":        r.Region,
+						"account_id":    r.AccountID,
+						"subresource":   r.Label,
+					},
+				},
+				"snippet": map[string]string{
+					"before":   string(r.Match.Snippet.Before),
+					"matching": string(r.Match.Snippet.Matching),
+					"after":    string(r.Match.Snippet.After),
+				},
+				"location": map[string]any{
+					"offset_span": map[string]any{
+						"start": r.Match.Location.Offset.Start,
+						"end":   r.Match.Location.Offset.End,
+					},
+					"source_span": map[string]any{
+						"start": map[string]any{
+							"line":   r.Match.Location.Source.Start.Line,
+							"column": r.Match.Location.Source.Start.Column,
+						},
+						"end": map[string]any{
+							"line":   r.Match.Location.Source.End.Line,
+							"column": r.Match.Location.Source.End.Column,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if r.Match.ValidationResult != nil {
+		proof["validation"] = map[string]any{
+			"status":     string(r.Match.ValidationResult.Status),
+			"confidence": r.Match.ValidationResult.Confidence,
+			"message":    r.Match.ValidationResult.Message,
+		}
+	}
+
+	return proof
+}
+
+// ToRisk converts a scan result into an AurelianRisk with marshalled proof.
+func (r SecretScanResult) ToRisk() (output.AurelianRisk, error) {
+	proofBytes, err := json.MarshalIndent(r.proofData(), "", "  ")
+	if err != nil {
+		return output.AurelianRisk{}, fmt.Errorf("marshalling proof: %w", err)
+	}
+	return newSecretRisk(r, proofBytes), nil
+}
+
+// RiskFromScanResult is a pipeline-compatible function that converts
+// SecretScanResult to AurelianRisk and sends it to the output pipeline.
+func RiskFromScanResult(result SecretScanResult, out *pipeline.P[model.AurelianModel]) error {
+	risk, err := result.ToRisk()
+	if err != nil {
+		slog.Warn("failed to build risk", "resource", result.ResourceRef, "error", err)
+		return nil
+	}
+	out.Send(risk)
+	return nil
+}
+
+// newSecretRisk constructs an AurelianRisk from a scan result and pre-marshalled proof bytes.
+func newSecretRisk(result SecretScanResult, proofBytes []byte) output.AurelianRisk {
 	impactedID := result.ResourceRef
 	if result.Match.FindingID != "" {
 		findingPrefix := result.Match.FindingID
@@ -21,7 +102,7 @@ func NewSecretRisk(result SecretScanResult, platform string, proofBytes []byte) 
 	}
 
 	return output.AurelianRisk{
-		Name:               fmt.Sprintf("%s-secret-%s", platform, ExtractRuleShortName(result.Match.RuleID)),
+		Name:               fmt.Sprintf("%s-secret-%s", result.Platform, ExtractRuleShortName(result.Match.RuleID)),
 		Severity:           RiskSeverityFromMatch(result.Match),
 		ImpactedResourceID: impactedID,
 		DeduplicationID:    result.Match.FindingID,

--- a/pkg/secrets/scanner.go
+++ b/pkg/secrets/scanner.go
@@ -26,6 +26,7 @@ type SecretScanResult struct {
 	ResourceType string       `json:"resource_type"`
 	Region       string       `json:"region"`
 	AccountID    string       `json:"account_id"`
+	Platform     string       `json:"platform"`
 	Label        string       `json:"label"`
 	Match        *types.Match `json:"match"`
 }
@@ -84,7 +85,16 @@ func (s *SecretScanner) Scan(input output.ScanInput, out *pipeline.P[SecretScanR
 	}
 
 	blobID := types.ComputeBlobID(input.Content)
-	provenance := types.FileProvenance{FilePath: input.Label}
+	provenance := types.ExtendedProvenance{
+		Payload: map[string]any{
+			"platform":      input.Platform,
+			"resource_id":   input.ResourceID,
+			"resource_type": input.ResourceType,
+			"region":        input.Region,
+			"account_id":    input.AccountID,
+			"subresource":   input.Label,
+		},
+	}
 
 	matches, err := s.ps.scanContent(input.Content, blobID, provenance)
 	if err != nil {
@@ -117,6 +127,7 @@ func toScanResult(input output.ScanInput, match *types.Match) SecretScanResult {
 		ResourceType: input.ResourceType,
 		Region:       input.Region,
 		AccountID:    input.AccountID,
+		Platform:     input.Platform,
 		Label:        input.Label,
 		Match:        match,
 	}


### PR DESCRIPTION
## Summary

- Switch from `FileProvenance` to `ExtendedProvenance` in the Titus DB, carrying full cloud context (platform, resource_id, resource_type, region, account_id, subresource) for every scanned blob
- Consolidate triplicated `buildProofData`/`riskFromScanResult` from AWS, GCP, and Azure modules into `SecretScanResult` methods and a shared `secrets.RiskFromScanResult` pipeline function
- Replace `first_commit.blob_path` with a top-level `subresource` field in proof JSON provenance to avoid triggering Guard's git-oriented Recent Activity tab for cloud findings
- Fix CloudWatch Logs label from opaque event ID to stream name for actionable provenance
- Remove legacy `f := f` loop variable copy in Lambda extractor (Go 1.22+)

## Companion PR

Requires a small Guard UI change to render the new `subresource` field in the Cloud Resource tab and detection sections of POE.tsx (~10 lines).