### PR TITLE
feat: granular public resource risk IDs with resource type slug

### DIFF
--- a/pkg/gcp/publicaccess/evaluator.go
+++ b/pkg/gcp/publicaccess/evaluator.go
@@ -28,17 +28,22 @@ func (e *AccessEvaluator) Evaluate(r output.GCPResource, out *pipeline.P[model.A
 	}
 
 	var severity output.RiskSeverity
-	var name string
+	var prefix string
 	switch {
 	case hasPublicNetwork && hasAnonymousAccess:
 		severity = output.RiskSeverityHigh
-		name = "public-anonymous-gcp-resource"
+		prefix = "public-anonymous-gcp-resource"
 	case hasAnonymousAccess:
 		severity = output.RiskSeverityMedium
-		name = "anonymous-gcp-resource"
+		prefix = "anonymous-gcp-resource"
 	default:
 		severity = output.RiskSeverityMedium
-		name = "public-gcp-resource"
+		prefix = "public-gcp-resource"
+	}
+
+	name := prefix
+	if slug := output.ResourceTypeSlug(r.ResourceType); slug != "" {
+		name = prefix + "-" + slug
 	}
 
 	ctx, _ := json.Marshal(map[string]any{
@@ -52,10 +57,11 @@ func (e *AccessEvaluator) Evaluate(r output.GCPResource, out *pipeline.P[model.A
 	})
 
 	out.Send(output.AurelianRisk{
-		Name:        name,
-		Severity:    severity,
+		Name:               name,
+		Severity:           severity,
 		ImpactedResourceID: r.ResourceID,
-		Context:     ctx,
+		DeduplicationID:    r.ResourceType,
+		Context:            ctx,
 	})
 
 	return nil

--- a/pkg/gcp/publicaccess/evaluator_test.go
+++ b/pkg/gcp/publicaccess/evaluator_test.go
@@ -70,4 +70,81 @@ func TestEvaluate_BothPublicAndAnonymous_HighSeverity(t *testing.T) {
 	risk, ok := items[1].(output.AurelianRisk)
 	require.True(t, ok)
 	assert.Equal(t, output.RiskSeverityHigh, risk.Severity)
+	assert.Equal(t, "public-anonymous-gcp-resource-run-service", risk.Name)
+	assert.Equal(t, "run.googleapis.com/Service", risk.DeduplicationID)
+}
+
+func TestEvaluate_GranularRiskName(t *testing.T) {
+	tests := []struct {
+		name         string
+		resource     output.GCPResource
+		wantRiskName string
+		wantDedupeID string
+		wantSeverity output.RiskSeverity
+	}{
+		{
+			name: "public+anonymous compute instance",
+			resource: output.GCPResource{
+				ResourceType: "compute.googleapis.com/Instance",
+				ResourceID:   "projects/p/zones/z/instances/i",
+				ProjectID:    "p",
+				IPs:          []string{"1.2.3.4"},
+				Properties:   map[string]any{"AnonymousAccess": true},
+			},
+			wantRiskName: "public-anonymous-gcp-resource-compute-instance",
+			wantDedupeID: "compute.googleapis.com/Instance",
+			wantSeverity: output.RiskSeverityHigh,
+		},
+		{
+			name: "anonymous-only storage bucket",
+			resource: output.GCPResource{
+				ResourceType: "storage.googleapis.com/Bucket",
+				ResourceID:   "projects/_/buckets/b",
+				ProjectID:    "p",
+				Properties:   map[string]any{"AnonymousAccess": true},
+			},
+			wantRiskName: "anonymous-gcp-resource-storage-bucket",
+			wantDedupeID: "storage.googleapis.com/Bucket",
+			wantSeverity: output.RiskSeverityMedium,
+		},
+		{
+			name: "public-only cloud run service",
+			resource: output.GCPResource{
+				ResourceType: "run.googleapis.com/Service",
+				ResourceID:   "projects/p/locations/l/services/s",
+				ProjectID:    "p",
+				URLs:         []string{"https://s.run.app"},
+			},
+			wantRiskName: "public-gcp-resource-run-service",
+			wantDedupeID: "run.googleapis.com/Service",
+			wantSeverity: output.RiskSeverityMedium,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &AccessEvaluator{}
+			out := pipeline.New[model.AurelianModel]()
+
+			go func() {
+				defer out.Close()
+				e.Evaluate(tt.resource, out)
+			}()
+
+			items, err := out.Collect()
+			require.NoError(t, err)
+
+			// First item is the resource itself, second is the risk.
+			var risk output.AurelianRisk
+			for _, item := range items {
+				if r, ok := item.(output.AurelianRisk); ok {
+					risk = r
+				}
+			}
+
+			assert.Equal(t, tt.wantRiskName, risk.Name)
+			assert.Equal(t, tt.wantDedupeID, risk.DeduplicationID)
+			assert.Equal(t, tt.wantSeverity, risk.Severity)
+		})
+	}
 }

--- a/pkg/modules/aws/recon/public_resources.go
+++ b/pkg/modules/aws/recon/public_resources.go
@@ -121,6 +121,13 @@ func riskFromResult(r publicaccess.PublicAccessResult, out *pipeline.P[model.Aur
 		impactedARN = resourceID
 	}
 
+	resourceType := r.AWSResource.ResourceType
+	slug := output.ResourceTypeSlug(resourceType)
+	name := "public-aws-resource"
+	if slug != "" {
+		name = "public-aws-resource-" + slug
+	}
+
 	r.AWSResource = nil
 	ctx, err := json.Marshal(r)
 	if err != nil {
@@ -129,10 +136,11 @@ func riskFromResult(r publicaccess.PublicAccessResult, out *pipeline.P[model.Aur
 	}
 
 	out.Send(output.AurelianRisk{
-		Name:        "public-aws-resource",
-		Severity:    severity,
+		Name:               name,
+		Severity:           severity,
 		ImpactedResourceID: impactedARN,
-		Context:     ctx,
+		DeduplicationID:    resourceType,
+		Context:            ctx,
 	})
 	return nil
 }

--- a/pkg/modules/aws/recon/public_resources_integration_test.go
+++ b/pkg/modules/aws/recon/public_resources_integration_test.go
@@ -59,7 +59,9 @@ func TestAWSPublicResources(t *testing.T) {
 	require.NotEmpty(t, risks, "should emit at least one risk")
 
 	for _, risk := range risks {
-		assert.Equal(t, "public-aws-resource", risk.Name)
+		assert.True(t, strings.HasPrefix(risk.Name, "public-aws-resource-"),
+			"risk name %q should have prefix public-aws-resource-", risk.Name)
+		assert.NotEmpty(t, risk.DeduplicationID, "risk should have DeduplicationID set to resource type")
 		assert.Contains(t, []output.RiskSeverity{output.RiskSeverityHigh, output.RiskSeverityMedium}, risk.Severity)
 		assert.NotContains(t, string(risk.Context), "aws_resource")
 		assert.NotEmpty(t, risk.ImpactedResourceID)

--- a/pkg/modules/aws/recon/public_resources_test.go
+++ b/pkg/modules/aws/recon/public_resources_test.go
@@ -1,0 +1,76 @@
+package recon
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/aws/publicaccess"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRiskFromResult_NameAndDeduplicationID(t *testing.T) {
+	tests := []struct {
+		name             string
+		resourceType     string
+		accessLevel      output.AccessLevel
+		wantRiskName     string
+		wantDedupeID     string
+		wantSeverity     output.RiskSeverity
+	}{
+		{
+			name:         "lambda function - public",
+			resourceType: "AWS::Lambda::Function",
+			accessLevel:  output.AccessLevelPublic,
+			wantRiskName: "public-aws-resource-lambda-function",
+			wantDedupeID: "AWS::Lambda::Function",
+			wantSeverity: output.RiskSeverityHigh,
+		},
+		{
+			name:         "s3 bucket - public",
+			resourceType: "AWS::S3::Bucket",
+			accessLevel:  output.AccessLevelPublic,
+			wantRiskName: "public-aws-resource-s3-bucket",
+			wantDedupeID: "AWS::S3::Bucket",
+			wantSeverity: output.RiskSeverityHigh,
+		},
+		{
+			name:         "ec2 instance - needs triage",
+			resourceType: "AWS::EC2::Instance",
+			accessLevel:  output.AccessLevelNeedsTriage,
+			wantRiskName: "public-aws-resource-ec2-instance",
+			wantDedupeID: "AWS::EC2::Instance",
+			wantSeverity: output.RiskSeverityMedium,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := publicaccess.PublicAccessResult{
+				AWSResource: &output.AWSResource{
+					ResourceType: tt.resourceType,
+					ResourceID:   "arn:aws:test:us-east-1:123456789012:test/test-resource",
+					ARN:          "arn:aws:test:us-east-1:123456789012:test/test-resource",
+					AccessLevel:  tt.accessLevel,
+				},
+			}
+
+			out := pipeline.New[model.AurelianModel]()
+			go func() {
+				defer out.Close()
+				riskFromResult(result, out)
+			}()
+
+			items, err := out.Collect()
+			require.NoError(t, err)
+			require.Len(t, items, 1)
+
+			risk := items[0].(output.AurelianRisk)
+			assert.Equal(t, tt.wantRiskName, risk.Name)
+			assert.Equal(t, tt.wantDedupeID, risk.DeduplicationID)
+			assert.Equal(t, tt.wantSeverity, risk.Severity)
+		})
+	}
+}

--- a/pkg/modules/azure/recon/public_resources.go
+++ b/pkg/modules/azure/recon/public_resources.go
@@ -128,11 +128,18 @@ func resultToRisk(result templates.ARGQueryResult, out *pipeline.P[model.Aurelia
 		return nil
 	}
 
+	slug := output.ResourceTypeSlug(result.ResourceType)
+	name := "public-azure-resource"
+	if slug != "" {
+		name = "public-azure-resource-" + slug
+	}
+
 	out.Send(output.AurelianRisk{
-		Name:        "public-azure-resource",
-		Severity:    result.TemplateDetails.Severity,
+		Name:               name,
+		Severity:           result.TemplateDetails.Severity,
 		ImpactedResourceID: result.ResourceID,
-		Context:     ctx,
+		DeduplicationID:    result.ResourceType,
+		Context:            ctx,
 	})
 	return nil
 }

--- a/pkg/modules/azure/recon/public_resources_integration_test.go
+++ b/pkg/modules/azure/recon/public_resources_integration_test.go
@@ -95,7 +95,10 @@ func TestAzurePublicResources(t *testing.T) {
 	// that must appear in the ImpactedResourceID to confirm the right resource was caught.
 	assertRisk := func(t *testing.T, rc riskWithContext, expectedTemplate string, expectedSeverity output.RiskSeverity, resourceNameSubstr string) {
 		t.Helper()
-		assert.Equal(t, "public-azure-resource", rc.Risk.Name)
+		assert.True(t, strings.HasPrefix(rc.Risk.Name, "public-azure-resource-"),
+			"template %s: risk name %q should have prefix public-azure-resource-", expectedTemplate, rc.Risk.Name)
+		assert.NotEmpty(t, rc.Risk.DeduplicationID,
+			"template %s: risk should have DeduplicationID", expectedTemplate)
 		assert.Equal(t, expectedSeverity, rc.Risk.Severity,
 			"template %s: expected severity %s, got %s", expectedTemplate, expectedSeverity, rc.Risk.Severity)
 		assert.Equal(t, expectedTemplate, rc.Template)
@@ -206,10 +209,12 @@ func TestAzurePublicResources(t *testing.T) {
 	// Cross-finding invariants
 	// =====================================================================
 
-	t.Run("all risks have name public-azure-resource", func(t *testing.T) {
+	t.Run("all risks have granular name with resource type slug", func(t *testing.T) {
 		for _, rc := range all {
-			assert.Equal(t, "public-azure-resource", rc.Risk.Name,
-				"template %q: risk name should be public-azure-resource", rc.Template)
+			assert.True(t, strings.HasPrefix(rc.Risk.Name, "public-azure-resource-"),
+				"template %q: risk name %q should have prefix public-azure-resource-", rc.Template, rc.Risk.Name)
+			assert.NotEmpty(t, rc.Risk.DeduplicationID,
+				"template %q: risk should have DeduplicationID set to resource type", rc.Template)
 		}
 	})
 

--- a/pkg/modules/azure/recon/public_resources_test.go
+++ b/pkg/modules/azure/recon/public_resources_test.go
@@ -224,7 +224,8 @@ func TestResultToRisk(t *testing.T) {
 	risk, ok := items[0].(output.AurelianRisk)
 	require.True(t, ok)
 
-	assert.Equal(t, "public-azure-resource", risk.Name)
+	assert.Equal(t, "public-azure-resource-storage-storageaccounts", risk.Name)
+	assert.Equal(t, "Microsoft.Storage/storageAccounts", risk.DeduplicationID)
 	assert.Equal(t, output.RiskSeverityHigh, risk.Severity)
 	assert.Equal(t, "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage", risk.ImpactedResourceID)
 	assert.NotEmpty(t, risk.Context)
@@ -251,6 +252,7 @@ func TestResultToRisk_SeverityPreserved(t *testing.T) {
 				TemplateID:      tmpl.ID,
 				TemplateDetails: tmpl,
 				ResourceID:      "/subscriptions/s/resourceGroups/r/providers/T/n",
+				ResourceType:    "Microsoft.Test/resources",
 			}
 
 			out := pipeline.New[model.AurelianModel]()
@@ -265,7 +267,7 @@ func TestResultToRisk_SeverityPreserved(t *testing.T) {
 
 			risk := items[0].(output.AurelianRisk)
 			assert.Equal(t, output.RiskSeverity(sev), risk.Severity)
-			assert.Equal(t, "public-azure-resource", risk.Name)
+			assert.Equal(t, "public-azure-resource-test-resources", risk.Name)
 		})
 	}
 }

--- a/pkg/modules/gcp/recon/public_resources_integration_test.go
+++ b/pkg/modules/gcp/recon/public_resources_integration_test.go
@@ -5,6 +5,7 @@ package recon_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/praetorian-inc/aurelian/pkg/model"
@@ -124,7 +125,7 @@ func TestGCPPublicResources(t *testing.T) {
 			"expected risk for public cloud run service %q", publicRunName)
 
 		// Private Cloud Run still gets a public URL from GCP, so it's flagged as
-		// "public-gcp-resource" (MEDIUM). Both should have risks, but severity differs.
+		// "public-gcp-resource-run-service" (MEDIUM). Both should have risks, but severity differs.
 		publicRisk := findRiskForNamedResource(resources, risks, publicRunName)
 		privateRisk := findRiskForNamedResource(resources, risks, privateRunName)
 		if publicRisk != nil && privateRisk != nil {
@@ -151,15 +152,24 @@ func TestGCPPublicResources(t *testing.T) {
 			"private compute instance %q should NOT have a risk", privateInstance)
 	})
 
-	t.Run("risk names follow gcp naming convention", func(t *testing.T) {
-		validNames := map[string]bool{
-			"public-anonymous-gcp-resource": true,
-			"anonymous-gcp-resource":        true,
-			"public-gcp-resource":           true,
+	t.Run("risk names follow granular gcp naming convention", func(t *testing.T) {
+		validPrefixes := []string{
+			"public-anonymous-gcp-resource-",
+			"anonymous-gcp-resource-",
+			"public-gcp-resource-",
 		}
 		for _, risk := range risks {
-			assert.Truef(t, validNames[risk.Name],
-				"unexpected risk name %q", risk.Name)
+			hasValidPrefix := false
+			for _, prefix := range validPrefixes {
+				if strings.HasPrefix(risk.Name, prefix) {
+					hasValidPrefix = true
+					break
+				}
+			}
+			assert.Truef(t, hasValidPrefix,
+				"risk name %q should start with one of the valid prefixes", risk.Name)
+			assert.NotEmpty(t, risk.DeduplicationID,
+				"risk %q should have DeduplicationID set to resource type", risk.Name)
 		}
 	})
 }

--- a/pkg/output/risk_slug.go
+++ b/pkg/output/risk_slug.go
@@ -1,0 +1,34 @@
+package output
+
+import "strings"
+
+// ResourceTypeSlug converts a cloud resource type string into a short, lowercase,
+// hyphen-delimited slug suitable for embedding in risk IDs.
+//
+// Supported formats:
+//   - AWS:    "AWS::Lambda::Function"                        → "lambda-function"
+//   - Azure:  "Microsoft.Compute/virtualMachines"            → "compute-virtualmachines"
+//   - Azure:  "microsoft.compute/virtualmachines" (from ARG) → "compute-virtualmachines"
+//   - GCP:    "compute.googleapis.com/Instance"              → "compute-instance"
+func ResourceTypeSlug(resourceType string) string {
+	if resourceType == "" {
+		return ""
+	}
+	// Normalize to lowercase first — Azure Resource Graph returns lowercase
+	// types (e.g., "microsoft.storage/storageaccounts"), while unit tests and
+	// ARM IDs may use mixed case ("Microsoft.Storage/storageAccounts").
+	lower := strings.ToLower(resourceType)
+	switch {
+	case strings.HasPrefix(lower, "aws::"):
+		// AWS::Lambda::Function → lambda-function
+		return strings.ReplaceAll(lower[len("aws::"):], "::", "-")
+	case strings.HasPrefix(lower, "microsoft."):
+		// microsoft.compute/virtualmachines → compute-virtualmachines
+		return strings.ReplaceAll(lower[len("microsoft."):], "/", "-")
+	case strings.Contains(lower, ".googleapis.com/"):
+		// compute.googleapis.com/instance → compute-instance
+		return strings.ReplaceAll(strings.Replace(lower, ".googleapis.com", "", 1), "/", "-")
+	default:
+		return lower
+	}
+}

--- a/pkg/output/risk_slug_test.go
+++ b/pkg/output/risk_slug_test.go
@@ -1,0 +1,64 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceTypeSlug(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		want         string
+	}{
+		// AWS (CloudControl always uses PascalCase)
+		{"aws lambda", "AWS::Lambda::Function", "lambda-function"},
+		{"aws s3", "AWS::S3::Bucket", "s3-bucket"},
+		{"aws ec2 instance", "AWS::EC2::Instance", "ec2-instance"},
+		{"aws rds", "AWS::RDS::DBInstance", "rds-dbinstance"},
+		{"aws redshift", "AWS::Redshift::Cluster", "redshift-cluster"},
+		{"aws efs", "AWS::EFS::FileSystem", "efs-filesystem"},
+		{"aws cognito", "AWS::Cognito::UserPool", "cognito-userpool"},
+		{"aws sns", "AWS::SNS::Topic", "sns-topic"},
+		{"aws sqs", "AWS::SQS::Queue", "sqs-queue"},
+		{"aws ec2 image", "AWS::EC2::Image", "ec2-image"},
+
+		// Azure — mixed case (unit test style)
+		{"azure vm mixed case", "Microsoft.Compute/virtualMachines", "compute-virtualmachines"},
+		{"azure storage mixed case", "Microsoft.Storage/storageAccounts", "storage-storageaccounts"},
+		{"azure keyvault mixed case", "Microsoft.KeyVault/vaults", "keyvault-vaults"},
+		{"azure cosmos mixed case", "Microsoft.DocumentDB/databaseAccounts", "documentdb-databaseaccounts"},
+		{"azure aks mixed case", "Microsoft.ContainerService/managedClusters", "containerservice-managedclusters"},
+		{"azure sql mixed case", "Microsoft.Sql/servers", "sql-servers"},
+		{"azure acr mixed case", "Microsoft.ContainerRegistry/registries", "containerregistry-registries"},
+
+		// Azure — lowercase (actual ARG output)
+		{"azure vm lowercase", "microsoft.compute/virtualmachines", "compute-virtualmachines"},
+		{"azure storage lowercase", "microsoft.storage/storageaccounts", "storage-storageaccounts"},
+		{"azure keyvault lowercase", "microsoft.keyvault/vaults", "keyvault-vaults"},
+		{"azure eventgrid lowercase", "microsoft.eventgrid/domains", "eventgrid-domains"},
+
+		// GCP
+		{"gcp compute instance", "compute.googleapis.com/Instance", "compute-instance"},
+		{"gcp bucket", "storage.googleapis.com/Bucket", "storage-bucket"},
+		{"gcp sql", "sqladmin.googleapis.com/Instance", "sqladmin-instance"},
+		{"gcp function", "cloudfunctions.googleapis.com/Function", "cloudfunctions-function"},
+		{"gcp cloud run", "run.googleapis.com/Service", "run-service"},
+		{"gcp appengine", "appengine.googleapis.com/Service", "appengine-service"},
+		{"gcp firebase", "firebasehosting.googleapis.com/Site", "firebasehosting-site"},
+		{"gcp forwarding rule", "compute.googleapis.com/ForwardingRule", "compute-forwardingrule"},
+		{"gcp global forwarding rule", "compute.googleapis.com/GlobalForwardingRule", "compute-globalforwardingrule"},
+		{"gcp address", "compute.googleapis.com/Address", "compute-address"},
+
+		// Edge cases
+		{"empty string", "", ""},
+		{"unrecognized format passthrough", "some-custom-type", "some-custom-type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ResourceTypeSlug(tt.resourceType))
+		})
+	}
+}

--- a/pkg/templates/azure/public-resources/virtual_machines_public.yaml
+++ b/pkg/templates/azure/public-resources/virtual_machines_public.yaml
@@ -155,6 +155,7 @@ query: |
   | project
       id = vmId,
       name = vmName,
+      type = 'microsoft.compute/virtualmachines',
       location = vmLocation,
       publicIPs = tostring(publicIPs),
       privateIPs = tostring(privateIPs),


### PR DESCRIPTION
## Summary

- Changes public-resources risk names from generic `public-<provider>-resource` to granular `public-<provider>-resource-<resource-type-slug>` across AWS, Azure, and GCP
- Sets `DeduplicationID` to the raw cloud resource type string on all public-resource risks
- Adds `ResourceTypeSlug()` function that mechanically derives slugs from cloud type strings (e.g., `AWS::Lambda::Function` → `lambda-function`, `microsoft.storage/storageaccounts` → `storage-storageaccounts`, `compute.googleapis.com/Instance` → `compute-instance`)
- Fixes Azure VM template (`virtual_machines_public.yaml`) to project the `type` column lost during KQL joins/summarizes

## Test plan

- [x] `ResourceTypeSlug` unit tests cover all 10 AWS types, 11 Azure types (mixed + lowercase), 10 GCP types, and edge cases
- [x] AWS `riskFromResult` unit tests verify granular name + DeduplicationID for Public and NeedsTriage access levels
- [x] Azure `resultToRisk` unit tests verify granular name + DeduplicationID with severity preservation
- [x] GCP `Evaluate` unit tests verify all three risk name variants (public, anonymous, public-anonymous) with slug
- [x] All existing non-integration tests pass (`go build ./...` clean, all affected package tests green)
- [ ] Integration tests (require cloud infra) — assertions updated to use prefix matching