### PR TITLE
Split release workflow into parallel matrix builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,56 @@ on:
     tags: ['v*']
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    steps:
+      - name: Free disk space
+        run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/share/boost
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: '~> v2'
+          args: release --split
+        env:
+          CGO_ENABLED: '0'
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/
+          retention-days: 1
+
   release:
     runs-on: ubuntu-latest
+    needs: build
     environment: release
     permissions:
       contents: write
@@ -21,11 +69,17 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run GoReleaser
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          pattern: dist-*
+          merge-multiple: true
+
+      - name: Merge and release
         uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
-          args: release --clean
+          args: continue --merge
         env:
-          CGO_ENABLED: '0'
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Split GoReleaser into 5 parallel matrix build jobs using `--split`/`--merge` to avoid running out of disk space on a single runner
- Free pre-installed Android SDK, .NET, Haskell, and Boost toolchains (~10-15GB) before each build
- Scope `contents: write` permission to only the release job

Fixes the `no space left on device` failure in [v1.0.0 release](https://github.com/praetorian-inc/aurelian/actions/runs/23344972379/job/67907802274).

## Test plan
- [ ] Delete the failed v1.0.0 tag and release, re-tag after merge, and verify the workflow completes
- [ ] Confirm all 5 platform binaries are present in the GitHub release
- [ ] Verify checksums file is correct