### PR TITLE
Add AWS Amplify app URLs to public-resources scanner

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v golangci-lint &>/dev/null; then
+    echo "golangci-lint not found, skipping lint check"
+    echo "Install: https://golangci-lint.run/welcome/install/"
+    exit 0
+fi
+
+# Find Go packages with staged changes.
+pkgs=$(git diff --cached --name-only --diff-filter=ACM -- '*.go' \
+    | xargs -I{} dirname {} \
+    | sort -u \
+    | sed 's|^|./|')
+
+if [ -z "$pkgs" ]; then
+    exit 0
+fi
+
+echo "Running golangci-lint on changed packages..."
+# shellcheck disable=SC2086
+golangci-lint run $pkgs

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 h1:JqcdRG//czea7Ppjb+g/n4o8i/R
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17/go.mod h1:CO+WeGmIdj/MlPel2KwID9Gt7CNq4M65HUfBW97liM0=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0 h1:bxsS3BE+wpRBd4B0//h/ZOo8Ay55jyb9zprax9rCSYs=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0/go.mod h1:BwMkMxZPTVtRT9zRKpB92ljsRFX0EXk2WoLQmCnNuRs=
+github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13 h1:dO3jyPlS/HY5cZVsR+mybSJjNuLAPO2EGu4K1DIlUVs=
+github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13/go.mod h1:8Yy4YO5rEbsoaRqkWkoHSEAkLE2EYw7C3vgFCFa9QQg=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11 h1:vsDNkqiXTCeTaSt1qNtri0RzTBDAXV1VQ4L5c5lvW2k=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11/go.mod h1:aH+Z4h+QZfJ2iEP+EITPDP8nZI1eFUJu38V6c9Nq9uQ=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.6 h1:3Rzut9v4ULIX3kjA6w3/Zaq2g8wBx6qJXB4BhQhIgjs=

--- a/pkg/aws/enumeration/amplify_enumerator.go
+++ b/pkg/aws/enumeration/amplify_enumerator.go
@@ -61,7 +61,7 @@ func (e *AmplifyAppEnumerator) EnumerateByARN(arn string, out *pipeline.P[output
 	}
 
 	if parsed.Region == "" {
-		return fmt.Errorf("Amplify app ARN missing region: %q", arn)
+		return fmt.Errorf("amplify app ARN missing region: %q", arn)
 	}
 
 	cfg, err := e.provider.GetAWSConfig(parsed.Region)

--- a/pkg/aws/enumeration/amplify_enumerator.go
+++ b/pkg/aws/enumeration/amplify_enumerator.go
@@ -1,0 +1,137 @@
+package enumeration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/amplify"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
+)
+
+// AmplifyAppEnumerator enumerates Amplify apps using the native Amplify SDK
+// because CloudControl does not support AWS::Amplify::App.
+type AmplifyAppEnumerator struct {
+	plugin.AWSCommonRecon
+	provider *AWSConfigProvider
+}
+
+func NewAmplifyAppEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider) *AmplifyAppEnumerator {
+	return &AmplifyAppEnumerator{
+		AWSCommonRecon: opts,
+		provider:       provider,
+	}
+}
+
+func (e *AmplifyAppEnumerator) ResourceType() string {
+	return "AWS::Amplify::App"
+}
+
+func (e *AmplifyAppEnumerator) EnumerateAll(out *pipeline.P[output.AWSResource]) error {
+	if len(e.Regions) == 0 {
+		return fmt.Errorf("no regions configured")
+	}
+
+	accountID, err := e.provider.GetAccountID(e.Regions[0])
+	if err != nil {
+		return fmt.Errorf("get account ID: %w", err)
+	}
+
+	actor := ratelimit.NewCrossRegionActor(e.Concurrency)
+	return actor.ActInRegions(e.Regions, func(region string) error {
+		return e.listAppsInRegion(region, accountID, out)
+	})
+}
+
+func (e *AmplifyAppEnumerator) EnumerateByARN(arn string, out *pipeline.P[output.AWSResource]) error {
+	parsed, err := awsarn.Parse(arn)
+	if err != nil {
+		return fmt.Errorf("parse ARN %q: %w", arn, err)
+	}
+
+	appID, ok := strings.CutPrefix(parsed.Resource, "apps/")
+	if !ok {
+		return fmt.Errorf("invalid Amplify app ARN resource: %q", parsed.Resource)
+	}
+
+	if parsed.Region == "" {
+		return fmt.Errorf("Amplify app ARN missing region: %q", arn)
+	}
+
+	cfg, err := e.provider.GetAWSConfig(parsed.Region)
+	if err != nil {
+		return fmt.Errorf("create Amplify client for %s: %w", parsed.Region, err)
+	}
+	client := amplify.NewFromConfig(*cfg)
+
+	result, err := client.GetApp(context.Background(), &amplify.GetAppInput{
+		AppId: aws.String(appID),
+	})
+	if err != nil {
+		return fmt.Errorf("get amplify app %s: %w", appID, err)
+	}
+
+	app := result.App
+	out.Send(output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   aws.ToString(app.AppId),
+		ARN:          aws.ToString(app.AppArn),
+		AccountRef:   parsed.AccountID,
+		Region:       parsed.Region,
+		DisplayName:  aws.ToString(app.Name),
+		Properties: map[string]any{
+			"AppId":         aws.ToString(app.AppId),
+			"Name":          aws.ToString(app.Name),
+			"DefaultDomain": aws.ToString(app.DefaultDomain),
+			"Platform":      string(app.Platform),
+			"Repository":    aws.ToString(app.Repository),
+		},
+	})
+	return nil
+}
+
+func (e *AmplifyAppEnumerator) listAppsInRegion(region, accountID string, out *pipeline.P[output.AWSResource]) error {
+	cfg, err := e.provider.GetAWSConfig(region)
+	if err != nil {
+		return fmt.Errorf("create Amplify client for %s: %w", region, err)
+	}
+	client := amplify.NewFromConfig(*cfg)
+
+	var nextToken *string
+	paginator := ratelimit.NewAWSPaginator()
+	return paginator.Paginate(func() (bool, error) {
+		result, err := client.ListApps(context.Background(), &amplify.ListAppsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return false, fmt.Errorf("list amplify apps in %s: %w", region, err)
+		}
+
+		for _, app := range result.Apps {
+			appID := aws.ToString(app.AppId)
+			out.Send(output.AWSResource{
+				ResourceType: "AWS::Amplify::App",
+				ResourceID:   appID,
+				ARN:          aws.ToString(app.AppArn),
+				AccountRef:   accountID,
+				Region:       region,
+				DisplayName:  aws.ToString(app.Name),
+				Properties: map[string]any{
+					"AppId":         appID,
+					"Name":          aws.ToString(app.Name),
+					"DefaultDomain": aws.ToString(app.DefaultDomain),
+					"Platform":      string(app.Platform),
+					"Repository":    aws.ToString(app.Repository),
+				},
+			})
+		}
+
+		nextToken = result.NextToken
+		return nextToken != nil, nil
+	})
+}

--- a/pkg/aws/enumeration/amplify_enumerator.go
+++ b/pkg/aws/enumeration/amplify_enumerator.go
@@ -3,6 +3,7 @@ package enumeration
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -95,6 +96,16 @@ func (e *AmplifyAppEnumerator) EnumerateByARN(arn string, out *pipeline.P[output
 	return nil
 }
 
+// isRegionUnsupportedError returns true when the error indicates the AWS service
+// is not available in the target region (DNS resolution failure or explicit
+// region-not-supported response).
+func isRegionUnsupportedError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "could not resolve endpoint") ||
+		strings.Contains(msg, "EndpointNotFound")
+}
+
 func (e *AmplifyAppEnumerator) listAppsInRegion(region, accountID string, out *pipeline.P[output.AWSResource]) error {
 	cfg, err := e.provider.GetAWSConfig(region)
 	if err != nil {
@@ -109,6 +120,10 @@ func (e *AmplifyAppEnumerator) listAppsInRegion(region, accountID string, out *p
 			NextToken: nextToken,
 		})
 		if err != nil {
+			if isRegionUnsupportedError(err) {
+				slog.Debug("amplify not available in region, skipping", "region", region)
+				return false, nil
+			}
 			return false, fmt.Errorf("list amplify apps in %s: %w", region, err)
 		}
 

--- a/pkg/aws/enumeration/enumerator.go
+++ b/pkg/aws/enumeration/enumerator.go
@@ -43,6 +43,7 @@ func NewEnumerator(opts plugin.AWSCommonRecon) *Enumerator {
 		cc:          cc,
 	}
 	// Register built-in enumerators here as they are implemented.
+	e.Register(NewAmplifyAppEnumerator(opts, provider))
 	e.Register(NewS3Enumerator(opts, provider))
 
 	iamEnum := NewIAMEnumerator(opts, provider)

--- a/pkg/aws/publicaccess/resource_evaluator.go
+++ b/pkg/aws/publicaccess/resource_evaluator.go
@@ -1,6 +1,7 @@
 package publicaccess
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -28,6 +29,7 @@ type evaluator func(resource *output.AWSResource, awsCfg aws.Config, accountID s
 // evaluators maps resource types to their evaluation functions.
 func (e *ResourceEvaluator) evaluators() map[string]evaluator {
 	return map[string]evaluator{
+		"AWS::Amplify::App":       e.evaluateAmplify,
 		"AWS::EC2::Instance":      e.evaluateEC2,
 		"AWS::RDS::DBInstance":    e.evaluateRDS,
 		"AWS::Redshift::Cluster":  e.evaluateRedshift,
@@ -45,6 +47,7 @@ func (e *ResourceEvaluator) evaluators() map[string]evaluator {
 func SupportedResourceTypes() []string {
 	// Stable ordering — not derived from map iteration.
 	return []string{
+		"AWS::Amplify::App",
 		"AWS::EC2::Instance",
 		"AWS::S3::Bucket",
 		"AWS::SNS::Topic",
@@ -153,6 +156,24 @@ func (e *ResourceEvaluator) evaluateCore(resource *output.AWSResource, awsCfg aw
 }
 
 // --- property-based evaluators ---
+
+func (e *ResourceEvaluator) evaluateAmplify(resource *output.AWSResource, _ aws.Config, _ string) *PublicAccessResult {
+	if len(resource.URLs) == 0 {
+		return nil
+	}
+
+	defaultDomain, _ := resource.Properties["DefaultDomain"].(string)
+	appName, _ := resource.Properties["Name"].(string)
+	label := cmp.Or(appName, defaultDomain, resource.ResourceID)
+
+	return &PublicAccessResult{
+		IsPublic:       true,
+		AllowedActions: []string{"amplify:GetApp"},
+		EvaluationReasons: []string{
+			fmt.Sprintf("Amplify app '%s' has %d publicly accessible branch URL(s)", label, len(resource.URLs)),
+		},
+	}
+}
 
 func (e *ResourceEvaluator) evaluateEC2(resource *output.AWSResource, _ aws.Config, _ string) *PublicAccessResult {
 	publicIP, _ := resource.Properties["PublicIp"].(string)

--- a/pkg/aws/publicaccess/resource_evaluator_test.go
+++ b/pkg/aws/publicaccess/resource_evaluator_test.go
@@ -18,7 +18,7 @@ func newTestEvaluator() *ResourceEvaluator {
 
 func TestSupportedResourceTypes(t *testing.T) {
 	types := SupportedResourceTypes()
-	assert.Len(t, types, 10)
+	assert.Len(t, types, 11)
 
 	e := newTestEvaluator()
 	registry := e.evaluators()
@@ -104,6 +104,80 @@ func TestEvaluateCognito_NoSelfSignup(t *testing.T) {
 
 	result := e.evaluateCognito(resource, aws.Config{}, "")
 	assert.Nil(t, result)
+}
+
+// --- Amplify evaluator tests ---
+
+func TestEvaluateAmplify_WithBranchURLs(t *testing.T) {
+	e := newTestEvaluator()
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   "d1234567890",
+		Properties: map[string]any{
+			"DefaultDomain": "d1234567890.amplifyapp.com",
+			"Name":          "my-app",
+		},
+		URLs: []string{
+			"https://main.d1234567890.amplifyapp.com",
+			"https://develop.d1234567890.amplifyapp.com",
+		},
+	}
+
+	result := e.evaluateAmplify(resource, aws.Config{}, "")
+	require.NotNil(t, result)
+	assert.True(t, result.IsPublic)
+	assert.Contains(t, result.AllowedActions, "amplify:GetApp")
+	assert.Contains(t, result.EvaluationReasons[0], "my-app")
+	assert.Contains(t, result.EvaluationReasons[0], "2 publicly accessible branch URL(s)")
+}
+
+func TestEvaluateAmplify_NoURLs(t *testing.T) {
+	e := newTestEvaluator()
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   "d1234567890",
+		Properties: map[string]any{
+			"DefaultDomain": "d1234567890.amplifyapp.com",
+			"Name":          "my-app",
+		},
+	}
+
+	result := e.evaluateAmplify(resource, aws.Config{}, "")
+	assert.Nil(t, result)
+}
+
+func TestEvaluateAmplify_FallbackLabel(t *testing.T) {
+	e := newTestEvaluator()
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   "d1234567890",
+		Properties:   map[string]any{"DefaultDomain": "d1234567890.amplifyapp.com"},
+		URLs:         []string{"https://main.d1234567890.amplifyapp.com"},
+	}
+
+	result := e.evaluateAmplify(resource, aws.Config{}, "")
+	require.NotNil(t, result)
+	assert.Contains(t, result.EvaluationReasons[0], "d1234567890.amplifyapp.com",
+		"should fall back to DefaultDomain when Name is absent")
+}
+
+func TestEvaluateCore_Amplify_Public(t *testing.T) {
+	e := newTestEvaluator()
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   "d1234567890",
+		Region:       "us-east-1",
+		Properties: map[string]any{
+			"DefaultDomain": "d1234567890.amplifyapp.com",
+			"Name":          "my-app",
+		},
+		URLs: []string{"https://main.d1234567890.amplifyapp.com"},
+	}
+
+	results := collectCore(e, resource)
+	require.Len(t, results, 1)
+	assert.True(t, results[0].IsPublic)
+	assert.Equal(t, output.AccessLevelPublic, results[0].AWSResource.AccessLevel)
 }
 
 // --- Lambda evaluateLambdaAccess integration tests ---

--- a/pkg/aws/resourcetypes/types.go
+++ b/pkg/aws/resourcetypes/types.go
@@ -6,6 +6,7 @@ import "fmt"
 
 // all is the comprehensive list of CloudControl-supported resource types.
 var all = []string{
+	"AWS::Amplify::App",
 	"AWS::ApiGateway::RestApi",
 	"AWS::ApiGatewayV2::Api",
 	"AWS::AutoScaling::AutoScalingGroup",

--- a/pkg/modules/aws/enrichers/amplify.go
+++ b/pkg/modules/aws/enrichers/amplify.go
@@ -1,0 +1,65 @@
+package enrichers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/service/amplify"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+)
+
+func init() {
+	plugin.RegisterEnricher("AWS::Amplify::App", enrichAmplifyAppWrapper)
+}
+
+type AmplifyClient interface {
+	ListBranches(ctx context.Context, params *amplify.ListBranchesInput, optFns ...func(*amplify.Options)) (*amplify.ListBranchesOutput, error)
+}
+
+func enrichAmplifyAppWrapper(cfg plugin.EnricherConfig, r *output.AWSResource) error {
+	client := amplify.NewFromConfig(cfg.AWSConfig)
+	return EnrichAmplifyApp(cfg, r, client)
+}
+
+// EnrichAmplifyApp fetches branches for an Amplify app and constructs public
+// URLs from the default domain. Each active branch produces a URL of the form
+// https://{branchName}.{defaultDomain}.
+func EnrichAmplifyApp(cfg plugin.EnricherConfig, r *output.AWSResource, client AmplifyClient) error {
+	appID, _ := r.Properties["AppId"].(string)
+	if appID == "" {
+		return nil
+	}
+
+	defaultDomain, _ := r.Properties["DefaultDomain"].(string)
+	if defaultDomain == "" {
+		return nil
+	}
+
+	out, err := client.ListBranches(cfg.Context, &amplify.ListBranchesInput{
+		AppId: &appID,
+	})
+	if err != nil {
+		slog.Warn("amplify enricher: failed to list branches",
+			"app_id", appID,
+			"error", err,
+		)
+		return fmt.Errorf("failed to list amplify branches: %w", err)
+	}
+
+	var branchNames []string
+	for _, branch := range out.Branches {
+		if branch.DisplayName != nil {
+			branchNames = append(branchNames, *branch.DisplayName)
+			r.URLs = append(r.URLs, fmt.Sprintf("https://%s.%s", *branch.DisplayName, defaultDomain))
+		}
+	}
+
+	if len(branchNames) > 0 {
+		r.Properties["BranchNames"] = branchNames
+		r.Properties["BranchCount"] = len(branchNames)
+	}
+
+	return nil
+}

--- a/pkg/modules/aws/enrichers/amplify_test.go
+++ b/pkg/modules/aws/enrichers/amplify_test.go
@@ -1,0 +1,129 @@
+package enrichers_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/amplify"
+	amplifytypes "github.com/aws/aws-sdk-go-v2/service/amplify/types"
+	"github.com/praetorian-inc/aurelian/pkg/modules/aws/enrichers"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockAmplifyClient struct {
+	branches *amplify.ListBranchesOutput
+	err      error
+}
+
+func (m *mockAmplifyClient) ListBranches(_ context.Context, _ *amplify.ListBranchesInput, _ ...func(*amplify.Options)) (*amplify.ListBranchesOutput, error) {
+	return m.branches, m.err
+}
+
+func TestEnrichAmplifyApp_WithBranches(t *testing.T) {
+	client := &mockAmplifyClient{
+		branches: &amplify.ListBranchesOutput{
+			Branches: []amplifytypes.Branch{
+				{DisplayName: aws.String("main")},
+				{DisplayName: aws.String("develop")},
+			},
+		},
+	}
+
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   "d1234567890",
+		Properties: map[string]any{
+			"AppId":         "d1234567890",
+			"DefaultDomain": "d1234567890.amplifyapp.com",
+		},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichAmplifyApp(cfg, resource, client)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"main", "develop"}, resource.Properties["BranchNames"])
+	assert.Equal(t, 2, resource.Properties["BranchCount"])
+	assert.Equal(t, []string{
+		"https://main.d1234567890.amplifyapp.com",
+		"https://develop.d1234567890.amplifyapp.com",
+	}, resource.URLs)
+}
+
+func TestEnrichAmplifyApp_NoBranches(t *testing.T) {
+	client := &mockAmplifyClient{
+		branches: &amplify.ListBranchesOutput{},
+	}
+
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   "d1234567890",
+		Properties: map[string]any{
+			"AppId":         "d1234567890",
+			"DefaultDomain": "d1234567890.amplifyapp.com",
+		},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichAmplifyApp(cfg, resource, client)
+	require.NoError(t, err)
+
+	assert.Nil(t, resource.Properties["BranchNames"])
+	assert.Nil(t, resource.Properties["BranchCount"])
+	assert.Empty(t, resource.URLs)
+}
+
+func TestEnrichAmplifyApp_MissingAppID(t *testing.T) {
+	client := &mockAmplifyClient{}
+
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   "d1234567890",
+		Properties:   map[string]any{"DefaultDomain": "d1234567890.amplifyapp.com"},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichAmplifyApp(cfg, resource, client)
+	require.NoError(t, err)
+	assert.Empty(t, resource.URLs, "should skip when AppId is missing")
+}
+
+func TestEnrichAmplifyApp_MissingDefaultDomain(t *testing.T) {
+	client := &mockAmplifyClient{}
+
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   "d1234567890",
+		Properties:   map[string]any{"AppId": "d1234567890"},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichAmplifyApp(cfg, resource, client)
+	require.NoError(t, err)
+	assert.Empty(t, resource.URLs, "should skip when DefaultDomain is missing")
+}
+
+func TestEnrichAmplifyApp_APIError(t *testing.T) {
+	client := &mockAmplifyClient{
+		err: fmt.Errorf("access denied"),
+	}
+
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Amplify::App",
+		ResourceID:   "d1234567890",
+		Properties: map[string]any{
+			"AppId":         "d1234567890",
+			"DefaultDomain": "d1234567890.amplifyapp.com",
+		},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichAmplifyApp(cfg, resource, client)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list amplify branches")
+}

--- a/pkg/modules/aws/recon/list_all_resources_integration_test.go
+++ b/pkg/modules/aws/recon/list_all_resources_integration_test.go
@@ -4,17 +4,52 @@ package recon
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
-	"github.com/praetorian-inc/aurelian/test/testutil"
-
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/enrichers"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAWSList(t *testing.T) {
 	fixture := testutil.NewAWSFixture(t, "aws/recon/list")
 	fixture.Setup()
+
+	t.Run("Amplify apps", func(t *testing.T) {
+		mod, ok := plugin.Get(plugin.PlatformAWS, plugin.CategoryRecon, "list-all")
+		if !ok {
+			t.Skip("list-all module not registered in plugin system")
+		}
+
+		results, err := testutil.RunAndCollect(t, mod, plugin.Config{
+			Args: map[string]any{
+				"resource-type": []string{"AWS::Amplify::App"},
+				"regions":       []string{"us-east-2"},
+				"scan-type":     "full",
+			},
+			Context: context.Background(),
+		})
+		require.NoError(t, err)
+		testutil.AssertMinResults(t, results, 1)
+		testutil.AssertNoDuplicateResults(t, results)
+		testutil.AssertResultContainsString(t, results, fixture.Output("amplify_app_id"))
+
+		// Verify enricher populated branch URLs
+		found := false
+		for _, r := range results {
+			b, _ := json.Marshal(r)
+			if strings.Contains(string(b), fixture.Output("amplify_app_id")) {
+				assert.Contains(t, string(b), "amplifyapp.com", "should contain default domain URL")
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "should find Amplify app in results")
+	})
 
 	t.Run("EC2 instances", func(t *testing.T) {
 		mod, ok := plugin.Get(plugin.PlatformAWS, plugin.CategoryRecon, "list-all")

--- a/pkg/modules/aws/recon/public_resources_integration_test.go
+++ b/pkg/modules/aws/recon/public_resources_integration_test.go
@@ -31,6 +31,7 @@ func TestAWSPublicResources(t *testing.T) {
 		Args: map[string]any{
 			"regions": []string{"us-east-1"},
 			"resource-type": []string{
+				"AWS::Amplify::App",
 				"AWS::S3::Bucket",
 				"AWS::SNS::Topic",
 				"AWS::SQS::Queue",
@@ -66,6 +67,7 @@ func TestAWSPublicResources(t *testing.T) {
 	}
 
 	expectedImpactedResources := []string{
+		fixture.Output("public_amplify_app_id"),
 		fixture.Output("public_bucket_name"),
 		fixture.Output("public_topic_arn"),
 		fixture.Output("public_queue_name"),
@@ -86,6 +88,7 @@ func TestAWSPublicResources(t *testing.T) {
 
 	hasInvokeFunction := false
 	hasInvokeFunctionURL := false
+	hasAmplifyGetApp := false
 	for _, risk := range risks {
 		var ctx struct {
 			AllowedActions []string `json:"allowed_actions"`
@@ -98,11 +101,29 @@ func TestAWSPublicResources(t *testing.T) {
 			if action == "lambda:InvokeFunctionUrl" {
 				hasInvokeFunctionURL = true
 			}
+			if action == "amplify:GetApp" {
+				hasAmplifyGetApp = true
+			}
 		}
 	}
 
 	assert.True(t, hasInvokeFunction, "expected at least one risk with lambda:InvokeFunction")
 	assert.True(t, hasInvokeFunctionURL, "expected at least one risk with lambda:InvokeFunctionUrl")
+	assert.True(t, hasAmplifyGetApp, "expected at least one risk with amplify:GetApp")
+
+	amplifyAppID := fixture.Output("public_amplify_app_id")
+	amplifyRisk := findRiskForResource(risks, amplifyAppID)
+	if assert.NotNilf(t, amplifyRisk, "expected risk for Amplify app %s", amplifyAppID) {
+		assert.Equal(t, output.RiskSeverityHigh, amplifyRisk.Severity)
+		var ctx struct {
+			AllowedActions    []string `json:"allowed_actions"`
+			EvaluationReasons []string `json:"evaluation_reasons"`
+		}
+		require.NoError(t, json.Unmarshal(amplifyRisk.Context, &ctx))
+		assert.Contains(t, ctx.AllowedActions, "amplify:GetApp")
+		assert.NotEmpty(t, ctx.EvaluationReasons)
+		assert.Contains(t, ctx.EvaluationReasons[0], "publicly accessible branch URL(s)")
+	}
 
 	publicAMIID := fixture.Output("public_ami_id")
 	amiRisk := findRiskForResource(risks, publicAMIID)

--- a/pkg/types/enriched_resource_description.go
+++ b/pkg/types/enriched_resource_description.go
@@ -357,6 +357,7 @@ var serviceResourcePrefixes = map[string][]resourcePrefixEntry{
 
 // serviceDefaultResourceType is the fallback when no prefix rule matches.
 var serviceDefaultResourceType = map[string]string{
+	"amplify":           "AWS::Amplify::App",
 	"ec2":               "AWS::EC2::Instance",
 	"s3":                "AWS::S3::Bucket",
 	"lambda":            "AWS::Lambda::Function",

--- a/test/terraform/aws/recon/list/main.tf
+++ b/test/terraform/aws/recon/list/main.tf
@@ -118,3 +118,13 @@ resource "aws_lambda_function" "test" {
   runtime          = "python3.12"
   source_code_hash = data.archive_file.dummy.output_base64sha256
 }
+
+# Amplify app (enumerated via custom AmplifyAppEnumerator)
+resource "aws_amplify_app" "test" {
+  name = "${local.prefix}-amplify-app"
+}
+
+resource "aws_amplify_branch" "main" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = "main"
+}

--- a/test/terraform/aws/recon/list/outputs.tf
+++ b/test/terraform/aws/recon/list/outputs.tf
@@ -37,3 +37,11 @@ output "iam_user_arn" {
 output "iam_user_name" {
   value = aws_iam_user.test.name
 }
+
+output "amplify_app_id" {
+  value = aws_amplify_app.test.id
+}
+
+output "amplify_app_name" {
+  value = aws_amplify_app.test.name
+}

--- a/test/terraform/aws/recon/public-resources/main.tf
+++ b/test/terraform/aws/recon/public-resources/main.tf
@@ -465,6 +465,18 @@ resource "aws_ami_launch_permission" "public" {
 }
 
 # ============================================================
+# Amplify app with branch (property-based detection via URLs)
+# ============================================================
+resource "aws_amplify_app" "public" {
+  name = "${local.prefix}-amplify-app"
+}
+
+resource "aws_amplify_branch" "main" {
+  app_id      = aws_amplify_app.public.id
+  branch_name = "main"
+}
+
+# ============================================================
 # OpenSearch domain with public policy (policy-based detection)
 # ============================================================
 resource "aws_opensearch_domain" "public" {

--- a/test/terraform/aws/recon/public-resources/outputs.tf
+++ b/test/terraform/aws/recon/public-resources/outputs.tf
@@ -54,6 +54,14 @@ output "public_ami_id" {
   value = aws_ami_copy.public.id
 }
 
+output "public_amplify_app_id" {
+  value = aws_amplify_app.public.id
+}
+
+output "public_amplify_default_domain" {
+  value = aws_amplify_app.public.default_domain
+}
+
 output "public_opensearch_domain" {
   value = aws_opensearch_domain.public.domain_name
 }


### PR DESCRIPTION
## Summary
- Adds custom `AmplifyAppEnumerator` using native Amplify SDK (CloudControl does not support `AWS::Amplify::App`)
- Enricher fetches branches via `amplify:ListBranches` and constructs public URLs from `DefaultDomain`
- Property-based evaluator marks apps with deployed branch URLs as public
- Integration test Terraform fixtures and subtests for both `list-all` and `public-resources` modules

## Changes
- **New:** `pkg/aws/enumeration/amplify_enumerator.go` — custom enumerator with cross-region pagination
- **New:** `pkg/modules/aws/enrichers/amplify.go` — enricher populating `resource.URLs` with branch URLs
- **New:** `pkg/modules/aws/enrichers/amplify_test.go` — unit tests for the enricher
- **Modified:** `pkg/aws/publicaccess/resource_evaluator.go` — added `evaluateAmplify` + `AWS::Amplify::App` to supported types
- **Modified:** `pkg/aws/resourcetypes/types.go` — added `AWS::Amplify::App` to all types list
- **Modified:** `pkg/types/enriched_resource_description.go` — added `amplify` service mapping for ARN resolution
- **Modified:** Integration tests and Terraform fixtures for both list and public-resources