### PR TITLE
Add GCP Organization Policy Constraints module

### DIFF
--- a/cmd/module_imports.go
+++ b/cmd/module_imports.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/recon"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/enrichers"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/evaluators"
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/enrichers"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/recon"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/praetorian-inc/aurelian
 go 1.25.3
 
 require (
+	cloud.google.com/go/orgpolicy v1.15.1
 	github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement v1.1.1
@@ -189,6 +190,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty v1.16.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
@@ -198,6 +200,8 @@ require (
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
+	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/grpc v1.79.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+cloud.google.com/go/orgpolicy v1.15.1 h1:0hq12wxNwcfUMojr5j3EjWECSInIuyYDhkAWXTomRhc=
+cloud.google.com/go/orgpolicy v1.15.1/go.mod h1:bpvi9YIyU7wCW9WiXL/ZKT7pd2Ovegyr2xENIeRX5q0=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -226,6 +228,8 @@ github.com/cloudflare/ahocorasick v0.0.0-20240916140611-054963ec9396 h1:W2HK1IdC
 github.com/cloudflare/ahocorasick v0.0.0-20240916140611-054963ec9396/go.mod h1:tGWUZLZp9ajsxUOnHmFFLnqnlKXsCn6GReG4jAD59H0=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -262,6 +266,11 @@ github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0o
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
+github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
+github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -414,6 +423,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -475,6 +486,8 @@ github.com/zclconf/go-cty v1.16.4 h1:QGXaag7/7dCzb+odlGrgr+YmYZFaOCMW6DEpS+UD1eE
 github.com/zclconf/go-cty v1.16.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0/go.mod h1:snMWehoOh2wsEwnvvwtDyFCxVeDAODenXHtn5vzrKjo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/otel v1.39.0 h1:8yPrr/S0ND9QEfTfdP9V+SiwT4E0G7Y5MO7p85nis48=

--- a/pkg/modules/gcp/recon/org_policies.go
+++ b/pkg/modules/gcp/recon/org_policies.go
@@ -1,0 +1,256 @@
+package recon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	orgpolicy "cloud.google.com/go/orgpolicy/apiv2"
+	orgpolicypb "cloud.google.com/go/orgpolicy/apiv2/orgpolicypb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"github.com/praetorian-inc/aurelian/pkg/gcp/gcperrors"
+	"github.com/praetorian-inc/aurelian/pkg/gcp/hierarchy"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+)
+
+func init() {
+	plugin.Register(&GCPOrgPoliciesModule{})
+}
+
+// GCPOrgPoliciesConfig holds parameters for the GCP org-policies module.
+type GCPOrgPoliciesConfig struct {
+	plugin.GCPCommonRecon
+}
+
+// GCPOrgPoliciesModule enumerates organization policy constraints and their
+// effective policies across GCP organizations, folders, and projects.
+type GCPOrgPoliciesModule struct {
+	GCPOrgPoliciesConfig
+}
+
+func (m *GCPOrgPoliciesModule) ID() string                { return "org-policies" }
+func (m *GCPOrgPoliciesModule) Name() string              { return "GCP Organization Policies" }
+func (m *GCPOrgPoliciesModule) Platform() plugin.Platform { return plugin.PlatformGCP }
+func (m *GCPOrgPoliciesModule) Category() plugin.Category { return plugin.CategoryRecon }
+func (m *GCPOrgPoliciesModule) OpsecLevel() string        { return "moderate" }
+func (m *GCPOrgPoliciesModule) Authors() []string         { return []string{"Praetorian"} }
+
+func (m *GCPOrgPoliciesModule) Description() string {
+	return "Enumerate organization policy constraints and their effective policies " +
+		"across GCP organizations, folders, and projects."
+}
+
+func (m *GCPOrgPoliciesModule) References() []string {
+	return []string{"https://cloud.google.com/resource-manager/docs/organization-policy/overview"}
+}
+
+func (m *GCPOrgPoliciesModule) SupportedResourceTypes() []string {
+	return []string{"orgpolicy.googleapis.com/Policy"}
+}
+
+func (m *GCPOrgPoliciesModule) Parameters() any {
+	return &m.GCPOrgPoliciesConfig
+}
+
+func (m *GCPOrgPoliciesModule) Run(cfg plugin.Config, out *pipeline.P[model.AurelianModel]) error {
+	c := m.GCPOrgPoliciesConfig
+
+	// Resolve hierarchy to discover projects.
+	resolver := hierarchy.NewResolver(c.GCPCommonRecon)
+	input := hierarchy.HierarchyResolverInput{
+		OrgIDs:     c.OrgID,
+		FolderIDs:  c.FolderID,
+		ProjectIDs: c.ProjectID,
+	}
+	hierarchyStream := pipeline.From(input)
+	resolved := pipeline.New[output.GCPResource]()
+	pipeline.Pipe(hierarchyStream, resolver.Resolve, resolved)
+
+	// Collect all scopes to query: orgs, folders, and projects.
+	scopes := pipeline.New[string]()
+	pipeline.Pipe(resolved, m.extractScopes(c), scopes)
+
+	// For each scope, list constraints and get effective policies.
+	pipeline.Pipe(scopes, m.enumeratePolicies(c.ClientOptions), out)
+
+	return out.Wait()
+}
+
+// extractScopes returns a pipeline function that extracts scope strings
+// (e.g. "projects/my-project", "organizations/123", "folders/456") from
+// hierarchy resources. It also adds org and folder scopes from the config.
+func (m *GCPOrgPoliciesModule) extractScopes(c GCPOrgPoliciesConfig) func(output.GCPResource, *pipeline.P[string]) error {
+	emittedOrgs := make(map[string]bool)
+	emittedFolders := make(map[string]bool)
+
+	// Pre-mark config-level orgs and folders so they are emitted once
+	// from hierarchy resources rather than duplicated.
+	for _, orgID := range c.OrgID {
+		emittedOrgs[orgID] = false
+	}
+	for _, folderID := range c.FolderID {
+		emittedFolders[folderID] = false
+	}
+
+	return func(res output.GCPResource, p *pipeline.P[string]) error {
+		switch res.ResourceType {
+		case "organizations":
+			orgID := extractResourceID(res.ResourceID)
+			if !emittedOrgs[orgID] {
+				emittedOrgs[orgID] = true
+				p.Send("organizations/" + orgID)
+			}
+		case "folders":
+			folderID := extractResourceID(res.ResourceID)
+			if !emittedFolders[folderID] {
+				emittedFolders[folderID] = true
+				p.Send("folders/" + folderID)
+			}
+		case "projects":
+			if res.ProjectID != "" {
+				p.Send("projects/" + res.ProjectID)
+			}
+		}
+		return nil
+	}
+}
+
+// enumeratePolicies returns a pipeline function that, for each scope, lists
+// all constraints and retrieves their effective policies.
+func (m *GCPOrgPoliciesModule) enumeratePolicies(clientOpts []option.ClientOption) func(string, *pipeline.P[model.AurelianModel]) error {
+	return func(scope string, out *pipeline.P[model.AurelianModel]) error {
+		ctx := context.Background()
+		client, err := orgpolicy.NewClient(ctx, clientOpts...)
+		if err != nil {
+			return fmt.Errorf("create orgpolicy client: %w", err)
+		}
+		defer client.Close()
+
+		// List all constraints for this scope.
+		iter := client.ListConstraints(ctx, &orgpolicypb.ListConstraintsRequest{
+			Parent: scope,
+		})
+
+		for {
+			constraint, err := iter.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				if gcperrors.IsDisabledAPI(err) {
+					slog.Warn("Organization Policy API not enabled — enable orgpolicy.googleapis.com or use --quota-project", "scope", scope)
+				} else if gcperrors.IsPermissionDenied(err) {
+					slog.Warn("permission denied listing org policy constraints — ensure roles/orgpolicy.policyViewer is granted", "scope", scope)
+				} else {
+					slog.Warn("failed to list constraints", "scope", scope, "error", err)
+				}
+				break
+			}
+
+			constraintName := constraint.GetName()
+			properties := map[string]any{
+				"constraint_name": constraintName,
+				"constraint_type": constraint.GetConstraintDefault().String(),
+				"description":     constraint.GetDescription(),
+				"display_name":    constraint.GetDisplayName(),
+				"supports_under":  constraint.GetSupportsDryRun(),
+				"scope":           scope,
+			}
+
+			// Get the effective (inherited+merged) policy for this constraint.
+			policyName := scope + "/policies/" + extractConstraintShortName(constraintName)
+			effectivePolicy, err := client.GetEffectivePolicy(ctx, &orgpolicypb.GetEffectivePolicyRequest{
+				Name: policyName,
+			})
+			if err != nil {
+				slog.Debug("failed to get effective policy", "policy", policyName, "error", err)
+				properties["effective_policy_error"] = err.Error()
+			} else {
+				properties["effective_policy"] = effectivePolicyToMap(effectivePolicy)
+			}
+
+			scopeID := extractResourceID(scope)
+
+			out.Send(output.GCPResource{
+				ResourceType: "orgpolicy.googleapis.com/Policy",
+				ResourceID:   constraintName,
+				ProjectID:    scopeID,
+				Properties:   properties,
+			})
+		}
+
+		return nil
+	}
+}
+
+// extractResourceID extracts the ID portion from a resource name like
+// "organizations/123" -> "123" or "projects/my-proj" -> "my-proj".
+func extractResourceID(resourceName string) string {
+	if _, after, ok := strings.Cut(resourceName, "/"); ok {
+		return after
+	}
+	return resourceName
+}
+
+// extractConstraintShortName extracts the short constraint name from its full
+// resource name. e.g. "constraints/compute.disableSerialPortAccess" ->
+// "compute.disableSerialPortAccess".
+func extractConstraintShortName(constraintName string) string {
+	if _, after, ok := strings.Cut(constraintName, "/"); ok {
+		return after
+	}
+	return constraintName
+}
+
+// effectivePolicyToMap converts an OrgPolicy proto message into a plain map
+// for storage in GCPResource.Properties.
+func effectivePolicyToMap(policy *orgpolicypb.Policy) map[string]any {
+	m := map[string]any{
+		"name": policy.GetName(),
+	}
+
+	if spec := policy.GetSpec(); spec != nil {
+		specMap := map[string]any{
+			"etag":                spec.GetEtag(),
+			"update_time":        spec.GetUpdateTime().AsTime().String(),
+			"inherit_from_parent": spec.GetInheritFromParent(),
+			"reset":              spec.GetReset_(),
+		}
+
+		var rules []map[string]any
+		for _, rule := range spec.GetRules() {
+			ruleMap := map[string]any{}
+			if v := rule.GetValues(); v != nil {
+				ruleMap["allowed_values"] = v.GetAllowedValues()
+				ruleMap["denied_values"] = v.GetDeniedValues()
+			}
+			if rule.GetAllowAll() {
+				ruleMap["allow_all"] = true
+			}
+			if rule.GetDenyAll() {
+				ruleMap["deny_all"] = true
+			}
+			if rule.GetEnforce() {
+				ruleMap["enforce"] = true
+			}
+			if cond := rule.GetCondition(); cond != nil {
+				ruleMap["condition"] = map[string]any{
+					"expression":  cond.GetExpression(),
+					"title":       cond.GetTitle(),
+					"description": cond.GetDescription(),
+				}
+			}
+			rules = append(rules, ruleMap)
+		}
+		specMap["rules"] = rules
+		m["spec"] = specMap
+	}
+
+	return m
+}

--- a/pkg/modules/gcp/recon/org_policies_test.go
+++ b/pkg/modules/gcp/recon/org_policies_test.go
@@ -1,0 +1,62 @@
+package recon
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGCPOrgPoliciesModule_Metadata(t *testing.T) {
+	m := &GCPOrgPoliciesModule{}
+	assert.Equal(t, "org-policies", m.ID())
+	assert.Equal(t, "GCP Organization Policies", m.Name())
+	assert.Equal(t, plugin.PlatformGCP, m.Platform())
+	assert.Equal(t, plugin.CategoryRecon, m.Category())
+	assert.Equal(t, "moderate", m.OpsecLevel())
+	assert.NotEmpty(t, m.Authors())
+	assert.NotEmpty(t, m.Description())
+	assert.NotEmpty(t, m.References())
+	assert.NotNil(t, m.Parameters())
+}
+
+func TestGCPOrgPoliciesModule_SupportedResourceTypes(t *testing.T) {
+	m := &GCPOrgPoliciesModule{}
+	types := m.SupportedResourceTypes()
+	assert.Equal(t, []string{"orgpolicy.googleapis.com/Policy"}, types)
+}
+
+func TestExtractConstraintShortName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"constraints/compute.disableSerialPortAccess", "compute.disableSerialPortAccess"},
+		{"constraints/iam.allowedPolicyMemberDomains", "iam.allowedPolicyMemberDomains"},
+		{"bareConstraint", "bareConstraint"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractConstraintShortName(tt.input))
+		})
+	}
+}
+
+func TestExtractResourceID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"organizations/123456", "123456"},
+		{"folders/789", "789"},
+		{"projects/my-project", "my-project"},
+		{"bare-id", "bare-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractResourceID(tt.input))
+		})
+	}
+}

--- a/pkg/modules/loader/loader.go
+++ b/pkg/modules/loader/loader.go
@@ -8,5 +8,6 @@ import (
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/recon"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/recon"
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/recon"
 )

--- a/pkg/plugin/gcp_params.go
+++ b/pkg/plugin/gcp_params.go
@@ -14,6 +14,7 @@ type GCPCommonRecon struct {
 	ResourceType       []string              `param:"resource-type"        desc:"Resource types to enumerate" default:"all" shortcode:"t"`
 	Concurrency        int                   `param:"concurrency"          desc:"Max concurrent API requests" default:"5"`
 	CredentialsFile    string                `param:"creds-file"           desc:"Path to GCP credentials JSON" shortcode:"c"`
+	QuotaProject       string                `param:"quota-project"        desc:"GCP project for API quota and billing (required for WIF credentials)" shortcode:"q"`
 	IncludeSysProjects bool                  `param:"include-sys-projects" desc:"Include system projects" default:"false"`
 	ClientOptions      []option.ClientOption `param:"-"`
 	ResolvedProjects   []string              `param:"-"`
@@ -27,6 +28,9 @@ func (c *GCPCommonRecon) PostBind(_ Config, _ Module) error {
 	}
 	if c.CredentialsFile != "" {
 		c.ClientOptions = append(c.ClientOptions, option.WithCredentialsFile(c.CredentialsFile)) //nolint:staticcheck // WithCredentialsFile is the intended API for file-based credentials
+	}
+	if c.QuotaProject != "" {
+		c.ClientOptions = append(c.ClientOptions, option.WithQuotaProject(c.QuotaProject))
 	}
 	c.Concurrency = max(1, c.Concurrency)
 	return nil


### PR DESCRIPTION
## Summary
- Implements `org-policies` recon module that enumerates Organization Policy constraints and effective policies across GCP orgs, folders, and projects
- Uses `cloud.google.com/go/orgpolicy/apiv2` (gRPC client with iterator pattern)
- Walks hierarchy via existing resolver, calls `ListConstraints` + `GetEffectivePolicy` per scope
- Adds `--quota-project`/`-q` flag to `GCPCommonRecon` for Workload Identity Federation credentials
- Adds `gcperrors` integration for actionable API-disabled/permission-denied messages

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (0 failures)
- [x] Module registers with ID `org-policies`, platform `gcp`, category `recon`
- [x] Field tested with WIF credentials — graceful error handling for disabled APIs
- [ ] Live test with orgpolicy API enabled project

🤖 Generated with [Claude Code](https://claude.com/claude-code)