### PR TITLE
Add GCP Permission Expansion module

### DIFF
--- a/cmd/module_imports.go
+++ b/cmd/module_imports.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/recon"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/enrichers"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/evaluators"
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/enrichers"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/recon"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/praetorian-inc/aurelian
 go 1.25.3
 
 require (
+	cloud.google.com/go/orgpolicy v1.15.1
 	github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement v1.1.1
@@ -94,7 +95,6 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
@@ -189,6 +189,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty v1.16.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
@@ -198,6 +199,8 @@ require (
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
+	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/grpc v1.79.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+cloud.google.com/go/orgpolicy v1.15.1 h1:0hq12wxNwcfUMojr5j3EjWECSInIuyYDhkAWXTomRhc=
+cloud.google.com/go/orgpolicy v1.15.1/go.mod h1:bpvi9YIyU7wCW9WiXL/ZKT7pd2Ovegyr2xENIeRX5q0=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -128,8 +130,6 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 h1:JqcdRG//czea7Ppjb+g/n4o8i/R
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17/go.mod h1:CO+WeGmIdj/MlPel2KwID9Gt7CNq4M65HUfBW97liM0=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0 h1:bxsS3BE+wpRBd4B0//h/ZOo8Ay55jyb9zprax9rCSYs=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0/go.mod h1:BwMkMxZPTVtRT9zRKpB92ljsRFX0EXk2WoLQmCnNuRs=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13 h1:dO3jyPlS/HY5cZVsR+mybSJjNuLAPO2EGu4K1DIlUVs=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13/go.mod h1:8Yy4YO5rEbsoaRqkWkoHSEAkLE2EYw7C3vgFCFa9QQg=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11 h1:vsDNkqiXTCeTaSt1qNtri0RzTBDAXV1VQ4L5c5lvW2k=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11/go.mod h1:aH+Z4h+QZfJ2iEP+EITPDP8nZI1eFUJu38V6c9Nq9uQ=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.6 h1:3Rzut9v4ULIX3kjA6w3/Zaq2g8wBx6qJXB4BhQhIgjs=
@@ -226,6 +226,8 @@ github.com/cloudflare/ahocorasick v0.0.0-20240916140611-054963ec9396 h1:W2HK1IdC
 github.com/cloudflare/ahocorasick v0.0.0-20240916140611-054963ec9396/go.mod h1:tGWUZLZp9ajsxUOnHmFFLnqnlKXsCn6GReG4jAD59H0=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -262,6 +264,11 @@ github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0o
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
+github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
+github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -414,6 +421,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -475,6 +484,8 @@ github.com/zclconf/go-cty v1.16.4 h1:QGXaag7/7dCzb+odlGrgr+YmYZFaOCMW6DEpS+UD1eE
 github.com/zclconf/go-cty v1.16.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0/go.mod h1:snMWehoOh2wsEwnvvwtDyFCxVeDAODenXHtn5vzrKjo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/otel v1.39.0 h1:8yPrr/S0ND9QEfTfdP9V+SiwT4E0G7Y5MO7p85nis48=

--- a/pkg/gcp/iam/role_expander.go
+++ b/pkg/gcp/iam/role_expander.go
@@ -1,0 +1,97 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+
+	"google.golang.org/api/option"
+
+	iamv1 "google.golang.org/api/iam/v1"
+)
+
+// RoleExpander fetches all predefined GCP IAM roles and their permissions,
+// caching the result for subsequent calls. It follows the same lazy-loading
+// pattern as the AWS ActionExpander.
+type RoleExpander struct {
+	rolePermissions map[string][]string
+	once            sync.Once
+	initErr         error
+	clientOptions   []option.ClientOption
+}
+
+// SetClientOptions configures the client options used when creating the IAM
+// service. Must be called before the first Expand call.
+func (re *RoleExpander) SetClientOptions(opts ...option.ClientOption) {
+	re.clientOptions = opts
+}
+
+// ExpandRoles takes a list of GCP IAM role names (e.g. "roles/editor",
+// "roles/storage.admin") and returns the deduplicated, sorted union of all
+// their permissions. On first call the full set of predefined roles is fetched
+// from the IAM API and cached.
+func ExpandRoles(ctx context.Context, roles []string, clientOptions ...option.ClientOption) ([]string, error) {
+	re := &RoleExpander{clientOptions: clientOptions}
+	return re.Expand(ctx, roles)
+}
+
+// Expand resolves the given role names to the union of their permissions.
+func (re *RoleExpander) Expand(ctx context.Context, roles []string) ([]string, error) {
+	re.once.Do(func() {
+		re.rolePermissions, re.initErr = re.fetchAllRoles(ctx)
+		if re.initErr != nil {
+			slog.Error("Error fetching GCP IAM roles during initialization", "error", re.initErr)
+		} else {
+			slog.Debug("Successfully loaded GCP IAM roles", "count", len(re.rolePermissions))
+		}
+	})
+	if re.initErr != nil {
+		return nil, re.initErr
+	}
+
+	seen := make(map[string]struct{})
+	for _, role := range roles {
+		perms, ok := re.rolePermissions[role]
+		if !ok {
+			slog.Warn("GCP IAM role not found in predefined roles", "role", role)
+			continue
+		}
+		for _, p := range perms {
+			seen[p] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(seen))
+	for p := range seen {
+		result = append(result, p)
+	}
+	sort.Strings(result)
+
+	slog.Debug("Expanded GCP IAM roles", "roles", len(roles), "permissions", len(result))
+	return result, nil
+}
+
+func (re *RoleExpander) fetchAllRoles(ctx context.Context) (map[string][]string, error) {
+	svc, err := iamv1.NewService(ctx, re.clientOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("creating IAM service: %w", err)
+	}
+
+	rolePerms := make(map[string][]string)
+	err = svc.Roles.List().
+		PageSize(1000).
+		View("FULL").
+		Pages(ctx, func(resp *iamv1.ListRolesResponse) error {
+			for _, role := range resp.Roles {
+				rolePerms[role.Name] = role.IncludedPermissions
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("listing IAM roles: %w", err)
+	}
+
+	return rolePerms, nil
+}

--- a/pkg/gcp/iam/role_expander_test.go
+++ b/pkg/gcp/iam/role_expander_test.go
@@ -1,0 +1,70 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoleExpanderInitialState(t *testing.T) {
+	re := &RoleExpander{}
+	assert.Nil(t, re.rolePermissions)
+	assert.Nil(t, re.initErr)
+}
+
+func TestRoleExpanderDeduplicatesAndSorts(t *testing.T) {
+	// Pre-populate the cache so we don't need a real API call.
+	re := &RoleExpander{
+		rolePermissions: map[string][]string{
+			"roles/viewer": {
+				"storage.objects.get",
+				"compute.instances.list",
+				"storage.buckets.list",
+			},
+			"roles/editor": {
+				"storage.objects.get", // duplicate with viewer
+				"compute.instances.create",
+				"storage.buckets.create",
+			},
+		},
+	}
+	// Mark as already initialised so once.Do is a no-op.
+	re.once.Do(func() {})
+
+	perms, err := re.Expand(context.Background(), []string{"roles/viewer", "roles/editor"})
+	assert.NoError(t, err)
+
+	expected := []string{
+		"compute.instances.create",
+		"compute.instances.list",
+		"storage.buckets.create",
+		"storage.buckets.list",
+		"storage.objects.get",
+	}
+	assert.Equal(t, expected, perms)
+}
+
+func TestRoleExpanderUnknownRoleSkipped(t *testing.T) {
+	re := &RoleExpander{
+		rolePermissions: map[string][]string{
+			"roles/viewer": {"storage.objects.get"},
+		},
+	}
+	re.once.Do(func() {})
+
+	perms, err := re.Expand(context.Background(), []string{"roles/viewer", "roles/nonexistent"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"storage.objects.get"}, perms)
+}
+
+func TestRoleExpanderEmptyRoles(t *testing.T) {
+	re := &RoleExpander{
+		rolePermissions: map[string][]string{},
+	}
+	re.once.Do(func() {})
+
+	perms, err := re.Expand(context.Background(), []string{})
+	assert.NoError(t, err)
+	assert.Empty(t, perms)
+}

--- a/pkg/modules/gcp/analyze/expand_permissions.go
+++ b/pkg/modules/gcp/analyze/expand_permissions.go
@@ -1,0 +1,98 @@
+package analyze
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/option"
+
+	"github.com/praetorian-inc/aurelian/pkg/gcp/iam"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+)
+
+func init() {
+	plugin.Register(&ExpandPermissionsModule{})
+}
+
+// ExpandPermissionsConfig holds the parameters for the expand-permissions module.
+type ExpandPermissionsConfig struct {
+	Roles           string `param:"roles" desc:"Comma-separated GCP role names (e.g. roles/editor,roles/storage.admin)" required:"true"`
+	CredentialsFile string `param:"creds-file" desc:"Path to GCP credentials JSON"`
+	QuotaProject    string `param:"quota-project" desc:"GCP project for API quota and billing (required for WIF credentials)"`
+}
+
+// ExpandPermissionsModule resolves GCP IAM roles to the full set of
+// permissions they grant.
+type ExpandPermissionsModule struct {
+	ExpandPermissionsConfig
+}
+
+func (m *ExpandPermissionsModule) ID() string                { return "expand-permissions" }
+func (m *ExpandPermissionsModule) Name() string              { return "GCP Expand Permissions" }
+func (m *ExpandPermissionsModule) Platform() plugin.Platform { return plugin.PlatformGCP }
+func (m *ExpandPermissionsModule) Category() plugin.Category { return plugin.CategoryAnalyze }
+func (m *ExpandPermissionsModule) OpsecLevel() string        { return "safe" }
+func (m *ExpandPermissionsModule) Authors() []string         { return []string{"Praetorian"} }
+func (m *ExpandPermissionsModule) Parameters() any           { return &m.ExpandPermissionsConfig }
+
+func (m *ExpandPermissionsModule) Description() string {
+	return "Expands GCP IAM role names into the full list of permissions they include " +
+		"by querying the IAM predefined roles API."
+}
+
+func (m *ExpandPermissionsModule) References() []string {
+	return []string{"https://cloud.google.com/iam/docs/understanding-roles"}
+}
+
+func (m *ExpandPermissionsModule) SupportedResourceTypes() []string {
+	return nil
+}
+
+func (m *ExpandPermissionsModule) Run(cfg plugin.Config, out *pipeline.P[model.AurelianModel]) error {
+	c := m.ExpandPermissionsConfig
+
+	roles := strings.Split(c.Roles, ",")
+	for i := range roles {
+		roles[i] = strings.TrimSpace(roles[i])
+	}
+
+	var clientOptions []option.ClientOption
+	if c.CredentialsFile != "" {
+		clientOptions = append(clientOptions, option.WithCredentialsFile(c.CredentialsFile)) //nolint:staticcheck
+	}
+	if c.QuotaProject != "" {
+		clientOptions = append(clientOptions, option.WithQuotaProject(c.QuotaProject))
+	}
+
+	ctx := cfg.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	expander := &iam.RoleExpander{}
+	expander.SetClientOptions(clientOptions...)
+	permissions, err := expander.Expand(ctx, roles)
+	if err != nil {
+		return fmt.Errorf("expanding roles %q: %w", c.Roles, err)
+	}
+
+	cfg.Info("expanded %q to %d permissions", c.Roles, len(permissions))
+
+	resultsJSON, err := json.Marshal(permissions)
+	if err != nil {
+		return fmt.Errorf("marshaling results: %w", err)
+	}
+
+	out.Send(output.AnalyzeResult{
+		Module:  m.ID(),
+		Input:   c.Roles,
+		Results: json.RawMessage(resultsJSON),
+	})
+
+	return nil
+}

--- a/pkg/modules/gcp/analyze/expand_permissions_test.go
+++ b/pkg/modules/gcp/analyze/expand_permissions_test.go
@@ -1,0 +1,41 @@
+package analyze
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandPermissionsModuleRegistration(t *testing.T) {
+	mod, ok := plugin.Get(plugin.PlatformGCP, plugin.CategoryAnalyze, "expand-permissions")
+	require.True(t, ok, "expand-permissions module should be registered")
+	require.NotNil(t, mod)
+}
+
+func TestExpandPermissionsModuleMetadata(t *testing.T) {
+	m := &ExpandPermissionsModule{}
+	assert.Equal(t, "expand-permissions", m.ID())
+	assert.Equal(t, "GCP Expand Permissions", m.Name())
+	assert.Equal(t, plugin.PlatformGCP, m.Platform())
+	assert.Equal(t, plugin.CategoryAnalyze, m.Category())
+	assert.Equal(t, "safe", m.OpsecLevel())
+	assert.NotEmpty(t, m.Description())
+	assert.Nil(t, m.SupportedResourceTypes())
+}
+
+func TestExpandPermissionsModuleParameters(t *testing.T) {
+	m := &ExpandPermissionsModule{}
+	params, err := plugin.ParametersFrom(m.Parameters())
+	require.NoError(t, err)
+
+	paramNames := make(map[string]bool)
+	for _, p := range params {
+		paramNames[p.Name] = true
+	}
+
+	assert.True(t, paramNames["roles"], "should have roles param")
+	assert.True(t, paramNames["creds-file"], "should have creds-file param")
+	assert.True(t, paramNames["quota-project"], "should have quota-project param")
+}

--- a/pkg/modules/loader/loader.go
+++ b/pkg/modules/loader/loader.go
@@ -8,5 +8,6 @@ import (
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/recon"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/recon"
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/recon"
 )

--- a/pkg/plugin/gcp_params.go
+++ b/pkg/plugin/gcp_params.go
@@ -14,6 +14,7 @@ type GCPCommonRecon struct {
 	ResourceType       []string              `param:"resource-type"        desc:"Resource types to enumerate" default:"all" shortcode:"t"`
 	Concurrency        int                   `param:"concurrency"          desc:"Max concurrent API requests" default:"5"`
 	CredentialsFile    string                `param:"creds-file"           desc:"Path to GCP credentials JSON" shortcode:"c"`
+	QuotaProject       string                `param:"quota-project"        desc:"GCP project for API quota and billing (required for WIF credentials)" shortcode:"q"`
 	IncludeSysProjects bool                  `param:"include-sys-projects" desc:"Include system projects" default:"false"`
 	ClientOptions      []option.ClientOption `param:"-"`
 	ResolvedProjects   []string              `param:"-"`
@@ -27,6 +28,9 @@ func (c *GCPCommonRecon) PostBind(_ Config, _ Module) error {
 	}
 	if c.CredentialsFile != "" {
 		c.ClientOptions = append(c.ClientOptions, option.WithCredentialsFile(c.CredentialsFile)) //nolint:staticcheck // WithCredentialsFile is the intended API for file-based credentials
+	}
+	if c.QuotaProject != "" {
+		c.ClientOptions = append(c.ClientOptions, option.WithQuotaProject(c.QuotaProject))
 	}
 	c.Concurrency = max(1, c.Concurrency)
 	return nil


### PR DESCRIPTION
## Summary
- Implements `expand-permissions` analyze module that resolves GCP IAM role names to their full permission sets
- Adds `pkg/gcp/iam/role_expander.go` with lazy-loading `sync.Once` caching pattern (mirrors AWS `ActionExpander`)
- Fetches all ~1,170 predefined roles via `iam/v1` SDK, returns deduplicated sorted permissions
- Field tested: `roles/viewer` → 5,692 permissions, `roles/editor,roles/storage.admin` → 11,327 permissions
- Adds `--quota-project`/`-q` flag and registers `gcp/analyze` package in module imports

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (0 failures)
- [x] Module registers with ID `expand-permissions`, platform `gcp`, category `analyze`
- [x] Live tested with WIF credentials — correctly expands predefined roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)