### PR TITLE
Add GCP Serial Console Analysis module

### DIFF
--- a/cmd/module_imports.go
+++ b/cmd/module_imports.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/recon"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/enrichers"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/evaluators"
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/enrichers"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/recon"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/praetorian-inc/aurelian
 go 1.25.3
 
 require (
+	cloud.google.com/go/orgpolicy v1.15.1
 	github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement v1.1.1
@@ -94,7 +95,6 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
@@ -189,6 +189,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty v1.16.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
@@ -198,6 +199,8 @@ require (
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
+	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/grpc v1.79.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+cloud.google.com/go/orgpolicy v1.15.1 h1:0hq12wxNwcfUMojr5j3EjWECSInIuyYDhkAWXTomRhc=
+cloud.google.com/go/orgpolicy v1.15.1/go.mod h1:bpvi9YIyU7wCW9WiXL/ZKT7pd2Ovegyr2xENIeRX5q0=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -128,8 +130,6 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 h1:JqcdRG//czea7Ppjb+g/n4o8i/R
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17/go.mod h1:CO+WeGmIdj/MlPel2KwID9Gt7CNq4M65HUfBW97liM0=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0 h1:bxsS3BE+wpRBd4B0//h/ZOo8Ay55jyb9zprax9rCSYs=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0/go.mod h1:BwMkMxZPTVtRT9zRKpB92ljsRFX0EXk2WoLQmCnNuRs=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13 h1:dO3jyPlS/HY5cZVsR+mybSJjNuLAPO2EGu4K1DIlUVs=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13/go.mod h1:8Yy4YO5rEbsoaRqkWkoHSEAkLE2EYw7C3vgFCFa9QQg=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11 h1:vsDNkqiXTCeTaSt1qNtri0RzTBDAXV1VQ4L5c5lvW2k=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11/go.mod h1:aH+Z4h+QZfJ2iEP+EITPDP8nZI1eFUJu38V6c9Nq9uQ=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.6 h1:3Rzut9v4ULIX3kjA6w3/Zaq2g8wBx6qJXB4BhQhIgjs=
@@ -226,6 +226,8 @@ github.com/cloudflare/ahocorasick v0.0.0-20240916140611-054963ec9396 h1:W2HK1IdC
 github.com/cloudflare/ahocorasick v0.0.0-20240916140611-054963ec9396/go.mod h1:tGWUZLZp9ajsxUOnHmFFLnqnlKXsCn6GReG4jAD59H0=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -262,6 +264,11 @@ github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0o
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
+github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
+github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -414,6 +421,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -475,6 +484,8 @@ github.com/zclconf/go-cty v1.16.4 h1:QGXaag7/7dCzb+odlGrgr+YmYZFaOCMW6DEpS+UD1eE
 github.com/zclconf/go-cty v1.16.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0/go.mod h1:snMWehoOh2wsEwnvvwtDyFCxVeDAODenXHtn5vzrKjo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/otel v1.39.0 h1:8yPrr/S0ND9QEfTfdP9V+SiwT4E0G7Y5MO7p85nis48=

--- a/pkg/modules/gcp/recon/serial_console.go
+++ b/pkg/modules/gcp/recon/serial_console.go
@@ -1,0 +1,186 @@
+package recon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	computeapi "google.golang.org/api/compute/v1"
+
+	"github.com/praetorian-inc/aurelian/pkg/gcp/enumeration"
+	"github.com/praetorian-inc/aurelian/pkg/gcp/hierarchy"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/pkg/secrets"
+)
+
+func init() {
+	plugin.Register(&GCPSerialConsoleModule{})
+}
+
+// GCPSerialConsoleConfig holds the typed parameters for the GCP serial-console module.
+type GCPSerialConsoleConfig struct {
+	plugin.GCPCommonRecon
+	secrets.ScannerConfig
+	OutputDir string `param:"output-dir" desc:"Base output directory" default:"aurelian-output"`
+}
+
+// GCPSerialConsoleModule analyzes GCP Compute Engine serial console output for secrets
+// and security-relevant instance metadata.
+type GCPSerialConsoleModule struct {
+	GCPSerialConsoleConfig
+}
+
+func (m *GCPSerialConsoleModule) ID() string                { return "serial-console" }
+func (m *GCPSerialConsoleModule) Name() string              { return "GCP Serial Console Analysis" }
+func (m *GCPSerialConsoleModule) Platform() plugin.Platform { return plugin.PlatformGCP }
+func (m *GCPSerialConsoleModule) Category() plugin.Category { return plugin.CategoryRecon }
+func (m *GCPSerialConsoleModule) OpsecLevel() string        { return "moderate" }
+func (m *GCPSerialConsoleModule) Authors() []string         { return []string{"Praetorian"} }
+
+func (m *GCPSerialConsoleModule) Description() string {
+	return "Fetches serial console output from GCP Compute Engine instances and scans for " +
+		"hardcoded secrets using Titus. Also checks instance metadata for security-relevant settings " +
+		"such as OS Login, serial port access, SSH keys, and overly permissive OAuth scopes."
+}
+
+func (m *GCPSerialConsoleModule) References() []string {
+	return []string{
+		"https://cloud.google.com/compute/docs/troubleshooting/viewing-serial-port-output",
+	}
+}
+
+func (m *GCPSerialConsoleModule) SupportedResourceTypes() []string {
+	return []string{"compute.googleapis.com/Instance"}
+}
+
+func (m *GCPSerialConsoleModule) Parameters() any {
+	return &m.GCPSerialConsoleConfig
+}
+
+func (m *GCPSerialConsoleModule) Run(_ plugin.Config, out *pipeline.P[model.AurelianModel]) error {
+	c := m.GCPSerialConsoleConfig
+	if c.DBPath == "" {
+		c.DBPath = secrets.DefaultDBPath(c.OutputDir)
+	}
+
+	var s secrets.SecretScanner
+	if err := s.Start(c.ScannerConfig); err != nil {
+		return fmt.Errorf("failed to create Titus scanner: %w", err)
+	}
+	defer func() {
+		if closeErr := s.Close(); closeErr != nil {
+			slog.Warn("failed to close Titus scanner", "error", closeErr)
+		}
+	}()
+
+	// Resolve hierarchy: org/folder/project -> project IDs.
+	resolver := hierarchy.NewResolver(c.GCPCommonRecon)
+	input := hierarchy.HierarchyResolverInput{
+		OrgIDs:     c.OrgID,
+		FolderIDs:  c.FolderID,
+		ProjectIDs: c.ProjectID,
+	}
+	hierarchyStream := pipeline.From(input)
+	resolved := pipeline.New[output.GCPResource]()
+	pipeline.Pipe(hierarchyStream, resolver.Resolve, resolved)
+
+	// Split: forward project IDs for enumeration.
+	projects := pipeline.New[string]()
+	pipeline.Pipe(resolved, splitHierarchyResources, projects)
+
+	// Enumerate compute instances per project.
+	enumerator := enumeration.NewEnumerator(c.GCPCommonRecon).ForTypes([]string{"compute.googleapis.com/Instance"})
+	listed := pipeline.New[output.GCPResource]()
+	pipeline.Pipe(projects, enumerator.ListForProject, listed)
+
+	// Create compute service client once for all instances.
+	ctx := context.Background()
+	computeSvc, err := computeapi.NewService(ctx, c.ClientOptions...)
+	if err != nil {
+		return fmt.Errorf("creating compute client: %w", err)
+	}
+
+	// Fetch serial port output and check instance metadata.
+	extracted := pipeline.New[output.ScanInput]()
+	pipeline.Pipe(listed, func(r output.GCPResource, p *pipeline.P[output.ScanInput]) error {
+		projectID := r.ProjectID
+		zone := r.Location
+		instanceName := r.DisplayName
+
+		// Fetch serial port output for ports 1-4.
+		for port := int64(1); port <= 4; port++ {
+			resp, err := computeSvc.Instances.GetSerialPortOutput(projectID, zone, instanceName).Port(port).Context(ctx).Do()
+			if err != nil {
+				continue // skip errors, some ports may be empty
+			}
+			if resp.Contents == "" {
+				continue
+			}
+			p.Send(output.ScanInputFromGCPResource(r, fmt.Sprintf("serial-port/%d", port), []byte(resp.Contents)))
+		}
+
+		// Check instance metadata for security-relevant settings.
+		checkInstanceMetadata(ctx, computeSvc, r, out)
+
+		return nil
+	}, extracted)
+
+	// Scan for secrets.
+	scanned := pipeline.New[secrets.SecretScanResult]()
+	pipeline.Pipe(extracted, s.Scan, scanned)
+	pipeline.Pipe(scanned, secrets.RiskFromScanResult, out)
+
+	return out.Wait()
+}
+
+// checkInstanceMetadata inspects instance metadata and OAuth scopes for security-relevant settings.
+func checkInstanceMetadata(ctx context.Context, svc *computeapi.Service, r output.GCPResource, out *pipeline.P[model.AurelianModel]) {
+	inst, err := svc.Instances.Get(r.ProjectID, r.Location, r.DisplayName).Context(ctx).Do()
+	if err != nil {
+		slog.Debug("failed to get instance for metadata check", "instance", r.DisplayName, "error", err)
+		return
+	}
+
+	// Check metadata items for security-relevant keys.
+	if inst.Metadata != nil {
+		for _, item := range inst.Metadata.Items {
+			switch item.Key {
+			case "enable-oslogin", "serial-port-enable", "ssh-keys":
+				value := ""
+				if item.Value != nil {
+					value = *item.Value
+				}
+				finding := output.NewGCPResource(r.ProjectID, "compute.googleapis.com/Instance", r.ResourceID)
+				finding.DisplayName = r.DisplayName
+				finding.Location = r.Location
+				finding.Properties = map[string]any{
+					"finding_type":   "metadata-security-setting",
+					"metadata_key":   item.Key,
+					"metadata_value": value,
+				}
+				out.Send(finding)
+			}
+		}
+	}
+
+	// Check OAuth scopes for overly permissive settings.
+	for _, sa := range inst.ServiceAccounts {
+		for _, scope := range sa.Scopes {
+			if strings.Contains(scope, "cloud-platform") {
+				finding := output.NewGCPResource(r.ProjectID, "compute.googleapis.com/Instance", r.ResourceID)
+				finding.DisplayName = r.DisplayName
+				finding.Location = r.Location
+				finding.Properties = map[string]any{
+					"finding_type":    "overly-permissive-scope",
+					"service_account": sa.Email,
+					"scope":           scope,
+				}
+				out.Send(finding)
+			}
+		}
+	}
+}

--- a/pkg/modules/gcp/recon/serial_console_test.go
+++ b/pkg/modules/gcp/recon/serial_console_test.go
@@ -1,0 +1,16 @@
+package recon
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGCPSerialConsoleModule_Metadata(t *testing.T) {
+	m := &GCPSerialConsoleModule{}
+	assert.Equal(t, "serial-console", m.ID())
+	assert.Equal(t, plugin.PlatformGCP, m.Platform())
+	assert.Equal(t, plugin.CategoryRecon, m.Category())
+	assert.NotNil(t, m.Parameters())
+}

--- a/pkg/modules/loader/loader.go
+++ b/pkg/modules/loader/loader.go
@@ -8,5 +8,6 @@ import (
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/recon"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/recon"
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/recon"
 )

--- a/pkg/plugin/gcp_params.go
+++ b/pkg/plugin/gcp_params.go
@@ -14,6 +14,7 @@ type GCPCommonRecon struct {
 	ResourceType       []string              `param:"resource-type"        desc:"Resource types to enumerate" default:"all" shortcode:"t"`
 	Concurrency        int                   `param:"concurrency"          desc:"Max concurrent API requests" default:"5"`
 	CredentialsFile    string                `param:"creds-file"           desc:"Path to GCP credentials JSON" shortcode:"c"`
+	QuotaProject       string                `param:"quota-project"        desc:"GCP project for API quota and billing (required for WIF credentials)" shortcode:"q"`
 	IncludeSysProjects bool                  `param:"include-sys-projects" desc:"Include system projects" default:"false"`
 	ClientOptions      []option.ClientOption `param:"-"`
 	ResolvedProjects   []string              `param:"-"`
@@ -27,6 +28,9 @@ func (c *GCPCommonRecon) PostBind(_ Config, _ Module) error {
 	}
 	if c.CredentialsFile != "" {
 		c.ClientOptions = append(c.ClientOptions, option.WithCredentialsFile(c.CredentialsFile)) //nolint:staticcheck // WithCredentialsFile is the intended API for file-based credentials
+	}
+	if c.QuotaProject != "" {
+		c.ClientOptions = append(c.ClientOptions, option.WithQuotaProject(c.QuotaProject))
 	}
 	c.Concurrency = max(1, c.Concurrency)
 	return nil


### PR DESCRIPTION
## Summary
- Implements `serial-console` recon module that fetches Compute Engine serial port output (ports 1-4) and scans for credential leakage via Titus
- Checks instance metadata for security-relevant settings: OS Login, serial port access, SSH keys, overly permissive OAuth scopes
- Follows `find-secrets` pipeline pattern: hierarchy resolve → instance enumerate → serial port fetch → Titus scan
- Creates compute service client once and reuses across all instances
- Adds `--quota-project`/`-q` flag to `GCPCommonRecon` for WIF credentials

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (0 failures)
- [x] Module registers with ID `serial-console`, platform `gcp`, category `recon`
- [x] Verified graceful no-op when no compute instances exist (consistent with `find-secrets`)
- [ ] Live test against project with compute instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)