### PR TITLE
Add GCP Billing Metadata module

### DIFF
--- a/cmd/module_imports.go
+++ b/cmd/module_imports.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/recon"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/enrichers"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/evaluators"
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/enrichers"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/recon"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/praetorian-inc/aurelian
 go 1.25.3
 
 require (
+	cloud.google.com/go/orgpolicy v1.15.1
 	github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/apimanagement/armapimanagement v1.1.1
@@ -94,7 +95,6 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
@@ -189,6 +189,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty v1.16.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
@@ -198,6 +199,8 @@ require (
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
+	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/grpc v1.79.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+cloud.google.com/go/orgpolicy v1.15.1 h1:0hq12wxNwcfUMojr5j3EjWECSInIuyYDhkAWXTomRhc=
+cloud.google.com/go/orgpolicy v1.15.1/go.mod h1:bpvi9YIyU7wCW9WiXL/ZKT7pd2Ovegyr2xENIeRX5q0=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -128,8 +130,6 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 h1:JqcdRG//czea7Ppjb+g/n4o8i/R
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17/go.mod h1:CO+WeGmIdj/MlPel2KwID9Gt7CNq4M65HUfBW97liM0=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0 h1:bxsS3BE+wpRBd4B0//h/ZOo8Ay55jyb9zprax9rCSYs=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0/go.mod h1:BwMkMxZPTVtRT9zRKpB92ljsRFX0EXk2WoLQmCnNuRs=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13 h1:dO3jyPlS/HY5cZVsR+mybSJjNuLAPO2EGu4K1DIlUVs=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13/go.mod h1:8Yy4YO5rEbsoaRqkWkoHSEAkLE2EYw7C3vgFCFa9QQg=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11 h1:vsDNkqiXTCeTaSt1qNtri0RzTBDAXV1VQ4L5c5lvW2k=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11/go.mod h1:aH+Z4h+QZfJ2iEP+EITPDP8nZI1eFUJu38V6c9Nq9uQ=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.6 h1:3Rzut9v4ULIX3kjA6w3/Zaq2g8wBx6qJXB4BhQhIgjs=
@@ -226,6 +226,8 @@ github.com/cloudflare/ahocorasick v0.0.0-20240916140611-054963ec9396 h1:W2HK1IdC
 github.com/cloudflare/ahocorasick v0.0.0-20240916140611-054963ec9396/go.mod h1:tGWUZLZp9ajsxUOnHmFFLnqnlKXsCn6GReG4jAD59H0=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -262,6 +264,11 @@ github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0o
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
+github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
+github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
+github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -414,6 +421,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -475,6 +484,8 @@ github.com/zclconf/go-cty v1.16.4 h1:QGXaag7/7dCzb+odlGrgr+YmYZFaOCMW6DEpS+UD1eE
 github.com/zclconf/go-cty v1.16.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0/go.mod h1:snMWehoOh2wsEwnvvwtDyFCxVeDAODenXHtn5vzrKjo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/otel v1.39.0 h1:8yPrr/S0ND9QEfTfdP9V+SiwT4E0G7Y5MO7p85nis48=

--- a/pkg/modules/gcp/recon/billing_metadata.go
+++ b/pkg/modules/gcp/recon/billing_metadata.go
@@ -1,0 +1,130 @@
+package recon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/praetorian-inc/aurelian/pkg/gcp/gcperrors"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	cloudbilling "google.golang.org/api/cloudbilling/v1"
+)
+
+func init() {
+	plugin.Register(&GCPBillingMetadataModule{})
+}
+
+// GCPBillingMetadataConfig holds parameters for the GCP billing-metadata module.
+type GCPBillingMetadataConfig struct {
+	plugin.GCPCommonRecon
+}
+
+// GCPBillingMetadataModule retrieves GCP billing account metadata and project bindings.
+type GCPBillingMetadataModule struct {
+	GCPBillingMetadataConfig
+}
+
+func (m *GCPBillingMetadataModule) ID() string                { return "billing-metadata" }
+func (m *GCPBillingMetadataModule) Name() string              { return "GCP Billing Metadata" }
+func (m *GCPBillingMetadataModule) Platform() plugin.Platform { return plugin.PlatformGCP }
+func (m *GCPBillingMetadataModule) Category() plugin.Category { return plugin.CategoryRecon }
+func (m *GCPBillingMetadataModule) OpsecLevel() string        { return "moderate" }
+func (m *GCPBillingMetadataModule) Authors() []string         { return []string{"Praetorian"} }
+
+func (m *GCPBillingMetadataModule) Description() string {
+	return "Enumerate GCP billing accounts and their project bindings. " +
+		"Lists all accessible billing accounts and maps projects to their billing configuration."
+}
+
+func (m *GCPBillingMetadataModule) References() []string {
+	return []string{"https://cloud.google.com/billing/docs/reference/rest"}
+}
+
+func (m *GCPBillingMetadataModule) SupportedResourceTypes() []string {
+	return nil
+}
+
+func (m *GCPBillingMetadataModule) Parameters() any {
+	return &m.GCPBillingMetadataConfig
+}
+
+func (m *GCPBillingMetadataModule) Run(cfg plugin.Config, out *pipeline.P[model.AurelianModel]) error {
+	c := m.GCPBillingMetadataConfig
+	ctx := context.Background()
+
+	svc, err := cloudbilling.NewService(ctx, c.ClientOptions...)
+	if err != nil {
+		return fmt.Errorf("creating billing service: %w", err)
+	}
+
+	summary := &output.GCPBillingSummary{}
+
+	// List all accessible billing accounts.
+	err = svc.BillingAccounts.List().Pages(ctx, func(resp *cloudbilling.ListBillingAccountsResponse) error {
+		for _, acct := range resp.BillingAccounts {
+			summary.BillingAccounts = append(summary.BillingAccounts, output.BillingAccountInfo{
+				Name:            acct.Name,
+				DisplayName:     acct.DisplayName,
+				Open:            acct.Open,
+				MasterAccountID: acct.MasterBillingAccount,
+			})
+
+			// List projects associated with this billing account.
+			listErr := svc.BillingAccounts.Projects.List(acct.Name).Pages(ctx, func(projResp *cloudbilling.ListProjectBillingInfoResponse) error {
+				for _, proj := range projResp.ProjectBillingInfo {
+					summary.ProjectBindings = append(summary.ProjectBindings, output.ProjectBinding{
+						ProjectID:        proj.ProjectId,
+						BillingAccountID: proj.BillingAccountName,
+						BillingEnabled:   proj.BillingEnabled,
+					})
+				}
+				return nil
+			})
+			if listErr != nil {
+				slog.Warn("failed to list projects for billing account", "account", acct.Name, "error", listErr)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		if gcperrors.IsDisabledAPI(err) {
+			slog.Warn("Cloud Billing API not enabled — enable cloudbilling.googleapis.com or use --quota-project")
+		} else if gcperrors.IsPermissionDenied(err) {
+			slog.Warn("permission denied listing billing accounts — ensure billing.accounts.list is granted")
+		} else {
+			slog.Warn("failed to list billing accounts", "error", err)
+		}
+	}
+
+	// Also get billing info for specifically requested projects that may not
+	// have appeared in the billing-account-centric listing above.
+	seen := make(map[string]bool, len(summary.ProjectBindings))
+	for _, pb := range summary.ProjectBindings {
+		seen[pb.ProjectID] = true
+	}
+
+	for _, projectID := range c.ProjectID {
+		if seen[projectID] {
+			continue
+		}
+		info, getErr := svc.Projects.GetBillingInfo("projects/" + projectID).Context(ctx).Do()
+		if getErr != nil {
+			if !gcperrors.ShouldSkip(getErr) {
+				slog.Warn("failed to get billing info", "project", projectID, "error", getErr)
+			}
+			continue
+		}
+		summary.ProjectBindings = append(summary.ProjectBindings, output.ProjectBinding{
+			ProjectID:        info.ProjectId,
+			BillingAccountID: info.BillingAccountName,
+			BillingEnabled:   info.BillingEnabled,
+		})
+	}
+
+	cfg.Info("\n%s", summary.String())
+	out.Send(*summary)
+	return nil
+}

--- a/pkg/modules/gcp/recon/billing_metadata_test.go
+++ b/pkg/modules/gcp/recon/billing_metadata_test.go
@@ -1,0 +1,87 @@
+package recon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCPBillingMetadataModule_Metadata(t *testing.T) {
+	m := &GCPBillingMetadataModule{}
+	assert.Equal(t, "billing-metadata", m.ID())
+	assert.Equal(t, "GCP Billing Metadata", m.Name())
+	assert.Equal(t, plugin.PlatformGCP, m.Platform())
+	assert.Equal(t, plugin.CategoryRecon, m.Category())
+	assert.Equal(t, "moderate", m.OpsecLevel())
+	assert.NotEmpty(t, m.Authors())
+	assert.NotEmpty(t, m.Description())
+	assert.NotEmpty(t, m.References())
+	assert.Nil(t, m.SupportedResourceTypes())
+	assert.NotNil(t, m.Parameters())
+}
+
+func TestGCPBillingSummary_String_Empty(t *testing.T) {
+	s := &output.GCPBillingSummary{}
+	out := s.String()
+	assert.Contains(t, out, "GCP Billing Accounts:")
+	assert.Contains(t, out, "(none)")
+	assert.Contains(t, out, "Project Billing Bindings:")
+}
+
+func TestGCPBillingSummary_String_WithData(t *testing.T) {
+	s := &output.GCPBillingSummary{
+		BillingAccounts: []output.BillingAccountInfo{
+			{
+				Name:        "billingAccounts/012345-ABCDEF-678901",
+				DisplayName: "My Billing Account",
+				Open:        true,
+			},
+			{
+				Name:            "billingAccounts/999999-ZZZZZ-000000",
+				DisplayName:     "Sub Account",
+				Open:            false,
+				MasterAccountID: "billingAccounts/012345-ABCDEF-678901",
+			},
+		},
+		ProjectBindings: []output.ProjectBinding{
+			{
+				ProjectID:        "my-project-123",
+				BillingAccountID: "billingAccounts/012345-ABCDEF-678901",
+				BillingEnabled:   true,
+			},
+			{
+				ProjectID:        "disabled-project",
+				BillingAccountID: "billingAccounts/012345-ABCDEF-678901",
+				BillingEnabled:   false,
+			},
+		},
+	}
+
+	out := s.String()
+
+	// Verify billing accounts table.
+	assert.Contains(t, out, "GCP Billing Accounts:")
+	assert.Contains(t, out, "billingAccounts/012345-ABCDEF-678901")
+	assert.Contains(t, out, "My Billing Account")
+	assert.Contains(t, out, "Sub Account")
+
+	// Verify project bindings table.
+	assert.Contains(t, out, "Project Billing Bindings:")
+	assert.Contains(t, out, "my-project-123")
+	assert.Contains(t, out, "disabled-project")
+
+	// Verify table structure: headers and separator rows.
+	lines := strings.Split(out, "\n")
+	hasSeparator := false
+	for _, line := range lines {
+		if strings.Contains(line, "-|-") {
+			hasSeparator = true
+			break
+		}
+	}
+	require.True(t, hasSeparator, "expected markdown table separator row")
+}

--- a/pkg/modules/loader/loader.go
+++ b/pkg/modules/loader/loader.go
@@ -8,5 +8,6 @@ import (
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/recon"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/azure/recon"
+	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/analyze"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/gcp/recon"
 )

--- a/pkg/output/gcp_billing_summary.go
+++ b/pkg/output/gcp_billing_summary.go
@@ -1,0 +1,127 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/praetorian-inc/aurelian/pkg/model"
+)
+
+// BillingAccountInfo holds metadata about a GCP billing account.
+type BillingAccountInfo struct {
+	Name            string `json:"name"`                        // e.g. "billingAccounts/012345-ABCDEF-678901"
+	DisplayName     string `json:"display_name"`
+	Open            bool   `json:"open"`
+	MasterAccountID string `json:"master_account_id,omitempty"`
+}
+
+// ProjectBinding maps a project to its billing account.
+type ProjectBinding struct {
+	ProjectID        string `json:"project_id"`
+	BillingAccountID string `json:"billing_account_id"`
+	BillingEnabled   bool   `json:"billing_enabled"`
+}
+
+// GCPBillingSummary holds billing account metadata and project-to-billing mappings.
+type GCPBillingSummary struct {
+	model.BaseAurelianModel
+	BillingAccounts []BillingAccountInfo `json:"billing_accounts"`
+	ProjectBindings []ProjectBinding     `json:"project_bindings"`
+}
+
+// String renders the billing summary as a formatted markdown table.
+func (b *GCPBillingSummary) String() string {
+	var sb strings.Builder
+
+	// Billing Accounts table.
+	sb.WriteString("\nGCP Billing Accounts:\n\n")
+	if len(b.BillingAccounts) == 0 {
+		sb.WriteString("(none)\n")
+	} else {
+		acctHeaders := []string{"Name", "Display Name", "Open", "Master Account"}
+		acctRows := make([][]string, 0, len(b.BillingAccounts))
+		for _, acct := range b.BillingAccounts {
+			openStr := "no"
+			if acct.Open {
+				openStr = "yes"
+			}
+			master := acct.MasterAccountID
+			if master == "" {
+				master = "-"
+			}
+			acctRows = append(acctRows, []string{acct.Name, acct.DisplayName, openStr, master})
+		}
+		sb.WriteString(renderTable(acctHeaders, acctRows))
+	}
+
+	// Project Bindings table.
+	sb.WriteString("\nProject Billing Bindings:\n\n")
+	if len(b.ProjectBindings) == 0 {
+		sb.WriteString("(none)\n")
+	} else {
+		projHeaders := []string{"Project ID", "Billing Account", "Billing Enabled"}
+		projRows := make([][]string, 0, len(b.ProjectBindings))
+		for _, proj := range b.ProjectBindings {
+			enabledStr := "no"
+			if proj.BillingEnabled {
+				enabledStr = "yes"
+			}
+			projRows = append(projRows, []string{proj.ProjectID, proj.BillingAccountID, enabledStr})
+		}
+		sb.WriteString(renderTable(projHeaders, projRows))
+	}
+
+	return sb.String()
+}
+
+// renderTable renders a markdown-style table with the given headers and rows.
+func renderTable(headers []string, rows [][]string) string {
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if i < len(widths) && len(cell) > widths[i] {
+				widths[i] = len(cell)
+			}
+		}
+	}
+
+	var sb strings.Builder
+
+	// Header row.
+	for i, h := range headers {
+		if i > 0 {
+			sb.WriteString(" | ")
+		}
+		fmt.Fprintf(&sb, "%-*s", widths[i], h)
+	}
+	sb.WriteByte('\n')
+
+	// Separator row.
+	for i, w := range widths {
+		if i > 0 {
+			sb.WriteString("-|-")
+		}
+		sb.WriteString(strings.Repeat("-", w))
+	}
+	sb.WriteByte('\n')
+
+	// Data rows.
+	for _, row := range rows {
+		for i, cell := range row {
+			if i > 0 {
+				sb.WriteString(" | ")
+			}
+			if i < len(widths) {
+				fmt.Fprintf(&sb, "%-*s", widths[i], cell)
+			} else {
+				sb.WriteString(cell)
+			}
+		}
+		sb.WriteByte('\n')
+	}
+
+	return sb.String()
+}

--- a/pkg/plugin/gcp_params.go
+++ b/pkg/plugin/gcp_params.go
@@ -14,6 +14,7 @@ type GCPCommonRecon struct {
 	ResourceType       []string              `param:"resource-type"        desc:"Resource types to enumerate" default:"all" shortcode:"t"`
 	Concurrency        int                   `param:"concurrency"          desc:"Max concurrent API requests" default:"5"`
 	CredentialsFile    string                `param:"creds-file"           desc:"Path to GCP credentials JSON" shortcode:"c"`
+	QuotaProject       string                `param:"quota-project"        desc:"GCP project for API quota and billing (required for WIF credentials)" shortcode:"q"`
 	IncludeSysProjects bool                  `param:"include-sys-projects" desc:"Include system projects" default:"false"`
 	ClientOptions      []option.ClientOption `param:"-"`
 	ResolvedProjects   []string              `param:"-"`
@@ -27,6 +28,9 @@ func (c *GCPCommonRecon) PostBind(_ Config, _ Module) error {
 	}
 	if c.CredentialsFile != "" {
 		c.ClientOptions = append(c.ClientOptions, option.WithCredentialsFile(c.CredentialsFile)) //nolint:staticcheck // WithCredentialsFile is the intended API for file-based credentials
+	}
+	if c.QuotaProject != "" {
+		c.ClientOptions = append(c.ClientOptions, option.WithQuotaProject(c.QuotaProject))
 	}
 	c.Concurrency = max(1, c.Concurrency)
 	return nil


### PR DESCRIPTION
## Summary
- Implements `billing-metadata` recon module that enumerates billing accounts, project-to-billing associations via Cloud Billing API
- Adds `GCPBillingSummary` output type with markdown table rendering (follows `AWSCostSummary` pattern)
- Lists all accessible billing accounts, maps projects to billing configuration, fetches per-project billing info
- Deduplicates project bindings and integrates `gcperrors` for clean API-disabled messages
- Adds `--quota-project`/`-q` flag to `GCPCommonRecon` for WIF credentials

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (0 failures)
- [x] Module registers with ID `billing-metadata`, platform `gcp`, category `recon`
- [x] Field tested with WIF credentials — graceful handling of disabled Billing API
- [ ] Live test with billing API enabled and `billing.accounts.list` permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)