### PR TITLE
Fix find-secrets memory leak: stream JSONL output, bump titus v1.1.19

### DIFF
--- a/cmd/generator.go
+++ b/cmd/generator.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -285,42 +286,49 @@ func runModule(cmd *cobra.Command, module plugin.Module, platform plugin.Platfor
 	p2 := pipeline.New[model.AurelianModel]()
 	pipeline.Pipe(p1, module.Run, p2)
 
-	results, err := p2.Collect()
+	// Determine output file path
+	var outputPath string
+	if outputFile != "" {
+		// User specified explicit file — use as-is
+		outputPath = outputFile
+	} else {
+		// Auto-generate: {output-dir}/{moduleID}-{timestamp}.{ext}
+		timestamp := time.Now().Format("20060102-150405")
+		filename := fmt.Sprintf("%s-%s%s", module.ID(), timestamp, ".jsonl")
+		outputPath = filepath.Join(outputDir, filename)
+	}
+
+	// Ensure the output directory exists
+	if err := utils.EnsureFileDirectory(outputPath); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	f, err := os.Create(outputPath)
 	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Stream results as JSONL (one JSON object per line) to avoid
+	// accumulating all results in memory.
+	enc := json.NewEncoder(f)
+	count := 0
+	for item := range p2.Range() {
+		if err := enc.Encode(item); err != nil {
+			return fmt.Errorf("failed to encode result: %w", err)
+		}
+		count++
+	}
+	if err := p2.Wait(); err != nil {
 		return err
 	}
 
-	// Output results if there are any
-	if len(results) > 0 {
-		// Determine output file path
-		var outputPath string
-		if outputFile != "" {
-			// User specified explicit file — use as-is
-			outputPath = outputFile
-		} else {
-			// Auto-generate: {output-dir}/{moduleID}-{timestamp}.{ext}
-			timestamp := time.Now().Format("20060102-150405")
-			filename := fmt.Sprintf("%s-%s%s", module.ID(), timestamp, ".json")
-			outputPath = filepath.Join(outputDir, filename)
-		}
-
-		// Ensure the output directory exists
-		if err := utils.EnsureFileDirectory(outputPath); err != nil {
-			return fmt.Errorf("failed to create output directory: %w", err)
-		}
-
-		f, err := os.Create(outputPath)
-		if err != nil {
-			return fmt.Errorf("failed to create output file: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-
-		formatter := &plugin.JSONFormatter{Writer: f, Pretty: true}
-		if err := formatter.Format(results); err != nil {
-			return fmt.Errorf("failed to format output: %w", err)
-		}
-
-		log.Success("output written to %s", outputPath)
+	if count > 0 {
+		log.Success("output written to %s (%d results)", outputPath, count)
+	} else {
+		// Clean up empty file
+		_ = f.Close()
+		_ = os.Remove(outputPath)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/account v1.24.0
+	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.6
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.54.4
@@ -72,7 +73,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.4.0
 	github.com/muesli/termenv v0.16.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.4
-	github.com/praetorian-inc/titus v1.1.10-0.20260324203732-67e248d9ab6b
+	github.com/praetorian-inc/titus v1.1.19
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/neo4j v0.40.0
@@ -94,7 +95,6 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.5 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/praetorian-inc/titus v1.1.10-0.20260324203732-67e248d9ab6b h1:NZ/fM6V2w9wvZ8Duz45Q/YjUOCT7yiHQsWnUYeUiZV0=
-github.com/praetorian-inc/titus v1.1.10-0.20260324203732-67e248d9ab6b/go.mod h1:i2tQG3iJmoi00n8dBE32g50wc/LkIVUV02PHhdC0c3s=
+github.com/praetorian-inc/titus v1.1.19 h1:yT0FR7+qQujEywYzaWgd0/KoBH7ta3l+XMaRETgI/UU=
+github.com/praetorian-inc/titus v1.1.19/go.mod h1:i2tQG3iJmoi00n8dBE32g50wc/LkIVUV02PHhdC0c3s=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/pkg/secrets/risk.go
+++ b/pkg/secrets/risk.go
@@ -71,7 +71,7 @@ func (r SecretScanResult) proofData() map[string]any {
 
 // ToRisk converts a scan result into an AurelianRisk with marshalled proof.
 func (r SecretScanResult) ToRisk() (output.AurelianRisk, error) {
-	proofBytes, err := json.MarshalIndent(r.proofData(), "", "  ")
+	proofBytes, err := json.Marshal(r.proofData())
 	if err != nil {
 		return output.AurelianRisk{}, fmt.Errorf("marshalling proof: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **Stream JSONL output** instead of accumulating all results in memory via `Collect()`. Results are written to disk one per line and freed immediately. Output extension changed from `.json` to `.jsonl`.
- **Switch `json.MarshalIndent` to `json.Marshal`** for proof bytes in `risk.go` — proof is embedded as a `[]byte` field, no need for pretty-printing.
- **Bump titus to v1.1.19** which fixes two critical memory issues in the matcher:
  - `runeSpanToByteSpan` was allocating ~6x content size per regex match (string copy + `[]rune` conversion + intermediate strings)
  - `regexp2.FindStringMatch` was converting content to `[]rune` **per rule** (~200 rules × 4x content size = 800x amplification). Fixed by converting once and using `FindRunesMatch`.

## pprof evidence

Before fixes — scanning a single AWS account:
- **920GB cumulative** from `regexp2.getRunes` (per-rule rune conversion)
- **128GB cumulative** from `runeSpanToByteSpan` (per-match rune conversion)  
- **17GB live** from `json.MarshalIndent` (result accumulation via `Collect()`)
- Process RSS: **44GB+**

After fixes — expected peak memory in low single-digit GB range.

## Test plan

- [ ] Run `find-secrets` against an AWS account and monitor RSS stays bounded
- [ ] Verify `.jsonl` output is valid (one JSON object per line, parseable by `jq`)
- [ ] Verify empty scans produce no output file (clean up behavior)
- [ ] Existing unit tests pass