### PR TITLE
ci: add external-contrib-action v2 workflow

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -1,0 +1,28 @@
+name: External Contribution Notify
+
+on:
+  issues:
+    types: [opened, assigned, closed]
+  pull_request_target:
+    types: [opened, assigned, closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: praetorian-inc/external-contrib-action@v2
+        with:
+          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
+          linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
+          linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
+          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          dry-run: "false"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds the external-contrib-action v2 workflow to detect external contributions (PRs and issues)
- Automatically creates Linear issues, posts Slack notifications, and replies to external contributors

## What this does
When an external (non-org-member) contributor opens, is assigned, or closes a PR or issue:
1. **Linear**: Creates a triage issue with `external-contribution` label
2. **Slack**: Posts a Block Kit notification to the repo's channel
3. **Auto-reply**: Posts contextual GitHub comments (welcome, investigating, resolved)

## Required secrets
Uses org-level secrets already configured: `ORG_MEMBER_CHECK_PAT`, `LINEAR_API_KEY`, `SLACK_BOT_TOKEN`, plus per-repo `LINEAR_TEAM_ID`, `LINEAR_ASSIGNEE_ID`, `LINEAR_PARENT_ISSUE_ID`, `SLACK_CHANNEL_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)