### PR TITLE
ci: migrate to centralized go-ci.yml reusable workflow (ENG-3081)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,5 @@ jobs:
     with:
       build-cmd-path: .
       build-binary-name: aurelian
+      golangci-lint-timeout: 10m
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,83 +2,20 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  ci:
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@f89bda45e8073b1b6ac20198164de2b71ebf0c69  # v1.0.2
     permissions:
       contents: read
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-build
-      cancel-in-progress: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Build
-        env:
-          CGO_ENABLED: '0'
-        run: go build -trimpath -ldflags="-s -w" ./...
-
-      - name: Vet
-        run: go vet ./...
-
-  test:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-test-${{ matrix.scope }}
-      cancel-in-progress: true
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - scope: aws
-            packages: ./pkg/aws/... ./pkg/modules/aws/...
-          - scope: azure
-            packages: ./pkg/azure/... ./pkg/modules/azure/...
-          - scope: gcp
-            packages: ./pkg/gcp/... ./pkg/modules/gcp/...
-          - scope: core
-            packages: ./pkg/graph/... ./pkg/integration/... ./pkg/modules/common/... ./pkg/output/... ./pkg/pipeline/... ./pkg/plugin/... ./pkg/ratelimit/... ./pkg/secrets/... ./pkg/store/... ./pkg/templates/... ./pkg/types/... ./cmd/... ./internal/... ./test/...
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Test (${{ matrix.scope }})
-        run: go test -race ${{ matrix.packages }}
-
-  lint:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-lint
-      cancel-in-progress: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: latest
+    with:
+      build-cmd-path: .
+      build-binary-name: aurelian
+    secrets: inherit


### PR DESCRIPTION
## Summary

Migrates aurelian's CI to centralized `go-ci.yml@v1.0.2` ([ENG-3092](https://linear.app/praetorianlabs/issue/ENG-3092)).

Inline ci.yml → 18-line caller. Build path `.` (aurelian builds `main.go` at repo root, not from `cmd/`).

gendoc.yml, pr-review.yml, release.yml, security-scan.yml unchanged.