### PR TITLE
ci: add centralized external-contribution.yml

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -1,0 +1,12 @@
+name: External Contribution Notify
+
+on:
+  issues:
+    types: [opened, assigned, closed]
+  pull_request_target:
+    types: [opened, assigned, closed]
+
+jobs:
+  notify:
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@4900fbd3aaf1992181e2ebfb108c71fee8250c67  # v2.0.1
+    secrets: inherit

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -6,7 +6,21 @@ on:
   pull_request_target:
     types: [opened, assigned, closed]
 
+# Permissions are declared explicitly at the caller. Reusable workflows
+# cannot elevate GITHUB_TOKEN beyond what the caller grants, so if this
+# block is omitted the notify job falls back to org/repo default token
+# permissions — which may be read-only, causing Linear/GitHub comment
+# writes to fail with "Resource not accessible by integration".
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   notify:
     uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@4900fbd3aaf1992181e2ebfb108c71fee8250c67  # v2.0.1
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     secrets: inherit


### PR DESCRIPTION
Adds `.github/workflows/external-contribution.yml` calling the centralized `praetorian-inc/public-workflows/external-contrib-notify.yml@v2.0.1` reusable workflow.

On non-org-member PRs or issues, creates a Linear ticket and posts a Slack notification. Uses org-level GitHub App credentials forwarded via `secrets: inherit`.

Matches the pattern now used across other Praetorian OSS Go repos (augustus, brutus, julius, nerva, titus, vespasian). Previously this repo lacked any external-contribution notification — external PRs would land silently.

Part of ENG-3079 supply-chain hardening rollout.

## Note on this PR's own Notify check

If CI shows a `notify` job failure on this PR, it's because `pull_request_target` events use the workflow from the **base branch (main)**, which doesn't yet have `external-contribution.yml`. Once this PR merges, future external PRs will use the centralized workflow correctly. This PR's own `notify` check is self-referential and expected to be absent or skipped.