### PR TITLE
fix(security): harden pr-review.yml against external-PR prompt injection

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,13 +18,18 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Defense-in-depth: the pull_request trigger is currently commented out, but if it's
+    # ever re-enabled, this gate blocks prompt-injection from external-PR content by
+    # requiring author_association ∈ {OWNER, MEMBER, COLLABORATOR}. workflow_dispatch
+    # is already collaborator-only by GitHub's permission model.
     if: |
       (github.event_name == 'workflow_dispatch') ||
       (
         github.event.pull_request.draft == false &&
         !contains(github.actor, '[bot]') &&
         github.actor != 'coderabbitai' &&
-        github.actor != 'devin-ai-integration'
+        github.actor != 'devin-ai-integration' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
       )
 
     steps:
@@ -40,7 +45,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Claude PR review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009  # v1.0.101
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/pr-review.yml` to close two gaps (ENG-3114):

1. **author_association gate** — defense-in-depth for the commented-out `pull_request` trigger. Requires `OWNER/MEMBER/COLLABORATOR` for PR runs. `workflow_dispatch` is already collaborator-only by GitHub's permission model.
2. **SHA-pin `anthropics/claude-code-action`** — `@v1` → `@38ec876 # v1.0.101`. Blocks the tj-actions class of attack (CVE-2025-30066).

## What's NOT touched

- Custom Aurelian-specific review prompt (19 rules, module architecture, SDK, testing, anti-patterns)
- `--allowedTools` (keeps `mcp__github_inline_comment__create_inline_comment` and the gh CLI subset the prompt needs)
- The `Bash(gh api:*)` fallback and its TODO comment referencing anthropics/claude-code-action#635

## Context

Part of an org-wide sweep. Related:
- [public-workflows PR #18](https://github.com/praetorian-inc/public-workflows/pull/18) — hardens centralized claude-code.yml
- ENG-3114 — direct claude-code-action callers that bypass public-workflows (this repo + orator + MSP-Triage-Insights-Helper)
- Parent: ENG-3079

## Test plan

- [ ] `workflow_dispatch` with a PR number input still runs (unchanged behavior)
- [ ] If someone uncomments the `pull_request` trigger, an external PR from a fork / non-collaborator would be blocked by the author_association gate
- [ ] Custom Aurelian review output format still works (skill files still readable, inline comments still post)

🤖 Generated with [Claude Code](https://claude.com/claude-code)