### PR TITLE
chore(ci): bump public-workflows pins to v2.0.11 (e7c1f39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ci:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@135c50049eeef6e664bd7ea4aacaa33118083e30  # v2.0.10
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@e7c1f39e9219a3256df321445d558e18cf3027c0  # v2.0.11
     permissions:
       contents: read
     with:

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@135c50049eeef6e664bd7ea4aacaa33118083e30  # v2.0.10
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@e7c1f39e9219a3256df321445d558e18cf3027c0  # v2.0.11
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   notify:
-    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@135c50049eeef6e664bd7ea4aacaa33118083e30  # v2.0.10
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@e7c1f39e9219a3256df321445d558e18cf3027c0  # v2.0.11
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Bump `praetorian-inc/public-workflows/.github/workflows/*` pins to `e7c1f39e9219a3256df321445d558e18cf3027c0` (v2.0.11).

New in v2.0.11: `timeout-minutes` wall-clock ceilings on all previously-uncapped jobs + documented block-mode Harden-Runner endpoints for go-ci/go-security + README `ACTIONS_STEP_DEBUG` warning.

Files bumped:
- ` .github/workflows/claude-code.yml .github/workflows/ci.yml .github/workflows/external-contribution.yml`

Part of [ENG-3079](https://linear.app/praetorianlabs/issue/ENG-3079) supply-chain hardening.