### PR TITLE
fix(claude-code): add ready_for_review to trigger types

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -2,7 +2,7 @@ name: Claude PR Assistant
 
 on:
   pull_request:
-    types: [synchronize, opened]
+    types: [synchronize, opened, ready_for_review]
   pull_request_review_comment:
     types: [created]
 


### PR DESCRIPTION
## Summary

- Adds `ready_for_review` to `on.pull_request.types` so draft-to-ready PRs trigger Claude review
- Companion to [public-workflows#30](https://github.com/praetorian-inc/public-workflows/pull/30) which updates the reusable workflow `if:` conditions

## Root cause

PRs opened as drafts never got a Claude review. The `opened` event fires while `draft==true` (blocked by the reusable workflow `if:` guard), and the `ready_for_review` event was never delivered because it was not in the caller types list.

## Dependencies

- This PR: adds `ready_for_review` to caller trigger types
- [public-workflows#30](https://github.com/praetorian-inc/public-workflows/pull/30): updates reusable workflow to accept the event
- SHA bump to new public-workflows commit (follow-up after #30 merges)

Generated with [Claude Code](https://claude.com/claude-code)
