### PR TITLE
feat(fixture): destroy integration fixtures on package success

### DIFF
--- a/pkg/aws/enumeration/testmain_test.go
+++ b/pkg/aws/enumeration/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package enumeration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/aws/gaad/testmain_test.go
+++ b/pkg/aws/gaad/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package gaad
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/aws/resourcepolicies/testmain_test.go
+++ b/pkg/aws/resourcepolicies/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package resourcepolicies
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/azure/extraction/testmain_test.go
+++ b/pkg/azure/extraction/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package extraction
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/azure/resourcegraph/testmain_test.go
+++ b/pkg/azure/resourcegraph/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package resourcegraph
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/azure/subscriptions/testmain_test.go
+++ b/pkg/azure/subscriptions/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package subscriptions
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/gcp/enumeration/testmain_test.go
+++ b/pkg/gcp/enumeration/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package enumeration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/modules/aws/recon/testmain_test.go
+++ b/pkg/modules/aws/recon/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package recon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/modules/azure/recon/testmain_test.go
+++ b/pkg/modules/azure/recon/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package recon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/modules/gcp/recon/testmain_test.go
+++ b/pkg/modules/gcp/recon/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package recon_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/pkg/modules/gcp/recon/testmain_test.go
+++ b/pkg/modules/gcp/recon/testmain_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Uses the recon_test external package to match the existing integration
+// tests in this directory.
 package recon_test
 
 import (

--- a/scripts/destroy-integration-fixtures.sh
+++ b/scripts/destroy-integration-fixtures.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bulk cleanup tool for Aurelian integration-test Terraform fixtures.
+#
+# Routine cleanup happens automatically: integration tests now destroy their
+# fixtures after a successful package run (see scripts/run-integration-tests.sh
+# and the AURELIAN_KEEP_FIXTURES / AURELIAN_REDEPLOY_FIXTURES env vars). This
+# script is for:
+#
+#   * Cleaning up fixtures whose tests no longer exist (orphaned moduleDirs).
+#   * Bulk cleanup after a run was killed / SIGINT'd before TestMain could fire.
+#   * Cleanup after a failed run where fixtures were kept alive for debugging
+#     and are no longer needed.
+#
+# The AWS profile gates access to the state bucket. For Azure or GCP fixtures,
+# the caller must also have the corresponding provider credentials configured
+# (az login / gcloud auth) — terraform destroy will fail otherwise.
+
+STATE_REGION="us-east-1"
+STATE_BUCKET_PREFIX="aurelian-integration-tests-"
+STATE_PREFIX="integration-tests/"
+
+PROFILE=""
+DRY_RUN=false
+ASSUME_YES=false
+KEEP_S3=false
+FILTER=""
+ONLY_MODULE=""
+
+usage() {
+  cat <<EOF
+Usage: $0 --profile PROFILE [options]
+
+Enumerates every Terraform state under s3://${STATE_BUCKET_PREFIX}<ACCOUNT_ID>/${STATE_PREFIX}
+and destroys the associated infrastructure.
+
+Required:
+  --profile PROFILE     AWS profile with access to the state bucket.
+
+Options:
+  --dry-run             List modules that would be destroyed and exit.
+  --yes                 Skip the interactive confirmation prompt.
+  --keep-s3             Do not delete state/artifacts from S3 after destroy.
+  --filter PATTERN      Only operate on modules whose key matches this grep
+                        extended-regex pattern (e.g. 'aws/recon').
+  --module MODULE_DIR   Destroy a single module (exact moduleDir, e.g.
+                        'aws/recon/list'). Overrides --filter.
+  -h, --help            Show this help.
+
+Examples:
+  $0 --profile my-integration --dry-run
+  $0 --profile my-integration --filter 'aws/recon'
+  $0 --profile my-integration --module aws/recon/old-module --yes
+EOF
+}
+
+log()  { printf '[destroy-fixtures] %s\n' "$*"; }
+warn() { printf '[destroy-fixtures][WARN] %s\n' "$*" >&2; }
+err()  { printf '[destroy-fixtures][ERROR] %s\n' "$*" >&2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)        PROFILE="$2"; shift 2 ;;
+    --profile=*)      PROFILE="${1#*=}"; shift ;;
+    --dry-run)        DRY_RUN=true; shift ;;
+    --yes|-y)         ASSUME_YES=true; shift ;;
+    --keep-s3)        KEEP_S3=true; shift ;;
+    --filter)         FILTER="$2"; shift 2 ;;
+    --filter=*)       FILTER="${1#*=}"; shift ;;
+    --module)         ONLY_MODULE="$2"; shift 2 ;;
+    --module=*)       ONLY_MODULE="${1#*=}"; shift ;;
+    -h|--help)        usage; exit 0 ;;
+    *)                err "Unknown argument: $1"; usage >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$PROFILE" ]]; then
+  err "--profile is required"
+  usage >&2
+  exit 1
+fi
+
+for tool in aws terraform; do
+  if ! command -v "$tool" &>/dev/null; then
+    err "$tool not found in PATH"
+    exit 1
+  fi
+done
+
+export AWS_PROFILE="$PROFILE"
+
+log "Validating AWS profile '$PROFILE'..."
+if ! ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text 2>/dev/null)"; then
+  err "Unable to authenticate with AWS profile '$PROFILE'."
+  exit 1
+fi
+BUCKET="${STATE_BUCKET_PREFIX}${ACCOUNT_ID}"
+log "Account: $ACCOUNT_ID"
+log "Bucket:  s3://${BUCKET}"
+
+if ! aws s3api head-bucket --bucket "$BUCKET" --region "$STATE_REGION" &>/dev/null; then
+  err "State bucket ${BUCKET} not found or not accessible in ${STATE_REGION}."
+  exit 1
+fi
+
+# Collect state keys (terraform.tfstate objects under integration-tests/).
+log "Listing state keys under s3://${BUCKET}/${STATE_PREFIX} ..."
+STATE_KEYS=()
+while IFS= read -r key; do
+  [[ -n "$key" ]] && STATE_KEYS+=("$key")
+done < <(
+  aws s3api list-objects-v2 \
+    --bucket "$BUCKET" \
+    --prefix "$STATE_PREFIX" \
+    --query 'Contents[?ends_with(Key, `terraform.tfstate`)].Key' \
+    --output text 2>/dev/null | tr '\t' '\n' | sort
+)
+
+if [[ ${#STATE_KEYS[@]} -eq 0 ]]; then
+  log "No Terraform state files found. Nothing to do."
+  exit 0
+fi
+
+# Derive moduleDir (everything between STATE_PREFIX and /terraform.tfstate).
+declare -a MODULES=()
+for key in "${STATE_KEYS[@]}"; do
+  module="${key#${STATE_PREFIX}}"
+  module="${module%/terraform.tfstate}"
+  MODULES+=("$module")
+done
+
+# Apply filters.
+declare -a SELECTED=()
+for module in "${MODULES[@]}"; do
+  if [[ -n "$ONLY_MODULE" ]]; then
+    [[ "$module" == "$ONLY_MODULE" ]] && SELECTED+=("$module")
+    continue
+  fi
+  if [[ -n "$FILTER" ]]; then
+    if printf '%s\n' "$module" | grep -Eq "$FILTER"; then
+      SELECTED+=("$module")
+    fi
+    continue
+  fi
+  SELECTED+=("$module")
+done
+
+if [[ ${#SELECTED[@]} -eq 0 ]]; then
+  log "No modules matched filter. Nothing to do."
+  exit 0
+fi
+
+log "Modules targeted for destruction (${#SELECTED[@]}):"
+for module in "${SELECTED[@]}"; do
+  printf '  - %s\n' "$module"
+done
+
+if $DRY_RUN; then
+  log "--dry-run set; exiting without changes."
+  exit 0
+fi
+
+if ! $ASSUME_YES; then
+  printf '\n'
+  read -rp "Destroy these ${#SELECTED[@]} fixture(s) in account ${ACCOUNT_ID}? [type 'yes' to continue] " REPLY
+  if [[ "$REPLY" != "yes" ]]; then
+    log "Aborted."
+    exit 1
+  fi
+fi
+
+WORK_ROOT="$(mktemp -d -t aurelian-destroy.XXXXXX)"
+trap 'rm -rf "$WORK_ROOT"' EXIT
+
+declare -a FAILURES=()
+declare -a SUCCEEDED=()
+
+destroy_module() {
+  local module="$1"
+  local state_key="${STATE_PREFIX}${module}/terraform.tfstate"
+  local artifacts_uri="s3://${BUCKET}/${STATE_PREFIX}${module}/artifacts/"
+  local work_dir="${WORK_ROOT}/${module//\//_}"
+
+  log "=== ${module} ==="
+  log "state:     s3://${BUCKET}/${state_key}"
+  log "artifacts: ${artifacts_uri}"
+
+  mkdir -p "$work_dir"
+
+  if ! aws s3 sync "$artifacts_uri" "$work_dir/" --only-show-errors; then
+    warn "failed to sync artifacts for ${module}; skipping"
+    return 1
+  fi
+
+  if [[ -z "$(ls -A "$work_dir" 2>/dev/null)" ]]; then
+    warn "no artifacts found for ${module}; skipping (state exists but no terraform snapshot)"
+    return 1
+  fi
+
+  (
+    cd "$work_dir"
+    terraform init -reconfigure -input=false \
+      -backend-config="bucket=${BUCKET}" \
+      -backend-config="region=${STATE_REGION}" \
+      -backend-config="key=${state_key}"
+    terraform destroy -auto-approve -input=false
+  ) || return 1
+
+  if ! $KEEP_S3; then
+    log "Removing S3 state/artifacts for ${module}"
+    aws s3 rm "s3://${BUCKET}/${STATE_PREFIX}${module}/" --recursive --only-show-errors || \
+      warn "s3 cleanup had errors for ${module}"
+  fi
+
+  return 0
+}
+
+for module in "${SELECTED[@]}"; do
+  if destroy_module "$module"; then
+    SUCCEEDED+=("$module")
+  else
+    FAILURES+=("$module")
+  fi
+done
+
+printf '\n'
+log "Summary:"
+log "  succeeded: ${#SUCCEEDED[@]}"
+log "  failed:    ${#FAILURES[@]}"
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  err "Failed modules:"
+  for module in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$module" >&2
+  done
+  exit 1
+fi

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -178,7 +178,7 @@ if $NEED_GCP; then
 fi
 
 if $DESTROY_FIXTURES; then
-  export AURELIAN_DESTROY_FIXTURES=1
+  export AURELIAN_REDEPLOY_FIXTURES=1
 fi
 
 set -x

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -38,7 +38,8 @@ while [[ $# -gt 0 ]]; do
       echo "  TARGET        Go test target pattern (default: ./...)"
       echo ""
       echo "Options:"
-      echo "  --go-flags    Additional flags to pass to 'go test' (e.g. '--go-flags \"-v -timeout 30m\"')"
+      echo "  --go-flags    Additional flags to pass to 'go test' (e.g. '--go-flags \"-v\"')."
+  echo "                A -timeout of 30m is applied by default unless you supply your own."
       echo "  --keep        Keep Terraform fixtures alive after the run. By default, fixtures"
       echo "                are destroyed when every test in the package passes."
       echo "  --redeploy    Force Terraform fixtures to be torn down and redeployed at Setup,"
@@ -191,6 +192,13 @@ if $KEEP_FIXTURES; then
 fi
 if $REDEPLOY_FIXTURES; then
   export AURELIAN_REDEPLOY_FIXTURES=1
+fi
+
+# Default to -timeout 30m unless the caller provided their own -timeout in --go-flags.
+# The default covers a long test phase plus the post-run fixture destroy (which
+# can take up to ~15 minutes for heavy cloud fixtures).
+if [[ "$GO_FLAGS" != *"-timeout"* ]]; then
+  GO_FLAGS="-timeout 30m $GO_FLAGS"
 fi
 
 set -x

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -7,7 +7,8 @@ ENV_FILE="$PROJECT_DIR/.env.integration"
 
 GO_FLAGS=""
 TARGET="./..."
-DESTROY_FIXTURES=false
+KEEP_FIXTURES=false
+REDEPLOY_FIXTURES=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -20,8 +21,12 @@ while [[ $# -gt 0 ]]; do
       GO_FLAGS="${1#*=}"
       shift
       ;;
-    --destroy)
-      DESTROY_FIXTURES=true
+    --keep)
+      KEEP_FIXTURES=true
+      shift
+      ;;
+    --redeploy)
+      REDEPLOY_FIXTURES=true
       shift
       ;;
     -h|--help)
@@ -34,13 +39,17 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Options:"
       echo "  --go-flags    Additional flags to pass to 'go test' (e.g. '--go-flags \"-v -timeout 30m\"')"
-      echo "  --destroy     Destroy and redeploy Terraform fixtures before running tests"
+      echo "  --keep        Keep Terraform fixtures alive after the run. By default, fixtures"
+      echo "                are destroyed when every test in the package passes."
+      echo "  --redeploy    Force Terraform fixtures to be torn down and redeployed at Setup,"
+      echo "                ignoring the hash-based reuse check. Combine with --keep to iterate"
+      echo "                on a freshly-provisioned fixture."
       echo ""
       echo "Examples:"
-      echo "  $0                              # run all integration tests"
-      echo "  $0 ./pkg/azure/...              # run just azure component tests"
-      echo "  $0 ./pkg/modules/aws/recon/...  # run just aws recon module tests"
-      echo "  $0 ./pkg/modules/gcp/recon/...  # run just gcp recon module tests"
+      echo "  $0                              # run all integration tests (destroy on success)"
+      echo "  $0 ./pkg/azure/...              # run azure component tests"
+      echo "  $0 --keep ./pkg/modules/aws/recon/...    # iterate locally, keep fixtures alive"
+      echo "  $0 --redeploy --keep ./pkg/modules/aws/recon/...  # fresh deploy, then iterate"
       exit 0
       ;;
     -*)
@@ -177,7 +186,10 @@ if $NEED_GCP; then
   export GCP_PROJECT_ID
 fi
 
-if $DESTROY_FIXTURES; then
+if $KEEP_FIXTURES; then
+  export AURELIAN_KEEP_FIXTURES=1
+fi
+if $REDEPLOY_FIXTURES; then
   export AURELIAN_REDEPLOY_FIXTURES=1
 fi
 

--- a/test/integration/aws/recon/testmain_test.go
+++ b/test/integration/aws/recon/testmain_test.go
@@ -1,0 +1,12 @@
+//go:build integration
+
+package recon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/test/testutil/fixture"
+)
+
+func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }

--- a/test/terraform/test/destroy-canary/main.tf
+++ b/test/terraform/test/destroy-canary/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 

--- a/test/terraform/test/destroy-canary/main.tf
+++ b/test/terraform/test/destroy-canary/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "canary" {
+  bucket        = "${var.prefix}-${random_id.suffix.hex}"
+  force_destroy = true
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}

--- a/test/terraform/test/destroy-canary/outputs.tf
+++ b/test/terraform/test/destroy-canary/outputs.tf
@@ -1,0 +1,3 @@
+output "bucket_name" {
+  value = aws_s3_bucket.canary.id
+}

--- a/test/terraform/test/destroy-canary/variables.tf
+++ b/test/terraform/test/destroy-canary/variables.tf
@@ -1,0 +1,4 @@
+variable "prefix" {
+  type    = string
+  default = "aurelian-destroy-canary"
+}

--- a/test/testutil/fixture/destroy_all_integration_test.go
+++ b/test/testutil/fixture/destroy_all_integration_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package fixture
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestDestroyAll_RemovesModulePrefix(t *testing.T) {
+	// Use a private registry so this test does not interact with other tests
+	// in the package (which use the global registry indirectly via TestMain).
+	reg := &registry{}
+
+	f := newCanaryFixture(t)
+	f.registry = reg
+	f.Setup()
+
+	ctx := context.Background()
+
+	// Sanity: state + artifacts + hash all exist under the prefix.
+	assertPrefixPopulated(t, ctx, f.cfg.StateKey)
+
+	if err := reg.DestroyAll(ctx); err != nil {
+		t.Fatalf("DestroyAll: %v", err)
+	}
+
+	assertPrefixEmpty(t, ctx, f.cfg.StateKey)
+}
+
+func TestDestroyAll_KeepFlag_DoesNotInvoke(t *testing.T) {
+	// Independent of Setup — just verifies the RunTests gate calls destroyFn
+	// iff the env var isn't set. This is already covered by unit tests, but
+	// we re-exercise under the integration tag to catch env-read regressions.
+	t.Setenv("AURELIAN_KEEP_FIXTURES", "1")
+	called := false
+	code := runTestsWith(stubM{code: 0}, func(context.Context) error {
+		called = true
+		return nil
+	}, os.Getenv)
+
+	if code != 0 || called {
+		t.Fatalf("KEEP_FIXTURES=1 should skip destroy: code=%d called=%v", code, called)
+	}
+}
+
+// --- helpers ---
+
+func newCanaryFixture(t *testing.T) *BaseFixture {
+	t.Helper()
+
+	execPath, err := lookTerraform()
+	if err != nil {
+		t.Fatalf("terraform not found: %v", err)
+	}
+
+	EnsureStateBucket(t)
+	accountID, err := ResolveAWSAccountID(context.Background())
+	if err != nil {
+		t.Fatalf("resolve account id: %v", err)
+	}
+
+	return NewBase(t, Config{
+		Provider:    ProviderAWS,
+		ModuleDir:   "test/destroy-canary",
+		FixtureDir:  locateFixtureDir(t, "test/destroy-canary"),
+		ExecPath:    execPath,
+		ContainerID: accountID,
+		StateKey:    "integration-tests/test/destroy-canary/terraform.tfstate",
+	})
+}
+
+func assertPrefixPopulated(t *testing.T, ctx context.Context, stateKey string) {
+	t.Helper()
+	keys := listModulePrefix(t, ctx, stateKey)
+	if len(keys) == 0 {
+		t.Fatalf("expected objects under module prefix, got none")
+	}
+}
+
+func assertPrefixEmpty(t *testing.T, ctx context.Context, stateKey string) {
+	t.Helper()
+	keys := listModulePrefix(t, ctx, stateKey)
+	if len(keys) != 0 {
+		t.Fatalf("expected module prefix to be empty, got %v", keys)
+	}
+}
+
+func listModulePrefix(t *testing.T, ctx context.Context, stateKey string) []string {
+	t.Helper()
+	client, err := newS3Client(ctx)
+	if err != nil {
+		t.Fatalf("s3 client: %v", err)
+	}
+	prefix := stateKey[:len(stateKey)-len("terraform.tfstate")]
+
+	var keys []string
+	var token *string
+	for {
+		out, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            &stateBucket,
+			Prefix:            &prefix,
+			ContinuationToken: token,
+		})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		for _, o := range out.Contents {
+			if o.Key != nil {
+				keys = append(keys, *o.Key)
+			}
+		}
+		if out.IsTruncated == nil || !*out.IsTruncated {
+			return keys
+		}
+		token = out.NextContinuationToken
+	}
+}

--- a/test/testutil/fixture/destroy_all_integration_test.go
+++ b/test/testutil/fixture/destroy_all_integration_test.go
@@ -5,6 +5,7 @@ package fixture
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -95,7 +96,7 @@ func listModulePrefix(t *testing.T, ctx context.Context, stateKey string) []stri
 	if err != nil {
 		t.Fatalf("s3 client: %v", err)
 	}
-	prefix := stateKey[:len(stateKey)-len("terraform.tfstate")]
+	prefix := filepath.ToSlash(filepath.Dir(stateKey)) + "/"
 
 	var keys []string
 	var token *string

--- a/test/testutil/fixture/fixture.go
+++ b/test/testutil/fixture/fixture.go
@@ -208,6 +208,8 @@ func (f *BaseFixture) runLifecycle(ctx context.Context) error {
 		return err
 	}
 
+	// registry is nil only for BaseFixture literals constructed directly
+	// in tests; NewBase always sets it to globalRegistry for production use.
 	if f.registry != nil {
 		f.registry.register(f)
 	}

--- a/test/testutil/fixture/fixture.go
+++ b/test/testutil/fixture/fixture.go
@@ -174,9 +174,9 @@ func (f *BaseFixture) runLifecycle(ctx context.Context) error {
 		return fmt.Errorf("terraform init: %w", err)
 	}
 
-	destroyFixtures := os.Getenv("AURELIAN_DESTROY_FIXTURES") == "1"
-	if destroyFixtures {
-		f.t.Log("terraform fixture hash check: AURELIAN_DESTROY_FIXTURES=1")
+	redeployFixtures := os.Getenv("AURELIAN_REDEPLOY_FIXTURES") == "1"
+	if redeployFixtures {
+		f.t.Log("terraform fixture hash check: AURELIAN_REDEPLOY_FIXTURES=1")
 		f.t.Log("terraform fixture decision: teardown + redeploy (forced)")
 		if err := f.redeployStack(ctx, effectiveHash); err != nil {
 			return err

--- a/test/testutil/fixture/fixture.go
+++ b/test/testutil/fixture/fixture.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -64,6 +65,7 @@ type BaseFixture struct {
 	cfg      Config
 	ops      ops
 	registry *registry
+	logf     func(format string, args ...any)
 }
 
 type baseOps struct {
@@ -81,7 +83,13 @@ func NewBase(t *testing.T, cfg Config) *BaseFixture {
 		t.Fatalf("failed to create terraform instance for %s: %v", cfg.ModuleDir, err)
 	}
 
-	fixture := &BaseFixture{tf: tf, t: t, cfg: cfg, registry: globalRegistry}
+	fixture := &BaseFixture{
+		tf:       tf,
+		t:        t,
+		cfg:      cfg,
+		registry: globalRegistry,
+		logf:     log.Printf,
+	}
 	fixture.ops = baseOps{fixture: fixture}
 
 	return fixture
@@ -153,6 +161,12 @@ func (o baseOps) PurgeModulePrefix(ctx context.Context) error {
 func (f *BaseFixture) Setup() {
 	f.t.Helper()
 
+	// Route fixture logging through the test while Setup is on the stack;
+	// restore the stderr fallback before returning so that teardown paths
+	// invoked from TestMain (after tests have completed) don't panic.
+	f.logf = f.t.Logf
+	defer func() { f.logf = log.Printf }()
+
 	err := f.runLifecycle(context.Background())
 	if err != nil {
 		f.t.Fatalf("fixture setup failed: %v", err)
@@ -160,14 +174,14 @@ func (f *BaseFixture) Setup() {
 }
 
 func (f *BaseFixture) runLifecycle(ctx context.Context) error {
-	f.t.Logf("terraform fixture state location: %s", f.cfg.StateURI)
-	f.t.Logf("terraform fixture artifacts location: %s", f.cfg.ArtifactsURI)
+	f.logf("terraform fixture state location: %s", f.cfg.StateURI)
+	f.logf("terraform fixture artifacts location: %s", f.cfg.ArtifactsURI)
 
 	fixtureHash, err := computeFixtureHash(f.cfg.FixtureDir)
 	if err != nil {
 		return fmt.Errorf("compute fixture hash: %w", err)
 	}
-	f.t.Logf("terraform fixture local hash: %s", fixtureHash)
+	f.logf("terraform fixture local hash: %s", fixtureHash)
 
 	effectiveHash := computeEffectiveHash(fixtureHash, f.cfg.ContainerID)
 	remoteHash, err := f.ops.GetRemoteHash(ctx)
@@ -182,23 +196,23 @@ func (f *BaseFixture) runLifecycle(ctx context.Context) error {
 	redeployFixtures := os.Getenv("AURELIAN_REDEPLOY_FIXTURES") == "1"
 	switch {
 	case redeployFixtures:
-		f.t.Log("terraform fixture hash check: AURELIAN_REDEPLOY_FIXTURES=1")
-		f.t.Log("terraform fixture decision: teardown + redeploy (forced)")
+		f.logf("terraform fixture hash check: AURELIAN_REDEPLOY_FIXTURES=1")
+		f.logf("terraform fixture decision: teardown + redeploy (forced)")
 		if err := f.redeployStack(ctx, effectiveHash); err != nil {
 			return err
 		}
 	case remoteHash == "":
-		f.t.Log("terraform fixture hash check: remote hash empty")
-		f.t.Log("terraform fixture decision: deploy")
+		f.logf("terraform fixture hash check: remote hash empty")
+		f.logf("terraform fixture decision: deploy")
 		if err := f.deployStack(ctx, effectiveHash); err != nil {
 			return err
 		}
 	case remoteHash == effectiveHash:
-		f.t.Log("terraform fixture hash check: hashes match")
-		f.t.Log("terraform fixture decision: reuse existing fixture")
+		f.logf("terraform fixture hash check: hashes match")
+		f.logf("terraform fixture decision: reuse existing fixture")
 	default:
-		f.t.Logf("terraform fixture hash check: hashes differ (remote=%s local_effective=%s)", remoteHash, effectiveHash)
-		f.t.Log("terraform fixture decision: re-apply (drift detected)")
+		f.logf("terraform fixture hash check: hashes differ (remote=%s local_effective=%s)", remoteHash, effectiveHash)
+		f.logf("terraform fixture decision: re-apply (drift detected)")
 		if err := f.deployStack(ctx, effectiveHash); err != nil {
 			return err
 		}

--- a/test/testutil/fixture/fixture.go
+++ b/test/testutil/fixture/fixture.go
@@ -58,11 +58,12 @@ type ops interface {
 
 // BaseFixture manages a Terraform fixture backed by S3 remote state.
 type BaseFixture struct {
-	tf      *tfexec.Terraform
-	outputs map[string]tfexec.OutputMeta
-	t       *testing.T
-	cfg     Config
-	ops     ops
+	tf       *tfexec.Terraform
+	outputs  map[string]tfexec.OutputMeta
+	t        *testing.T
+	cfg      Config
+	ops      ops
+	registry *registry
 }
 
 type baseOps struct {
@@ -80,7 +81,7 @@ func NewBase(t *testing.T, cfg Config) *BaseFixture {
 		t.Fatalf("failed to create terraform instance for %s: %v", cfg.ModuleDir, err)
 	}
 
-	fixture := &BaseFixture{tf: tf, t: t, cfg: cfg}
+	fixture := &BaseFixture{tf: tf, t: t, cfg: cfg, registry: globalRegistry}
 	fixture.ops = baseOps{fixture: fixture}
 
 	return fixture
@@ -174,47 +175,43 @@ func (f *BaseFixture) runLifecycle(ctx context.Context) error {
 		return fmt.Errorf("get remote hash: %w", err)
 	}
 
-	err = f.ops.Init(ctx, f.cfg.InitOpts...)
-	if err != nil {
+	if err := f.ops.Init(ctx, f.cfg.InitOpts...); err != nil {
 		return fmt.Errorf("terraform init: %w", err)
 	}
 
 	redeployFixtures := os.Getenv("AURELIAN_REDEPLOY_FIXTURES") == "1"
-	if redeployFixtures {
+	switch {
+	case redeployFixtures:
 		f.t.Log("terraform fixture hash check: AURELIAN_REDEPLOY_FIXTURES=1")
 		f.t.Log("terraform fixture decision: teardown + redeploy (forced)")
 		if err := f.redeployStack(ctx, effectiveHash); err != nil {
 			return err
 		}
-
-		return f.loadOutputs(ctx)
-	}
-
-	missingRemoteHash := remoteHash == ""
-	if missingRemoteHash {
+	case remoteHash == "":
 		f.t.Log("terraform fixture hash check: remote hash empty")
 		f.t.Log("terraform fixture decision: deploy")
 		if err := f.deployStack(ctx, effectiveHash); err != nil {
 			return err
 		}
-
-		return f.loadOutputs(ctx)
-	}
-
-	hashMatches := remoteHash == effectiveHash
-	if hashMatches {
+	case remoteHash == effectiveHash:
 		f.t.Log("terraform fixture hash check: hashes match")
 		f.t.Log("terraform fixture decision: reuse existing fixture")
-		return f.loadOutputs(ctx)
+	default:
+		f.t.Logf("terraform fixture hash check: hashes differ (remote=%s local_effective=%s)", remoteHash, effectiveHash)
+		f.t.Log("terraform fixture decision: re-apply (drift detected)")
+		if err := f.deployStack(ctx, effectiveHash); err != nil {
+			return err
+		}
 	}
 
-	f.t.Logf("terraform fixture hash check: hashes differ (remote=%s local_effective=%s)", remoteHash, effectiveHash)
-	f.t.Log("terraform fixture decision: re-apply (drift detected)")
-	if err := f.deployStack(ctx, effectiveHash); err != nil {
+	if err := f.loadOutputs(ctx); err != nil {
 		return err
 	}
 
-	return f.loadOutputs(ctx)
+	if f.registry != nil {
+		f.registry.register(f)
+	}
+	return nil
 }
 
 // Output returns a single Terraform output as a string.

--- a/test/testutil/fixture/fixture.go
+++ b/test/testutil/fixture/fixture.go
@@ -53,6 +53,7 @@ type ops interface {
 	Output(context.Context, ...tfexec.OutputOption) (map[string]tfexec.OutputMeta, error)
 	UploadArtifacts(context.Context) error
 	DeleteArtifacts(context.Context) error
+	PurgeModulePrefix(context.Context) error
 }
 
 // BaseFixture manages a Terraform fixture backed by S3 remote state.
@@ -139,6 +140,10 @@ func (o baseOps) UploadArtifacts(ctx context.Context) error {
 
 func (o baseOps) DeleteArtifacts(ctx context.Context) error {
 	return o.fixture.deleteFixtureArtifacts(ctx)
+}
+
+func (o baseOps) PurgeModulePrefix(ctx context.Context) error {
+	return o.fixture.purgeModulePrefix(ctx)
 }
 
 // --- Public API ---

--- a/test/testutil/fixture/fixture_test.go
+++ b/test/testutil/fixture/fixture_test.go
@@ -156,6 +156,7 @@ func TestRunLifecycle_RedeployEnvVar_ForcesRedeploy(t *testing.T) {
 func TestRunLifecycle_RegistersOnSuccess(t *testing.T) {
 	// Use a local registry instead of the process-global to keep tests isolated.
 	localReg := &registry{}
+	localReg.teardownFn = func(context.Context, *BaseFixture) error { return nil }
 	t.Cleanup(func() {
 		// defensive: drain the local registry in case anything else got added
 		_ = localReg.DestroyAll(context.Background())

--- a/test/testutil/fixture/fixture_test.go
+++ b/test/testutil/fixture/fixture_test.go
@@ -128,6 +128,11 @@ func (m *mockOps) DeleteArtifacts(context.Context) error {
 	return nil
 }
 
+func (m *mockOps) PurgeModulePrefix(context.Context) error {
+	*m.calls = append(*m.calls, "purge")
+	return nil
+}
+
 func TestRunLifecycle_RedeployEnvVar_ForcesRedeploy(t *testing.T) {
 	t.Setenv("AURELIAN_REDEPLOY_FIXTURES", "1")
 

--- a/test/testutil/fixture/fixture_test.go
+++ b/test/testutil/fixture/fixture_test.go
@@ -201,7 +201,8 @@ func newLifecycleFixture(t *testing.T, remoteHash string, hashErr error, outputE
 			ArtifactsURI: "test://artifacts/",
 			InitOpts:     []tfexec.InitOption{},
 		},
-		ops: mock,
+		ops:  mock,
+		logf: t.Logf,
 	}
 
 	return f, &calls, effectiveHash, mock

--- a/test/testutil/fixture/fixture_test.go
+++ b/test/testutil/fixture/fixture_test.go
@@ -153,6 +153,28 @@ func TestRunLifecycle_RedeployEnvVar_ForcesRedeploy(t *testing.T) {
 	}
 }
 
+func TestRunLifecycle_RegistersOnSuccess(t *testing.T) {
+	// Use a local registry instead of the process-global to keep tests isolated.
+	localReg := &registry{}
+	t.Cleanup(func() {
+		// defensive: drain the local registry in case anything else got added
+		_ = localReg.DestroyAll(context.Background())
+	})
+
+	f, _, _, _ := newLifecycleFixture(t, "", nil, nil)
+	f.cfg.StateKey = "integration-tests/test/register/terraform.tfstate"
+	f.registry = localReg
+
+	if err := f.runLifecycle(context.Background()); err != nil {
+		t.Fatalf("run lifecycle: %v", err)
+	}
+
+	got := localReg.snapshot()
+	if len(got) != 1 || got[0] != f {
+		t.Fatalf("expected fixture to be registered exactly once; got %v", got)
+	}
+}
+
 func newLifecycleFixture(t *testing.T, remoteHash string, hashErr error, outputErr error) (*BaseFixture, *[]string, string, *mockOps) {
 	t.Helper()
 

--- a/test/testutil/fixture/fixture_test.go
+++ b/test/testutil/fixture/fixture_test.go
@@ -128,6 +128,25 @@ func (m *mockOps) DeleteArtifacts(context.Context) error {
 	return nil
 }
 
+func TestRunLifecycle_RedeployEnvVar_ForcesRedeploy(t *testing.T) {
+	t.Setenv("AURELIAN_REDEPLOY_FIXTURES", "1")
+
+	f, calls, effectiveHash, mock := newLifecycleFixture(t, "", nil, nil)
+	mock.remoteHash = effectiveHash // hash matches, but the env var should force redeploy
+
+	err := f.runLifecycle(context.Background())
+	if err != nil {
+		t.Fatalf("run lifecycle: %v", err)
+	}
+
+	// downloadArtifactsToTempDir fails (no artifacts in S3 under the test prefix)
+	// so redeployStack falls back to ops.Destroy, then re-init + apply.
+	expected := []string{"init", "destroy", "delete", "init", "apply", "upload", "put", "output"}
+	if !slices.Equal(*calls, expected) {
+		t.Fatalf("unexpected calls: got=%v want=%v", *calls, expected)
+	}
+}
+
 func newLifecycleFixture(t *testing.T, remoteHash string, hashErr error, outputErr error) (*BaseFixture, *[]string, string, *mockOps) {
 	t.Helper()
 

--- a/test/testutil/fixture/fixture_test.go
+++ b/test/testutil/fixture/fixture_test.go
@@ -139,8 +139,9 @@ func TestRunLifecycle_RedeployEnvVar_ForcesRedeploy(t *testing.T) {
 		t.Fatalf("run lifecycle: %v", err)
 	}
 
-	// downloadArtifactsToTempDir fails (no artifacts in S3 under the test prefix)
-	// so redeployStack falls back to ops.Destroy, then re-init + apply.
+	// downloadArtifactsToTempDir fails — either at credential resolution (no
+	// AWS profile) or because the test prefix has no real S3 objects — and
+	// redeployStack falls back to ops.Destroy, then re-init + apply.
 	expected := []string{"init", "destroy", "delete", "init", "apply", "upload", "put", "output"}
 	if !slices.Equal(*calls, expected) {
 		t.Fatalf("unexpected calls: got=%v want=%v", *calls, expected)

--- a/test/testutil/fixture/integration_helpers_test.go
+++ b/test/testutil/fixture/integration_helpers_test.go
@@ -1,0 +1,38 @@
+//go:build integration
+
+package fixture
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func lookTerraform() (string, error) {
+	path, err := exec.LookPath("terraform")
+	if err != nil {
+		return "", fmt.Errorf("terraform binary not found: %w", err)
+	}
+	return path, nil
+}
+
+// locateFixtureDir returns an absolute path to test/terraform/<moduleDir>
+// relative to this test file, regardless of the caller's working directory.
+func locateFixtureDir(t *testing.T, moduleDir string) string {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	// thisFile: .../test/testutil/fixture/integration_helpers_test.go
+	// target:   .../test/terraform/<moduleDir>
+	root := filepath.Join(filepath.Dir(thisFile), "..", "..", "terraform", moduleDir)
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		t.Fatalf("abs path for %s: %v", root, err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		t.Fatalf("fixture dir %s: %v", abs, err)
+	}
+	return abs
+}

--- a/test/testutil/fixture/registry.go
+++ b/test/testutil/fixture/registry.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 )
 
 // registry holds fixtures that had Setup() complete successfully during
@@ -55,6 +56,8 @@ func (r *registry) snapshot() []*BaseFixture {
 	return out
 }
 
+const perFixtureDestroyTimeout = 10 * time.Minute
+
 // DestroyAll tears down every registered fixture and sweeps its S3
 // prefix. Failures are collected and returned as a single aggregated
 // error so that one bad fixture does not prevent others from being
@@ -72,9 +75,11 @@ func (r *registry) DestroyAll(ctx context.Context) error {
 
 	var errs []error
 	for _, f := range fixtures {
-		if err := fn(ctx, f); err != nil {
+		fixtureCtx, cancel := context.WithTimeout(ctx, perFixtureDestroyTimeout)
+		if err := fn(fixtureCtx, f); err != nil {
 			errs = append(errs, fmt.Errorf("destroy %s: %w", f.cfg.StateKey, err))
 		}
+		cancel()
 	}
 
 	if len(errs) == 0 {

--- a/test/testutil/fixture/registry.go
+++ b/test/testutil/fixture/registry.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// registry holds fixtures that had Setup() complete successfully during
+// this test binary's execution. Keyed by StateKey so fixtures shared by
+// multiple tests collapse to one entry.
+//
+// The registry is process-scoped, which matches the per-package execution
+// model of `go test`: each package is its own binary, so the registry
+// never crosses package boundaries.
+type registry struct {
+	mu    sync.Mutex
+	items map[string]*BaseFixture
+
+	// teardownFn overrides the default teardown behavior; set in tests.
+	teardownFn func(context.Context, *BaseFixture) error
+}
+
+var globalRegistry = &registry{}
+
+// register adds a fixture to the registry. First writer for a given
+// StateKey wins; subsequent registrations of the same key are no-ops.
+func (r *registry) register(f *BaseFixture) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.items == nil {
+		r.items = map[string]*BaseFixture{}
+	}
+
+	if _, exists := r.items[f.cfg.StateKey]; exists {
+		return
+	}
+	r.items[f.cfg.StateKey] = f
+}
+
+// snapshot returns the registered fixtures. The underlying map is
+// copied so callers may iterate without holding the registry lock.
+func (r *registry) snapshot() []*BaseFixture {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := make([]*BaseFixture, 0, len(r.items))
+	for _, f := range r.items {
+		out = append(out, f)
+	}
+	return out
+}
+
+// DestroyAll tears down every registered fixture and sweeps its S3
+// prefix. Failures are collected and returned as a single aggregated
+// error so that one bad fixture does not prevent others from being
+// cleaned up.
+func (r *registry) DestroyAll(ctx context.Context) error {
+	fixtures := r.snapshot()
+	if len(fixtures) == 0 {
+		return nil
+	}
+
+	fn := r.teardownFn
+	if fn == nil {
+		fn = defaultTeardown
+	}
+
+	var errs []error
+	for _, f := range fixtures {
+		if err := fn(ctx, f); err != nil {
+			errs = append(errs, fmt.Errorf("destroy %s: %w", f.cfg.StateKey, err))
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.Join(errs...)
+}
+
+// defaultTeardown is the production teardown path: destroy terraform
+// resources then sweep the whole module prefix in S3.
+func defaultTeardown(ctx context.Context, f *BaseFixture) error {
+	if err := f.teardownStack(ctx); err != nil {
+		return err
+	}
+	if err := f.ops.PurgeModulePrefix(ctx); err != nil {
+		return fmt.Errorf("purge module prefix: %w", err)
+	}
+	return nil
+}

--- a/test/testutil/fixture/registry_test.go
+++ b/test/testutil/fixture/registry_test.go
@@ -5,6 +5,7 @@ package fixture
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -112,7 +113,7 @@ func TestRegistry_DestroyAll_AggregatesErrors(t *testing.T) {
 		t.Fatal("want aggregated error, got nil")
 	}
 	msg := err.Error()
-	if !contains(msg, "boom: a") || !contains(msg, "boom: b") {
+	if !strings.Contains(msg, "boom: a") || !strings.Contains(msg, "boom: b") {
 		t.Fatalf("want aggregated error to mention both failures, got: %v", msg)
 	}
 }
@@ -142,15 +143,3 @@ func (baseOpsZero) UploadArtifacts(context.Context) error   { return nil }
 func (baseOpsZero) DeleteArtifacts(context.Context) error   { return nil }
 func (baseOpsZero) PurgeModulePrefix(context.Context) error { return nil }
 
-func contains(s, substr string) bool {
-	return len(substr) == 0 || (len(s) >= len(substr) && stringsIndex(s, substr) >= 0)
-}
-
-func stringsIndex(s, substr string) int {
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-	return -1
-}

--- a/test/testutil/fixture/registry_test.go
+++ b/test/testutil/fixture/registry_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func TestRegistry_RegistersFixtureByStateKey(t *testing.T) {
+	r := &registry{}
+
+	a := &BaseFixture{cfg: Config{StateKey: "integration-tests/aws/recon/one/terraform.tfstate"}}
+	b := &BaseFixture{cfg: Config{StateKey: "integration-tests/aws/recon/two/terraform.tfstate"}}
+
+	r.register(a)
+	r.register(b)
+
+	got := r.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got))
+	}
+}
+
+func TestRegistry_DedupesByStateKey(t *testing.T) {
+	r := &registry{}
+
+	key := "integration-tests/aws/recon/shared/terraform.tfstate"
+	a := &BaseFixture{cfg: Config{StateKey: key}}
+	b := &BaseFixture{cfg: Config{StateKey: key}} // different pointer, same key
+
+	r.register(a)
+	r.register(b)
+
+	got := r.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("want 1 deduplicated entry, got %d", len(got))
+	}
+	if got[0] != a {
+		t.Fatalf("want first registered fixture to win")
+	}
+}
+
+func TestRegistry_ConcurrentRegisterIsSafe(t *testing.T) {
+	r := &registry{}
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			r.register(&BaseFixture{cfg: Config{StateKey: "k"}})
+		}(i)
+	}
+	wg.Wait()
+
+	got := r.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("want 1 deduplicated entry after concurrent registration, got %d", len(got))
+	}
+}
+
+func TestRegistry_DestroyAll_CallsTeardownForEach(t *testing.T) {
+	r := &registry{}
+
+	var mu sync.Mutex
+	var teardowns []string
+	mkFixture := func(key string) *BaseFixture {
+		return &BaseFixture{
+			cfg: Config{StateKey: key},
+			ops: &destroyRecordingOps{
+				onDestroy: func() {
+					mu.Lock()
+					teardowns = append(teardowns, key)
+					mu.Unlock()
+				},
+			},
+		}
+	}
+	// Use the registry's test hook to swap teardown with a recorded no-op.
+	r.teardownFn = func(ctx context.Context, f *BaseFixture) error {
+		f.ops.(*destroyRecordingOps).onDestroy()
+		return nil
+	}
+
+	r.register(mkFixture("a"))
+	r.register(mkFixture("b"))
+
+	if err := r.DestroyAll(context.Background()); err != nil {
+		t.Fatalf("DestroyAll: %v", err)
+	}
+	if len(teardowns) != 2 {
+		t.Fatalf("want 2 teardowns, got %d: %v", len(teardowns), teardowns)
+	}
+}
+
+func TestRegistry_DestroyAll_AggregatesErrors(t *testing.T) {
+	r := &registry{}
+	r.teardownFn = func(ctx context.Context, f *BaseFixture) error {
+		return errors.New("boom: " + f.cfg.StateKey)
+	}
+
+	r.register(&BaseFixture{cfg: Config{StateKey: "a"}})
+	r.register(&BaseFixture{cfg: Config{StateKey: "b"}})
+
+	err := r.DestroyAll(context.Background())
+	if err == nil {
+		t.Fatal("want aggregated error, got nil")
+	}
+	msg := err.Error()
+	if !contains(msg, "boom: a") || !contains(msg, "boom: b") {
+		t.Fatalf("want aggregated error to mention both failures, got: %v", msg)
+	}
+}
+
+type destroyRecordingOps struct {
+	baseOpsZero
+	onDestroy func()
+}
+
+// baseOpsZero is a do-nothing ops impl used only to satisfy the interface
+// in tests that don't care about terraform calls.
+type baseOpsZero struct{}
+
+func (baseOpsZero) GetRemoteHash(context.Context) (string, error) { return "", nil }
+func (baseOpsZero) PutRemoteHash(context.Context, string) error   { return nil }
+func (baseOpsZero) Init(context.Context, ...tfexec.InitOption) error {
+	return nil
+}
+func (baseOpsZero) Destroy(context.Context, ...tfexec.DestroyOption) error {
+	return nil
+}
+func (baseOpsZero) Apply(context.Context, ...tfexec.ApplyOption) error { return nil }
+func (baseOpsZero) Output(context.Context, ...tfexec.OutputOption) (map[string]tfexec.OutputMeta, error) {
+	return nil, nil
+}
+func (baseOpsZero) UploadArtifacts(context.Context) error   { return nil }
+func (baseOpsZero) DeleteArtifacts(context.Context) error   { return nil }
+func (baseOpsZero) PurgeModulePrefix(context.Context) error { return nil }
+
+func contains(s, substr string) bool {
+	return len(substr) == 0 || (len(s) >= len(substr) && stringsIndex(s, substr) >= 0)
+}
+
+func stringsIndex(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/test/testutil/fixture/run_tests.go
+++ b/test/testutil/fixture/run_tests.go
@@ -1,0 +1,58 @@
+//go:build integration
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// destroyTimeout bounds a single DestroyAll pass. Sized generously to
+// accommodate slow cloud teardowns (EKS, CloudFront) without running up
+// against typical `go test -timeout 30m` ceilings. This is an outer
+// bound — DestroyAll additionally enforces a per-fixture timeout.
+const destroyTimeout = 15 * time.Minute
+
+// runner is the interface satisfied by *testing.M; declared here so
+// runTestsWith can be unit-tested with a stub.
+type runner interface {
+	Run() int
+}
+
+// RunTests wraps testing.M.Run, then — if tests passed and the user
+// didn't opt out via AURELIAN_KEEP_FIXTURES — destroys every fixture
+// that was Setup()'d during this test binary's execution.
+//
+// Intended usage, one per integration-test package:
+//
+//	func TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }
+func RunTests(m *testing.M) int {
+	return runTestsWith(m, globalDestroyAll, os.Getenv)
+}
+
+func runTestsWith(m runner, destroyFn func(context.Context) error, getenv func(string) string) int {
+	code := m.Run()
+	if code != 0 {
+		return code
+	}
+
+	if getenv("AURELIAN_KEEP_FIXTURES") == "1" {
+		return code
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), destroyTimeout)
+	defer cancel()
+
+	if err := destroyFn(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "[fixture] cleanup failures: %v\n", err)
+		return 1
+	}
+	return code
+}
+
+func globalDestroyAll(ctx context.Context) error {
+	return globalRegistry.DestroyAll(ctx)
+}

--- a/test/testutil/fixture/run_tests_test.go
+++ b/test/testutil/fixture/run_tests_test.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package fixture
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubM struct{ code int }
+
+func (s stubM) Run() int { return s.code }
+
+func TestRunTestsWith_TestsFailed_SkipsDestroy(t *testing.T) {
+	called := false
+	got := runTestsWith(stubM{code: 2}, func(context.Context) error {
+		called = true
+		return nil
+	}, func(string) string { return "" })
+
+	if got != 2 {
+		t.Errorf("want exit code 2, got %d", got)
+	}
+	if called {
+		t.Errorf("destroy should not run on test failure")
+	}
+}
+
+func TestRunTestsWith_KeepFlagSet_SkipsDestroy(t *testing.T) {
+	called := false
+	got := runTestsWith(stubM{code: 0}, func(context.Context) error {
+		called = true
+		return nil
+	}, func(key string) string {
+		if key == "AURELIAN_KEEP_FIXTURES" {
+			return "1"
+		}
+		return ""
+	})
+
+	if got != 0 {
+		t.Errorf("want exit code 0, got %d", got)
+	}
+	if called {
+		t.Errorf("destroy should not run when AURELIAN_KEEP_FIXTURES=1")
+	}
+}
+
+func TestRunTestsWith_Success_InvokesDestroy(t *testing.T) {
+	called := false
+	got := runTestsWith(stubM{code: 0}, func(context.Context) error {
+		called = true
+		return nil
+	}, func(string) string { return "" })
+
+	if got != 0 {
+		t.Errorf("want exit code 0, got %d", got)
+	}
+	if !called {
+		t.Errorf("destroy should run on success with no opt-out")
+	}
+}
+
+func TestRunTestsWith_DestroyFailure_ReturnsOne(t *testing.T) {
+	got := runTestsWith(stubM{code: 0}, func(context.Context) error {
+		return errors.New("destroy boom")
+	}, func(string) string { return "" })
+
+	if got != 1 {
+		t.Errorf("want exit code 1 when destroy fails on otherwise-passing run, got %d", got)
+	}
+}

--- a/test/testutil/fixture/s3.go
+++ b/test/testutil/fixture/s3.go
@@ -289,7 +289,7 @@ func (f *BaseFixture) downloadArtifactsToTempDir(ctx context.Context) (string, e
 		}
 	}
 
-	f.t.Logf("terraform fixture: downloaded %d artifacts to %s", len(allKeys), tmpDir)
+	f.logf("terraform fixture: downloaded %d artifacts to %s", len(allKeys), tmpDir)
 	return tmpDir, nil
 }
 

--- a/test/testutil/fixture/s3.go
+++ b/test/testutil/fixture/s3.go
@@ -348,3 +348,57 @@ func (f *BaseFixture) putRemoteHash(ctx context.Context, hash string) error {
 
 	return nil
 }
+
+// purgeModulePrefix deletes every object under the module's S3 prefix
+// (integration-tests/<moduleDir>/). Used after a successful teardown to
+// remove the empty terraform.tfstate, the fixture.md5 hash marker, the
+// artifacts/* tree, and any terraform.tfstate.tflock left by the S3
+// backend.
+func (f *BaseFixture) purgeModulePrefix(ctx context.Context) error {
+	client, err := newS3Client(ctx)
+	if err != nil {
+		return fmt.Errorf("create S3 client: %w", err)
+	}
+
+	bucket := stateBucket
+	prefix := filepath.ToSlash(filepath.Dir(f.cfg.StateKey)) + "/"
+
+	var continuationToken *string
+	for {
+		listOutput, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            &bucket,
+			Prefix:            &prefix,
+			ContinuationToken: continuationToken,
+		})
+		if err != nil {
+			return fmt.Errorf("list module prefix: %w", err)
+		}
+
+		if len(listOutput.Contents) > 0 {
+			objects := make([]types.ObjectIdentifier, 0, len(listOutput.Contents))
+			for _, object := range listOutput.Contents {
+				if object.Key == nil {
+					continue
+				}
+				objects = append(objects, types.ObjectIdentifier{Key: object.Key})
+			}
+
+			if len(objects) > 0 {
+				_, err = client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+					Bucket: &bucket,
+					Delete: &types.Delete{Objects: objects, Quiet: aws.Bool(true)},
+				})
+				if err != nil {
+					return fmt.Errorf("delete module prefix objects: %w", err)
+				}
+			}
+		}
+
+		isTruncated := listOutput.IsTruncated != nil && *listOutput.IsTruncated
+		if !isTruncated {
+			return nil
+		}
+
+		continuationToken = listOutput.NextContinuationToken
+	}
+}

--- a/test/testutil/fixture/s3.go
+++ b/test/testutil/fixture/s3.go
@@ -384,12 +384,17 @@ func (f *BaseFixture) purgeModulePrefix(ctx context.Context) error {
 			}
 
 			if len(objects) > 0 {
-				_, err = client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+				deleteOutput, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
 					Bucket: &bucket,
 					Delete: &types.Delete{Objects: objects, Quiet: aws.Bool(true)},
 				})
 				if err != nil {
 					return fmt.Errorf("delete module prefix objects: %w", err)
+				}
+				if len(deleteOutput.Errors) > 0 {
+					e := deleteOutput.Errors[0]
+					return fmt.Errorf("delete module prefix objects: partial failure: key=%q code=%q message=%q (and %d more)",
+						aws.ToString(e.Key), aws.ToString(e.Code), aws.ToString(e.Message), len(deleteOutput.Errors)-1)
 				}
 			}
 		}

--- a/test/testutil/fixture/stack.go
+++ b/test/testutil/fixture/stack.go
@@ -41,7 +41,11 @@ func (f *BaseFixture) deployStack(ctx context.Context, hash string) error {
 	return nil
 }
 
-func (f *BaseFixture) redeployStack(ctx context.Context, hash string) error {
+// teardownStack runs `terraform destroy` using the most authoritative
+// source of the module's `.tf` files — the artifacts snapshot in S3 if
+// present, otherwise the local fixture directory. After destroy it also
+// deletes the artifacts/ prefix so a subsequent Setup uploads fresh.
+func (f *BaseFixture) teardownStack(ctx context.Context) error {
 	f.t.Log("terraform fixture action: teardown start")
 
 	tmpDir, downloadErr := f.downloadArtifactsToTempDir(ctx)
@@ -72,7 +76,17 @@ func (f *BaseFixture) redeployStack(ctx context.Context, hash string) error {
 	}
 	f.t.Log("terraform fixture action: teardown complete")
 
-	// Re-init local dir since remote artifact destroy may have changed backend state.
+	return nil
+}
+
+// redeployStack tears down existing infrastructure and deploys fresh.
+// The local directory's init may have been invalidated by the remote
+// destroy, so re-init before the deploy.
+func (f *BaseFixture) redeployStack(ctx context.Context, hash string) error {
+	if err := f.teardownStack(ctx); err != nil {
+		return err
+	}
+
 	if err := f.ops.Init(ctx, f.cfg.InitOpts...); err != nil {
 		return fmt.Errorf("terraform re-init: %w", err)
 	}

--- a/test/testutil/fixture/stack.go
+++ b/test/testutil/fixture/stack.go
@@ -41,10 +41,10 @@ func (f *BaseFixture) deployStack(ctx context.Context, hash string) error {
 	return nil
 }
 
-// teardownStack runs `terraform destroy` using the most authoritative
-// source of the module's `.tf` files — the artifacts snapshot in S3 if
-// present, otherwise the local fixture directory. After destroy it also
-// deletes the artifacts/ prefix so a subsequent Setup uploads fresh.
+// teardownStack destroys existing infrastructure using the most
+// authoritative source of .tf files — the artifacts snapshot in S3
+// if present, otherwise the local fixture directory — then deletes
+// the artifacts/ prefix from S3.
 func (f *BaseFixture) teardownStack(ctx context.Context) error {
 	f.t.Log("terraform fixture action: teardown start")
 
@@ -80,13 +80,14 @@ func (f *BaseFixture) teardownStack(ctx context.Context) error {
 }
 
 // redeployStack tears down existing infrastructure and deploys fresh.
-// The local directory's init may have been invalidated by the remote
-// destroy, so re-init before the deploy.
+// The remote destroy may have changed backend state, so the local
+// working directory is re-initialised before deploying.
 func (f *BaseFixture) redeployStack(ctx context.Context, hash string) error {
 	if err := f.teardownStack(ctx); err != nil {
 		return err
 	}
 
+	// Re-init local dir since remote artifact destroy may have changed backend state.
 	if err := f.ops.Init(ctx, f.cfg.InitOpts...); err != nil {
 		return fmt.Errorf("terraform re-init: %w", err)
 	}

--- a/test/testutil/fixture/stack.go
+++ b/test/testutil/fixture/stack.go
@@ -21,12 +21,12 @@ func (f *BaseFixture) loadOutputs(ctx context.Context) error {
 }
 
 func (f *BaseFixture) deployStack(ctx context.Context, hash string) error {
-	f.t.Log("terraform fixture action: deploy start")
+	f.logf("terraform fixture action: deploy start")
 	err := f.ops.Apply(ctx)
 	if err != nil {
 		return fmt.Errorf("terraform apply: %w", err)
 	}
-	f.t.Log("terraform fixture action: deploy complete")
+	f.logf("terraform fixture action: deploy complete")
 
 	err = f.ops.UploadArtifacts(ctx)
 	if err != nil {
@@ -46,11 +46,11 @@ func (f *BaseFixture) deployStack(ctx context.Context, hash string) error {
 // if present, otherwise the local fixture directory — then deletes
 // the artifacts/ prefix from S3.
 func (f *BaseFixture) teardownStack(ctx context.Context) error {
-	f.t.Log("terraform fixture action: teardown start")
+	f.logf("terraform fixture action: teardown start")
 
 	tmpDir, downloadErr := f.downloadArtifactsToTempDir(ctx)
 	if downloadErr != nil {
-		f.t.Logf("terraform fixture: failed to download remote artifacts, falling back to local destroy: %v", downloadErr)
+		f.logf("terraform fixture: failed to download remote artifacts, falling back to local destroy: %v", downloadErr)
 		if err := f.ops.Destroy(ctx); err != nil {
 			return fmt.Errorf("terraform destroy (fallback): %w", err)
 		}
@@ -74,7 +74,7 @@ func (f *BaseFixture) teardownStack(ctx context.Context) error {
 	if err := f.ops.DeleteArtifacts(ctx); err != nil {
 		return fmt.Errorf("delete fixture artifacts: %w", err)
 	}
-	f.t.Log("terraform fixture action: teardown complete")
+	f.logf("terraform fixture action: teardown complete")
 
 	return nil
 }

--- a/test/testutil/fixture/testmain_test.go
+++ b/test/testutil/fixture/testmain_test.go
@@ -1,0 +1,10 @@
+//go:build integration
+
+package fixture
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) { os.Exit(RunTests(m)) }


### PR DESCRIPTION
## Summary

Flip the Aurelian integration-test fixture framework from "persist by default" to **"destroy on successful package run, persist on failure or opt-out."**

- **Default:** fixtures are torn down after every test package that passes. No more idle cloud cost between runs.
- **`--keep` / `AURELIAN_KEEP_FIXTURES=1`:** opt out of post-run destroy (local iteration).
- **`--redeploy` / `AURELIAN_REDEPLOY_FIXTURES=1`:** force teardown + redeploy at Setup (replaces the old `--destroy` / `AURELIAN_DESTROY_FIXTURES`, whose name collided with the new default).
- **Any test failure** in the package keeps all its fixtures alive for debugging.
- **Default `-timeout 30m`** applied automatically in `run-integration-tests.sh` so cleanup isn't SIGKILLed on long runs.

## Behavior matrix

| Env / flags | Setup | End-of-package |
|---|---|---|
| (none) | reuse if hash matches, deploy if not | **destroy iff package passed** |
| `--keep` / `AURELIAN_KEEP_FIXTURES=1` | same | skip destroy |
| `--redeploy` / `AURELIAN_REDEPLOY_FIXTURES=1` | force teardown + redeploy | destroy iff package passed |
| both | force teardown + redeploy | skip destroy |
| any test failed | — | skip destroy regardless |

## Implementation

- Process-level fixture registry in `test/testutil/fixture/` keyed by `StateKey`, mutex-guarded, dedupes shared fixtures across tests.
- `Setup()` registers in `globalRegistry` after successful deploy/reuse.
- New `fixture.RunTests(m *testing.M) int` — each integration-test package's `TestMain` calls it. On success (unless `AURELIAN_KEEP_FIXTURES=1`), drains the registry via `DestroyAll`.
- `DestroyAll` runs each fixture's teardown under a 10-minute per-fixture context; `RunTests` wraps the whole thing in a 15-minute outer bound. Errors are aggregated via `errors.Join` so one bad fixture doesn't block the rest.
- New `PurgeModulePrefix` S3 op sweeps the entire `integration-tests/<moduleDir>/` prefix post-destroy (empty state, hash marker, artifacts, `.tflock`) and surfaces `DeleteObjects` partial-failure errors.
- `teardownStack` extracted from `redeployStack` for reuse.
- TestMain added to 12 integration-test packages.
- `BaseFixture.logf` routes log output through `testing.T.Logf` during Setup and falls back to `log.Printf` afterward — fixes a panic where `teardownStack` tried to log to a completed test from the TestMain drain.

## Scripts

- `run-integration-tests.sh`: removed `--destroy`, added `--keep` and `--redeploy`, defaulted `-timeout 30m`, updated help + examples.
- `destroy-integration-fixtures.sh`: new bulk-cleanup tool for orphaned / SIGINT'd / debug-held fixtures. The preamble documents it as a complement to the now-automatic routine cleanup.

## Test plan

Validated end-to-end against the real integration state bucket:

- [x] Canary (`TestDestroyAll_RemovesModulePrefix`) provisions an S3 bucket, calls `DestroyAll`, asserts the S3 module prefix is empty after — passes.
- [x] `TestEC2IMDSEnricher` with default flags → fixture deployed, tests pass, TestMain drains, S3 prefix empty after.
- [x] Same test with `--keep` → S3 prefix populated after (destroy skipped).
- [x] Same test with `--redeploy --keep` → log shows `teardown + redeploy (forced)` even on hash match; S3 populated after.
- [x] Same test with default flags again → reuses fixture, passes, TestMain drains, S3 prefix empty after.
- [x] `./scripts/run-integration-tests.sh --destroy` → exits with `Unknown argument: --destroy`.
- [x] All 17 fixture package unit tests pass (registry, RunTests decision matrix, lifecycle branches, env var regression).
- [x] `go vet -tags=integration` clean across every package that gained a TestMain.

Failure-path (any test fail → keep fixtures) is covered by `TestRunTestsWith_TestsFailed_SkipsDestroy` in the unit suite.