### PR TITLE
fix(aws/enumeration): warn and continue on AccessDenied instead of aborting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse v0.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
-	github.com/aws/aws-sdk-go-v2 v1.41.4
+	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/account v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13
@@ -45,6 +45,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.54.4
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.63.2
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.0
+	github.com/aws/aws-sdk-go-v2/service/configservice v1.62.2
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.5
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.202.4
 	github.com/aws/aws-sdk-go-v2/service/efs v1.41.10
@@ -63,7 +64,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.13
-	github.com/aws/smithy-go v1.24.2
+	github.com/aws/smithy-go v1.25.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fatih/color v1.18.0
@@ -214,8 +215,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNx
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
-github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
+github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.5 h1:zWFmPmgw4sveAYi1mRqG+E/g0461cJ5M4bJ8/nc6d3Q=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.5/go.mod h1:nVUlMLVV8ycXSb7mSkcNu9e3v/1TJq2RTlrPwhYWr5c=
 github.com/aws/aws-sdk-go-v2/config v1.32.7 h1:vxUyWGUwmkQ2g19n7JY/9YL8MfAIl7bTesIUykECXmY=
@@ -118,10 +118,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.7 h1:tHK47VqqtJxOymRrNtUXN5SP/zUT
 github.com/aws/aws-sdk-go-v2/credentials v1.19.7/go.mod h1:qOZk8sPDrxhf+4Wf4oT2urYJrYt3RejHSzgAquYeppw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 h1:I0GyV8wiYrP8XpA70g1HBcQO1JlQxCMTW9npl5UbDHY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17/go.mod h1:tyw7BOl5bBe/oqvoIeECFJjMdzXoa/dfVz3QQ5lgHGA=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 h1:CNXO7mvgThFGqOFgbNAP2nol2qAWBOGfqR/7tQlvLmc=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20/go.mod h1:oydPDJKcfMhgfcgBUZaG+toBbwy8yPWubJXBVERtI4o=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 h1:tN6W/hg+pkM+tf9XDkWUbDEjGLb+raoBMFsTodcoYKw=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20/go.mod h1:YJ898MhD067hSHA6xYCx5ts/jEd8BSOLtQDL3iZsvbc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22/go.mod h1:KIpEUx0JuRZLO7U6cbV204cWAEco2iC3l061IxlwLtI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 h1:JqcdRG//czea7Ppjb+g/n4o8i/R50aTBHkA7vu0lK+k=
@@ -140,6 +140,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.63.2 h1:9Zc/otv2WzK7gbhXI
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.63.2/go.mod h1:dvfInk3WN/sz8is2m5iN5EFYQzIXcQLaT2UnauE8uL4=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.0 h1:FQQi7oGHGAn3aJJcq0rntRCy3xOfNw7u0FUUm2+6+AU=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.58.0/go.mod h1:bBgsO3htjygdyPTgT0Fou14A5VAQaLqiJ8YE2SW4NKw=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.62.2 h1:iyAjN2NU9dMlpnN1ykTQaN/yMfI4HSae10cfLykqiXw=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.62.2/go.mod h1:zesNwMWxY+ZQZzN+npfj6KwNWPSXUGNmsXGv93b4GYA=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.5 h1:iNNJ6ZrQO37Xh12XjNncS3fq/11l1TzyZwBWcZMHWkY=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.5/go.mod h1:auLb1gCiI54TM7iUxSYu5MYSimWr0fL6t5/PgxkJOr0=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.202.4 h1:gdFRXlTMgV0+yrhQLAJKb+vX2K32Vw3n2TntDd+8AEM=
@@ -192,8 +194,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 h1:5fFjR/ToSOzB2OQ/XqWpZBmNvmP/
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6/go.mod h1:qgFDZQSD/Kys7nJnVqYlWKnh0SSdMjAi0uSwON4wgYQ=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.13 h1:Iu9ue+m7Ff/7S/QckPSB2kqkKHziyCwr/4DNuVvsCaE=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.13/go.mod h1:CL79M20C9MGo2r0/MT7i9OcM/RY25wfNz043aG2fBvw=
-github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
-github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
+github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/pkg/aws/enumeration/amplify_enumerator.go
+++ b/pkg/aws/enumeration/amplify_enumerator.go
@@ -3,7 +3,6 @@ package enumeration
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -96,16 +95,6 @@ func (e *AmplifyAppEnumerator) EnumerateByARN(arn string, out *pipeline.P[output
 	return nil
 }
 
-// isRegionUnsupportedError returns true when the error indicates the AWS service
-// is not available in the target region (DNS resolution failure or explicit
-// region-not-supported response).
-func isRegionUnsupportedError(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "no such host") ||
-		strings.Contains(msg, "could not resolve endpoint") ||
-		strings.Contains(msg, "EndpointNotFound")
-}
-
 func (e *AmplifyAppEnumerator) listAppsInRegion(region, accountID string, out *pipeline.P[output.AWSResource]) error {
 	cfg, err := e.provider.GetAWSConfig(region)
 	if err != nil {
@@ -120,8 +109,7 @@ func (e *AmplifyAppEnumerator) listAppsInRegion(region, accountID string, out *p
 			NextToken: nextToken,
 		})
 		if err != nil {
-			if isRegionUnsupportedError(err) {
-				slog.Debug("amplify not available in region, skipping", "region", region)
+			if handled := handleListError(err, "AWS::Amplify::App", region); handled == nil {
 				return false, nil
 			}
 			return false, fmt.Errorf("list amplify apps in %s: %w", region, err)

--- a/pkg/aws/enumeration/amplify_enumerator.go
+++ b/pkg/aws/enumeration/amplify_enumerator.go
@@ -19,12 +19,14 @@ import (
 type AmplifyAppEnumerator struct {
 	plugin.AWSCommonRecon
 	provider *AWSConfigProvider
+	fallback *ConfigFallback
 }
 
-func NewAmplifyAppEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider) *AmplifyAppEnumerator {
+func NewAmplifyAppEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider, fallback *ConfigFallback) *AmplifyAppEnumerator {
 	return &AmplifyAppEnumerator{
 		AWSCommonRecon: opts,
 		provider:       provider,
+		fallback:       fallback,
 	}
 }
 
@@ -109,7 +111,13 @@ func (e *AmplifyAppEnumerator) listAppsInRegion(region, accountID string, out *p
 			NextToken: nextToken,
 		})
 		if err != nil {
-			if handled := handleListError(err, "AWS::Amplify::App", region); handled == nil {
+			var fb fallbackFn
+			if e.fallback != nil {
+				fb = func() error {
+					return e.fallback.Attempt(context.Background(), "AWS::Amplify::App", region, out)
+				}
+			}
+			if handled := handleListError(err, "AWS::Amplify::App", region, fb); handled == nil {
 				return false, nil
 			}
 			return false, fmt.Errorf("list amplify apps in %s: %w", region, err)

--- a/pkg/aws/enumeration/cloud_control_enumerator.go
+++ b/pkg/aws/enumeration/cloud_control_enumerator.go
@@ -21,6 +21,7 @@ type CloudControlEnumerator struct {
 	plugin.AWSCommonRecon
 	CrossRegionActor *ratelimit.CrossRegionActor
 	provider         *AWSConfigProvider
+	fallback         *ConfigFallback
 }
 
 func NewCloudControlEnumerator(options plugin.AWSCommonRecon) *CloudControlEnumerator {
@@ -93,6 +94,34 @@ func (cc *CloudControlEnumerator) getResourceByARN(arn string) (output.AWSResour
 
 	cr := awshelpers.CloudControlToAWSResource(*result.ResourceDescription, resourceType, accountID, region)
 	return cr, nil
+}
+
+// getResourceByTypeAndIdentifier fetches a single resource by an already-known
+// resource type + primary identifier, skipping the ARN-parse step of
+// getResourceByARN. Used by ConfigFallback after translating a Config
+// ResourceIdentifier; all other callers should prefer getResourceByARN.
+func (cc *CloudControlEnumerator) getResourceByTypeAndIdentifier(
+	region, resourceType, identifier string,
+) (output.AWSResource, error) {
+	client, err := cc.newCloudControlClient(region)
+	if err != nil {
+		return output.AWSResource{}, fmt.Errorf("create client: %w", err)
+	}
+
+	accountID, err := cc.provider.GetAccountID(region)
+	if err != nil {
+		return output.AWSResource{}, err
+	}
+
+	result, err := client.GetResource(context.Background(), &cloudcontrol.GetResourceInput{
+		TypeName:   aws.String(resourceType),
+		Identifier: aws.String(identifier),
+	})
+	if err != nil {
+		return output.AWSResource{}, fmt.Errorf("get %s %s: %w", resourceType, identifier, err)
+	}
+
+	return awshelpers.CloudControlToAWSResource(*result.ResourceDescription, resourceType, accountID, region), nil
 }
 
 func (cc *CloudControlEnumerator) resolveARNTarget(resourceARN string) (string, string, string, error) {
@@ -242,7 +271,13 @@ func (cc *CloudControlEnumerator) listInRegionByType(region, resourceType string
 	}
 
 	err = cc.listByType(client, accountID, region, resourceType, out)
-	if handled := handleListError(err, resourceType, region); handled == nil {
+	var fb fallbackFn
+	if cc.fallback != nil {
+		fb = func() error {
+			return cc.fallback.Attempt(context.Background(), resourceType, region, out)
+		}
+	}
+	if handled := handleListError(err, resourceType, region, fb); handled == nil {
 		return nil
 	}
 	slog.Warn("error listing resources", "type", resourceType, "region", region, "error", err)

--- a/pkg/aws/enumeration/cloud_control_enumerator.go
+++ b/pkg/aws/enumeration/cloud_control_enumerator.go
@@ -51,11 +51,15 @@ func (cc *CloudControlEnumerator) List(identifier string, out *pipeline.P[output
 
 func (cc *CloudControlEnumerator) EnumerateByARN(resourceARN string, out *pipeline.P[output.AWSResource]) error {
 	resource, err := cc.getResourceByARN(resourceARN)
-	if cc.isSkippableError(err) {
-		slog.Debug("skipping arn", "arn", resourceARN, "error", err)
-		return nil
-	}
 	if err != nil {
+		if isUnsupportedTypeError(err) || isRegionUnsupportedError(err) {
+			slog.Debug("skipping arn", "arn", resourceARN, "error", err)
+			return nil
+		}
+		if isAccessDeniedError(err) {
+			slog.Warn("access denied fetching resource, skipping", "arn", resourceARN, "error", err)
+			return nil
+		}
 		return err
 	}
 
@@ -238,16 +242,11 @@ func (cc *CloudControlEnumerator) listInRegionByType(region, resourceType string
 	}
 
 	err = cc.listByType(client, accountID, region, resourceType, out)
-	if cc.isSkippableError(err) {
-		slog.Debug("skipping resource type", "type", resourceType, "region", region, "error", err)
+	if handled := handleListError(err, resourceType, region); handled == nil {
 		return nil
 	}
-	if err != nil {
-		slog.Warn("error listing resources", "type", resourceType, "region", region, "error", err)
-		return err
-	}
-
-	return nil
+	slog.Warn("error listing resources", "type", resourceType, "region", region, "error", err)
+	return err
 }
 
 func (cc *CloudControlEnumerator) listByType(
@@ -281,16 +280,6 @@ func (cc *CloudControlEnumerator) listByType(
 		nextToken = result.NextToken
 		return nextToken != nil, nil
 	})
-}
-
-func (cc *CloudControlEnumerator) isSkippableError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	return strings.Contains(s, "TypeNotFoundException") ||
-		strings.Contains(s, "UnsupportedActionException") ||
-		strings.Contains(s, "AccessDeniedException")
 }
 
 func (cc *CloudControlEnumerator) newCloudControlClient(region string) (*cloudcontrol.Client, error) {

--- a/pkg/aws/enumeration/cloud_control_enumerator_test.go
+++ b/pkg/aws/enumeration/cloud_control_enumerator_test.go
@@ -38,3 +38,13 @@ func TestResolveARNTarget_InvalidARNFails(t *testing.T) {
 	_, _, _, err := cc.resolveARNTarget("not-an-arn")
 	require.Error(t, err)
 }
+
+func TestGetResourceByTypeAndIdentifier_SkipsARNParse(t *testing.T) {
+	// Smoke test to pin the function signature; real SDK integration is
+	// covered by the CloudControlEnumerator integration suite. The intent of
+	// this unit test is that the helper exists and compiles — full behavioral
+	// coverage is in the integration test and in ConfigFallback tests that
+	// swap this helper via a seam.
+	cc := &CloudControlEnumerator{}
+	_ = cc.getResourceByTypeAndIdentifier // method must exist
+}

--- a/pkg/aws/enumeration/config_fallback.go
+++ b/pkg/aws/enumeration/config_fallback.go
@@ -1,0 +1,309 @@
+package enumeration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/configservice"
+	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+	awshelpers "github.com/praetorian-inc/aurelian/internal/helpers/aws"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+)
+
+// errConfigNoRecorder is the cached reason when DescribeConfigurationRecorderStatus
+// returns no recorders for the region.
+var errConfigNoRecorder = errors.New("no config recorder in region")
+
+// errConfigNoRecords is the reason returned when the recorder is up but
+// ListDiscoveredResources returned zero records for this (type, region). This
+// does NOT poison the region cache; only this (type, region) pair is marked
+// exhausted.
+var errConfigNoRecords = errors.New("no config records for resource type in region")
+
+// errHydrationBlocked is the cached reason when Config listed records but every
+// CloudControl GetResource call for them failed. Indicates the region is
+// unusable for the rest of the run.
+var errHydrationBlocked = errors.New("cloudcontrol get denied in region")
+
+type regionState int
+
+const (
+	regionUnknown regionState = iota
+	regionAvailable
+	regionUnavailable
+	regionHydrationBlocked
+)
+
+type regionStateEntry struct {
+	mu      sync.Mutex
+	state   regionState
+	reason  error
+	logOnce sync.Once
+}
+
+// ConfigFallback wraps AWS Config ListDiscoveredResources + CloudControl
+// GetResource to restore visibility when a primary list call is denied by an
+// SCP or IAM policy. Callers invoke Attempt from within a fallback closure
+// passed to handleListError.
+type ConfigFallback struct {
+	provider   *AWSConfigProvider
+	cc         *CloudControlEnumerator
+	translator *configIdentifier
+	regions    sync.Map // map[string]*regionStateEntry
+
+	// Test seams; production callers leave these nil and the real SDK paths
+	// run via the provider + cc fields.
+	describeRecorders func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error)
+	listDiscovered    func(ctx context.Context, region, resourceType string) ([]configtypes.ResourceIdentifier, error)
+	hydrate           func(region, resourceType, identifier string) (output.AWSResource, error)
+}
+
+// NewConfigFallback constructs a ConfigFallback that shares provider and
+// CloudControl state with the rest of the enumerator pipeline.
+func NewConfigFallback(provider *AWSConfigProvider, cc *CloudControlEnumerator) *ConfigFallback {
+	return &ConfigFallback{
+		provider:   provider,
+		cc:         cc,
+		translator: newConfigIdentifier(),
+	}
+}
+
+// Attempt runs the Config fallback for the given resource type in the given
+// region, emitting hydrated resources into out. Returns nil on at least one
+// successful emission; errFallbackExhausted otherwise.
+func (f *ConfigFallback) Attempt(
+	ctx context.Context,
+	resourceType, region string,
+	out *pipeline.P[output.AWSResource],
+) error {
+	if awshelpers.IsGlobalService(resourceType) {
+		region = "us-east-1"
+	}
+
+	if entry, ok := f.regions.Load(region); ok {
+		e := entry.(*regionStateEntry)
+		e.mu.Lock()
+		state, reason := e.state, e.reason
+		e.mu.Unlock()
+		if state == regionUnavailable || state == regionHydrationBlocked {
+			return fmt.Errorf("%w: %w", errFallbackExhausted, reason)
+		}
+	}
+
+	entryVal, _ := f.regions.LoadOrStore(region, &regionStateEntry{})
+	entry := entryVal.(*regionStateEntry)
+
+	if err := f.ensureRegionProbed(ctx, region, entry); err != nil {
+		return err
+	}
+
+	return f.listAndHydrate(ctx, resourceType, region, entry, out)
+}
+
+// ensureRegionProbed runs DescribeConfigurationRecorderStatus exactly once per
+// region per run and caches the outcome. Concurrent callers for the same region
+// serialize on entry.mu; only the first one probes.
+func (f *ConfigFallback) ensureRegionProbed(
+	ctx context.Context,
+	region string,
+	entry *regionStateEntry,
+) error {
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	if entry.state == regionAvailable {
+		return nil
+	}
+	if entry.state == regionUnavailable || entry.state == regionHydrationBlocked {
+		return fmt.Errorf("%w: %w", errFallbackExhausted, entry.reason)
+	}
+
+	statuses, err := f.describeRecorderStatus(ctx, region)
+	switch {
+	case err == nil && !hasActiveRecorder(statuses):
+		entry.state = regionUnavailable
+		entry.reason = errConfigNoRecorder
+		entry.logOnce.Do(func() {
+			slog.Info("config recorder unavailable in region",
+				"region", region, "reason", errConfigNoRecorder.Error())
+		})
+		return fmt.Errorf("%w: %w", errFallbackExhausted, errConfigNoRecorder)
+	case err == nil:
+		entry.state = regionAvailable
+		return nil
+	case isAccessDeniedError(err):
+		entry.state = regionUnavailable
+		entry.reason = err
+		entry.logOnce.Do(func() {
+			slog.Info("config recorder unavailable in region",
+				"region", region, "reason", err.Error())
+		})
+		return fmt.Errorf("%w: %w", errFallbackExhausted, err)
+	default:
+		// Transient; do not cache.
+		return fmt.Errorf("%w: describe recorder status: %w", errFallbackExhausted, err)
+	}
+}
+
+func (f *ConfigFallback) describeRecorderStatus(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+	if f.describeRecorders != nil {
+		return f.describeRecorders(ctx, region)
+	}
+	cfg, err := f.provider.GetAWSConfig(region)
+	if err != nil {
+		return nil, fmt.Errorf("get aws config for %s: %w", region, err)
+	}
+	client := configservice.NewFromConfig(*cfg)
+	resp, err := client.DescribeConfigurationRecorderStatus(ctx,
+		&configservice.DescribeConfigurationRecorderStatusInput{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.ConfigurationRecordersStatus, nil
+}
+
+// listAndHydrate performs the type-specific part of the fallback: paginated
+// ListDiscoveredResources, per-record identifier translation, and CloudControl
+// GetResource hydration. Step numbers refer to the spec.
+func (f *ConfigFallback) listAndHydrate(
+	ctx context.Context,
+	resourceType, region string,
+	entry *regionStateEntry,
+	out *pipeline.P[output.AWSResource],
+) error {
+	records, err := f.listDiscoveredResources(ctx, region, resourceType)
+	if err != nil {
+		if isAccessDeniedError(err) {
+			f.markRegionUnavailable(entry, region, err)
+		}
+		return fmt.Errorf("%w: list discovered resources: %w", errFallbackExhausted, err)
+	}
+	if len(records) == 0 {
+		return fmt.Errorf("%w: %w", errFallbackExhausted, errConfigNoRecords)
+	}
+
+	// accountID is only needed for the real translation path; when the hydrate
+	// seam is injected (tests), skip the provider call.
+	accountID := ""
+	if f.hydrate == nil {
+		accountID, err = f.provider.GetAccountID(region)
+		if err != nil {
+			return fmt.Errorf("%w: get account id: %w", errFallbackExhausted, err)
+		}
+	}
+
+	hydrated := 0
+	for _, rec := range records {
+		identifier, ok := f.translator.Translate(resourceType, rec, accountID, region)
+		if !ok {
+			slog.Debug("skipping config record: no identifier",
+				"type", resourceType,
+				"resource_id", aws.ToString(rec.ResourceId),
+				"resource_name", aws.ToString(rec.ResourceName),
+			)
+			continue
+		}
+		resource, err := f.hydrateIdentifier(region, resourceType, identifier)
+		if err != nil {
+			slog.Debug("skipping config record: get failed",
+				"type", resourceType, "identifier", identifier, "error", err)
+			continue
+		}
+		out.Send(resource)
+		hydrated++
+	}
+
+	if hydrated == 0 {
+		f.markRegionHydrationBlocked(entry, region)
+		return fmt.Errorf("%w: %w", errFallbackExhausted, errHydrationBlocked)
+	}
+	slog.Debug("config fallback emitted resources",
+		"type", resourceType, "region", region, "count", hydrated)
+	return nil
+}
+
+func (f *ConfigFallback) listDiscoveredResources(ctx context.Context, region, resourceType string) ([]configtypes.ResourceIdentifier, error) {
+	if f.listDiscovered != nil {
+		return f.listDiscovered(ctx, region, resourceType)
+	}
+	cfg, err := f.provider.GetAWSConfig(region)
+	if err != nil {
+		return nil, fmt.Errorf("get aws config for %s: %w", region, err)
+	}
+	client := configservice.NewFromConfig(*cfg)
+
+	var (
+		all       []configtypes.ResourceIdentifier
+		nextToken *string
+	)
+	for {
+		input := &configservice.ListDiscoveredResourcesInput{
+			ResourceType: configtypes.ResourceType(resourceType),
+		}
+		if nextToken != nil {
+			input.NextToken = nextToken
+		}
+		resp, err := client.ListDiscoveredResources(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, resp.ResourceIdentifiers...)
+		if resp.NextToken == nil {
+			return all, nil
+		}
+		nextToken = resp.NextToken
+	}
+}
+
+func (f *ConfigFallback) hydrateIdentifier(region, resourceType, identifier string) (output.AWSResource, error) {
+	if f.hydrate != nil {
+		return f.hydrate(region, resourceType, identifier)
+	}
+	return f.cc.getResourceByTypeAndIdentifier(region, resourceType, identifier)
+}
+
+func (f *ConfigFallback) markRegionUnavailable(entry *regionStateEntry, region string, reason error) {
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.state == regionAvailable {
+		entry.state = regionUnavailable
+		entry.reason = reason
+		entry.logOnce.Do(func() {
+			slog.Info("config list access denied in region; treating as region-wide unavailable",
+				"region", region, "reason", reason.Error())
+		})
+	}
+}
+
+func (f *ConfigFallback) markRegionHydrationBlocked(entry *regionStateEntry, region string) {
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	// Only transition from regionAvailable. If a concurrent listAndHydrate
+	// already observed list AccessDenied and set regionUnavailable, the
+	// stronger signal wins — do not downgrade it.
+	if entry.state == regionAvailable {
+		entry.state = regionHydrationBlocked
+		entry.reason = errHydrationBlocked
+		entry.logOnce.Do(func() {
+			slog.Info("cloudcontrol get denied in region; config fallback ineffective",
+				"region", region)
+		})
+	}
+}
+
+// hasActiveRecorder reports whether at least one recorder in statuses is
+// actively recording. A recorder that exists but is stopped yields stale
+// ListDiscoveredResources results and is treated the same as no recorder.
+func hasActiveRecorder(statuses []configtypes.ConfigurationRecorderStatus) bool {
+	for _, s := range statuses {
+		if s.Recording {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/aws/enumeration/config_fallback_integration_test.go
+++ b/pkg/aws/enumeration/config_fallback_integration_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package enumeration
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/configservice"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_ConfigFallback_DiscoversBucketsViaConfig deploys an S3 bucket and an
+// AWS Config recorder that tracks S3 buckets, then invokes ConfigFallback
+// directly to verify it discovers the bucket end-to-end (ListDiscoveredResources
+// → CloudControl GetResource → pipeline emission).
+//
+// This test does NOT simulate the SCP denial of s3:ListAllMyBuckets — it
+// exercises the ConfigFallback path directly with a real Config recorder.
+// Manual verification against the LAB-2525 pilot covers the SCP path.
+func Test_ConfigFallback_DiscoversBucketsViaConfig(t *testing.T) {
+	fixture := testutil.NewAWSFixture(t, "aws/enumeration/config-fallback")
+	fixture.Setup()
+
+	opts := plugin.AWSCommonRecon{
+		Regions:     []string{fixture.Output("region")},
+		Concurrency: 2,
+	}
+	provider := NewAWSConfigProvider(opts)
+	cc := NewCloudControlEnumeratorWithProvider(opts, provider)
+	fallback := NewConfigFallback(provider, cc)
+
+	var logBuf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// Pre-flight: wait for the recorder's first Success status. Until this
+	// fires, discovery has not yet run at all, so polling ListDiscoveredResources
+	// will return confusing empties.
+	cfgSDK, err := provider.GetAWSConfig(fixture.Output("region"))
+	require.NoError(t, err)
+	cfgClient := configservice.NewFromConfig(*cfgSDK)
+	require.Eventually(t, func() bool {
+		resp, err := cfgClient.DescribeConfigurationRecorderStatus(
+			context.Background(),
+			&configservice.DescribeConfigurationRecorderStatusInput{},
+		)
+		if err != nil || len(resp.ConfigurationRecordersStatus) == 0 {
+			return false
+		}
+		return aws.ToString(resp.ConfigurationRecordersStatus[0].LastStatus) == "Success"
+	}, 5*time.Minute, 15*time.Second, "recorder never reached Success status")
+
+	// Bounded retry on errConfigNoRecords: the recorder can take 10-15 minutes
+	// after first Success to populate the baseline snapshot.
+	var (
+		got     []output.AWSResource
+		lastErr error
+	)
+	const (
+		maxAttempts    = 40
+		attemptBackoff = 30 * time.Second
+	)
+	for attempt := range maxAttempts {
+		out := pipeline.New[output.AWSResource]()
+		done := make(chan []output.AWSResource, 1)
+		go func() {
+			var collected []output.AWSResource
+			for r := range out.Range() {
+				collected = append(collected, r)
+			}
+			done <- collected
+		}()
+
+		lastErr = fallback.Attempt(context.Background(), "AWS::S3::Bucket", fixture.Output("region"), out)
+		out.Close()
+		require.NoError(t, out.Wait())
+		got = <-done
+		if lastErr == nil {
+			break
+		}
+		if !errors.Is(lastErr, errConfigNoRecords) {
+			break
+		}
+		if attempt == maxAttempts-1 {
+			break
+		}
+		t.Logf("recorder not yet populated (attempt %d/%d); retrying in %s", attempt+1, maxAttempts, attemptBackoff)
+		time.Sleep(attemptBackoff)
+	}
+
+	require.NoError(t, lastErr, "fallback must eventually succeed (recorder baseline takes ~10-15min on cold start)")
+
+	wantBucket := fixture.Output("target_bucket_name")
+
+	found := false
+	for _, r := range got {
+		if r.ResourceID == wantBucket {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected target bucket %q in fallback output; got %d resources", wantBucket, len(got))
+
+	logs := logBuf.String()
+	assert.NotContains(t, logs, "config recorder unavailable in region",
+		"must not log recorder-unavailable when recorder is recording")
+	assert.NotContains(t, logs, "cloudcontrol get denied in region",
+		"must not log hydration-blocked on happy path")
+	// Expect the success debug line somewhere in the run.
+	assert.Contains(t, strings.ToLower(logs), "config fallback emitted resources")
+}

--- a/pkg/aws/enumeration/config_fallback_test.go
+++ b/pkg/aws/enumeration/config_fallback_test.go
@@ -1,0 +1,309 @@
+package enumeration
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeConfigFallback builds a ConfigFallback with all SDK calls replaced by
+// closures under test control.
+type fakeConfigFallback struct {
+	describeStatus func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error)
+	listDiscovered func(ctx context.Context, region, resourceType string) ([]configtypes.ResourceIdentifier, error)
+	hydrate        func(region, resourceType, identifier string) (output.AWSResource, error)
+}
+
+func (f *fakeConfigFallback) build() *ConfigFallback {
+	return &ConfigFallback{
+		translator:        newConfigIdentifier(),
+		describeRecorders: f.describeStatus,
+		listDiscovered:    f.listDiscovered,
+		hydrate:           f.hydrate,
+	}
+}
+
+func collectAttempt(t *testing.T, fb *ConfigFallback, resourceType, region string) ([]output.AWSResource, error) {
+	t.Helper()
+	out := pipeline.New[output.AWSResource]()
+	var got []output.AWSResource
+	var collectWG sync.WaitGroup
+	collectWG.Add(1)
+	go func() {
+		defer collectWG.Done()
+		for r := range out.Range() {
+			got = append(got, r)
+		}
+	}()
+	err := fb.Attempt(context.Background(), resourceType, region, out)
+	out.Close()
+	require.NoError(t, out.Wait())
+	collectWG.Wait()
+	return got, err
+}
+
+func accessDenied(msg string) error {
+	return &smithy.GenericAPIError{Code: "AccessDeniedException", Message: msg}
+}
+
+func TestConfigFallback_RecorderProbeAccessDeniedCachesRegionUnavailable(t *testing.T) {
+	var calls atomic.Int32
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			calls.Add(1)
+			return nil, accessDenied("config denied")
+		},
+	}
+	fb := f.build()
+
+	_, err1 := collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+	assert.ErrorIs(t, err1, errFallbackExhausted)
+
+	_, err2 := collectAttempt(t, fb, "AWS::Amplify::App", "us-east-1")
+	assert.ErrorIs(t, err2, errFallbackExhausted)
+
+	assert.Equal(t, int32(1), calls.Load(), "recorder probe must run exactly once per region")
+}
+
+func TestConfigFallback_RecorderProbeEmptyCachesRegionUnavailable(t *testing.T) {
+	var calls atomic.Int32
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			calls.Add(1)
+			return nil, nil // no recorders configured
+		},
+	}
+	fb := f.build()
+
+	_, err1 := collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+	assert.ErrorIs(t, err1, errFallbackExhausted)
+
+	_, err2 := collectAttempt(t, fb, "AWS::Amplify::App", "us-east-1")
+	assert.ErrorIs(t, err2, errFallbackExhausted)
+
+	assert.Equal(t, int32(1), calls.Load(), "recorder probe must run exactly once per region")
+}
+
+func TestConfigFallback_RecorderProbeTransientErrorDoesNotCache(t *testing.T) {
+	var calls atomic.Int32
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			calls.Add(1)
+			return nil, errors.New("throttled")
+		},
+	}
+	fb := f.build()
+
+	_, err1 := collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+	assert.ErrorIs(t, err1, errFallbackExhausted)
+
+	_, err2 := collectAttempt(t, fb, "AWS::Amplify::App", "us-east-1")
+	assert.ErrorIs(t, err2, errFallbackExhausted)
+
+	assert.Equal(t, int32(2), calls.Load(), "transient errors must not cache the region")
+}
+
+func TestConfigFallback_GlobalServiceNormalizesToUSEast1(t *testing.T) {
+	var seenRegion string
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			seenRegion = region
+			return nil, accessDenied("x")
+		},
+	}
+	fb := f.build()
+
+	_, _ = collectAttempt(t, fb, "AWS::CloudFront::Distribution", "ap-northeast-1")
+	assert.Equal(t, "us-east-1", seenRegion, "global service types must normalize region to us-east-1")
+}
+
+func TestConfigFallback_RecorderStoppedTreatedAsUnavailable(t *testing.T) {
+	var calls atomic.Int32
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			calls.Add(1)
+			return []configtypes.ConfigurationRecorderStatus{{Recording: false}}, nil
+		},
+	}
+	fb := f.build()
+
+	_, err1 := collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+	assert.ErrorIs(t, err1, errFallbackExhausted)
+	assert.ErrorIs(t, err1, errConfigNoRecorder)
+
+	_, err2 := collectAttempt(t, fb, "AWS::Amplify::App", "us-east-1")
+	assert.ErrorIs(t, err2, errFallbackExhausted)
+
+	assert.Equal(t, int32(1), calls.Load(), "stopped recorder must be cached as unavailable, probed once")
+}
+
+func okStatus() []configtypes.ConfigurationRecorderStatus {
+	return []configtypes.ConfigurationRecorderStatus{{Recording: true}}
+}
+
+func TestConfigFallback_SuccessEmitsHydratedResources(t *testing.T) {
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			return okStatus(), nil
+		},
+		listDiscovered: func(ctx context.Context, region, resourceType string) ([]configtypes.ResourceIdentifier, error) {
+			return []configtypes.ResourceIdentifier{
+				{ResourceName: aws.String("bucket-a"), ResourceId: aws.String("bucket-a")},
+				{ResourceName: aws.String("bucket-b"), ResourceId: aws.String("bucket-b")},
+			}, nil
+		},
+		hydrate: func(region, resourceType, identifier string) (output.AWSResource, error) {
+			return output.AWSResource{ResourceType: resourceType, ResourceID: identifier, Region: region}, nil
+		},
+	}
+	fb := f.build()
+
+	got, err := collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+	assert.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "bucket-a", got[0].ResourceID)
+	assert.Equal(t, "bucket-b", got[1].ResourceID)
+}
+
+func TestConfigFallback_EmptyListExhaustsTypeWithoutPoisoningRegion(t *testing.T) {
+	listCalls := 0
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			return okStatus(), nil
+		},
+		listDiscovered: func(ctx context.Context, region, resourceType string) ([]configtypes.ResourceIdentifier, error) {
+			listCalls++
+			return nil, nil
+		},
+		hydrate: func(region, resourceType, identifier string) (output.AWSResource, error) {
+			return output.AWSResource{}, errors.New("should not be called")
+		},
+	}
+	fb := f.build()
+
+	_, err1 := collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+	assert.ErrorIs(t, err1, errFallbackExhausted)
+	assert.ErrorIs(t, err1, errConfigNoRecords, "empty list must wrap errConfigNoRecords")
+
+	_, err2 := collectAttempt(t, fb, "AWS::Amplify::App", "us-east-1")
+	assert.ErrorIs(t, err2, errFallbackExhausted)
+
+	assert.Equal(t, 2, listCalls, "empty list must not cache the region; each type re-probes")
+}
+
+func TestConfigFallback_ListAccessDeniedCachesRegionUnavailable(t *testing.T) {
+	listCalls := 0
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			return okStatus(), nil
+		},
+		listDiscovered: func(ctx context.Context, region, resourceType string) ([]configtypes.ResourceIdentifier, error) {
+			listCalls++
+			return nil, accessDenied("list denied")
+		},
+	}
+	fb := f.build()
+
+	_, err1 := collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+	assert.ErrorIs(t, err1, errFallbackExhausted)
+
+	_, err2 := collectAttempt(t, fb, "AWS::Amplify::App", "us-east-1")
+	assert.ErrorIs(t, err2, errFallbackExhausted)
+
+	assert.Equal(t, 1, listCalls, "list AccessDenied is region-wide; subsequent types short-circuit")
+}
+
+func TestConfigFallback_AllHydrationFailsTransitionsToHydrationBlocked(t *testing.T) {
+	hydrateCalls := 0
+	listCalls := 0
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			return okStatus(), nil
+		},
+		listDiscovered: func(ctx context.Context, region, resourceType string) ([]configtypes.ResourceIdentifier, error) {
+			listCalls++
+			return []configtypes.ResourceIdentifier{
+				{ResourceName: aws.String("x")}, {ResourceName: aws.String("y")},
+			}, nil
+		},
+		hydrate: func(region, resourceType, identifier string) (output.AWSResource, error) {
+			hydrateCalls++
+			return output.AWSResource{}, accessDenied("get denied")
+		},
+	}
+	fb := f.build()
+
+	_, err1 := collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+	assert.ErrorIs(t, err1, errFallbackExhausted)
+
+	_, err2 := collectAttempt(t, fb, "AWS::Amplify::App", "us-east-1")
+	assert.ErrorIs(t, err2, errFallbackExhausted)
+
+	assert.Equal(t, 1, listCalls, "hydrationBlocked short-circuits subsequent types at step 2")
+	assert.Equal(t, 2, hydrateCalls, "only the first type hydrates")
+}
+
+func TestConfigFallback_PartialHydrationStillSucceeds(t *testing.T) {
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			return okStatus(), nil
+		},
+		listDiscovered: func(ctx context.Context, region, resourceType string) ([]configtypes.ResourceIdentifier, error) {
+			return []configtypes.ResourceIdentifier{
+				{ResourceName: aws.String("ok")},
+				{ResourceName: aws.String("broken")},
+			}, nil
+		},
+		hydrate: func(region, resourceType, identifier string) (output.AWSResource, error) {
+			if identifier == "broken" {
+				return output.AWSResource{}, errors.New("not found")
+			}
+			return output.AWSResource{ResourceType: resourceType, ResourceID: identifier, Region: region}, nil
+		},
+	}
+	fb := f.build()
+
+	got, err := collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+	assert.NoError(t, err, "≥1 successful emission means not exhausted")
+	require.Len(t, got, 1)
+	assert.Equal(t, "ok", got[0].ResourceID)
+}
+
+func TestConfigFallback_ConcurrentCallsProbeOnce(t *testing.T) {
+	var probeCalls atomic.Int32
+	f := &fakeConfigFallback{
+		describeStatus: func(ctx context.Context, region string) ([]configtypes.ConfigurationRecorderStatus, error) {
+			probeCalls.Add(1)
+			return okStatus(), nil
+		},
+		listDiscovered: func(ctx context.Context, region, resourceType string) ([]configtypes.ResourceIdentifier, error) {
+			return []configtypes.ResourceIdentifier{{ResourceName: aws.String("x")}}, nil
+		},
+		hydrate: func(region, resourceType, identifier string) (output.AWSResource, error) {
+			return output.AWSResource{ResourceType: resourceType, ResourceID: identifier}, nil
+		},
+	}
+	fb := f.build()
+
+	var wg sync.WaitGroup
+	for range 30 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = collectAttempt(t, fb, "AWS::S3::Bucket", "us-east-1")
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), probeCalls.Load(), "30 concurrent callers must trigger exactly one recorder probe")
+}

--- a/pkg/aws/enumeration/config_identifier.go
+++ b/pkg/aws/enumeration/config_identifier.go
@@ -1,0 +1,77 @@
+package enumeration
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+)
+
+// translateFn produces a CloudControl GetResource identifier from a Config
+// ResourceIdentifier. Returns ("", false) when no usable identifier can be
+// derived, in which case the caller should skip the record without attempting
+// a CloudControl GET.
+type translateFn func(rec configtypes.ResourceIdentifier, accountID, region string) (string, bool)
+
+// configIdentifier translates Config ResourceIdentifier records into the
+// identifier format CloudControl GetResource expects for each resource type.
+// Default behavior is a heuristic (ResourceName if non-empty, else ResourceId);
+// per-type overrides handle the cases where the heuristic is wrong.
+type configIdentifier struct {
+	overrides map[string]translateFn
+}
+
+// newConfigIdentifier returns a configIdentifier pre-loaded with the
+// per-type override table.
+func newConfigIdentifier() *configIdentifier {
+	return &configIdentifier{
+		overrides: map[string]translateFn{
+			// CloudFormation stores ResourceId as the stack ARN and ResourceName
+			// as the stack name; CloudControl wants the name.
+			"AWS::CloudFormation::Stack": returnResourceName,
+			// Amplify stores ResourceId as AppId (d1xxx) and ResourceName as the
+			// human-readable app name; CloudControl wants AppId.
+			"AWS::Amplify::App": returnResourceID,
+		},
+	}
+}
+
+// Translate returns the CloudControl primary identifier for rec, along with a
+// boolean indicating whether a usable identifier was derived.
+func (t *configIdentifier) Translate(
+	resourceType string,
+	rec configtypes.ResourceIdentifier,
+	accountID, region string,
+) (string, bool) {
+	if fn, ok := t.overrides[resourceType]; ok {
+		return fn(rec, accountID, region)
+	}
+	return heuristicTranslate(rec)
+}
+
+// heuristicTranslate returns the identifier field that most Config-to-CloudControl
+// translations need: ResourceName if populated, otherwise ResourceId. Returns
+// ("", false) when neither field is set.
+func heuristicTranslate(rec configtypes.ResourceIdentifier) (string, bool) {
+	if name := aws.ToString(rec.ResourceName); name != "" {
+		return name, true
+	}
+	if id := aws.ToString(rec.ResourceId); id != "" {
+		return id, true
+	}
+	return "", false
+}
+
+func returnResourceName(rec configtypes.ResourceIdentifier, _, _ string) (string, bool) {
+	name := aws.ToString(rec.ResourceName)
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+func returnResourceID(rec configtypes.ResourceIdentifier, _, _ string) (string, bool) {
+	id := aws.ToString(rec.ResourceId)
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}

--- a/pkg/aws/enumeration/config_identifier_test.go
+++ b/pkg/aws/enumeration/config_identifier_test.go
@@ -1,0 +1,87 @@
+package enumeration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	configtypes "github.com/aws/aws-sdk-go-v2/service/configservice/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigIdentifierTranslate(t *testing.T) {
+	trans := newConfigIdentifier()
+
+	cases := []struct {
+		name         string
+		resourceType string
+		rec          configtypes.ResourceIdentifier
+		accountID    string
+		region       string
+		wantID       string
+		wantOK       bool
+	}{
+		{
+			name:         "heuristic_name_present",
+			resourceType: "AWS::S3::Bucket",
+			rec:          configtypes.ResourceIdentifier{ResourceName: aws.String("my-bucket"), ResourceId: aws.String("should-not-be-returned")},
+			wantID:       "my-bucket",
+			wantOK:       true,
+		},
+		{
+			name:         "heuristic_name_empty_fallback_to_id",
+			resourceType: "AWS::EC2::Instance",
+			rec:          configtypes.ResourceIdentifier{ResourceId: aws.String("i-abc123")},
+			wantID:       "i-abc123",
+			wantOK:       true,
+		},
+		{
+			name:         "heuristic_both_empty",
+			resourceType: "AWS::S3::Bucket",
+			rec:          configtypes.ResourceIdentifier{},
+			wantID:       "",
+			wantOK:       false,
+		},
+		{
+			name:         "override_cloudformation_stack_returns_name",
+			resourceType: "AWS::CloudFormation::Stack",
+			rec: configtypes.ResourceIdentifier{
+				ResourceId:   aws.String("arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/abcd"),
+				ResourceName: aws.String("my-stack"),
+			},
+			wantID: "my-stack",
+			wantOK: true,
+		},
+		{
+			name:         "override_cloudformation_stack_name_missing",
+			resourceType: "AWS::CloudFormation::Stack",
+			rec:          configtypes.ResourceIdentifier{ResourceId: aws.String("arn:aws:cloudformation:...:stack/my-stack/abcd")},
+			wantID:       "",
+			wantOK:       false,
+		},
+		{
+			name:         "override_amplify_app_returns_id",
+			resourceType: "AWS::Amplify::App",
+			rec: configtypes.ResourceIdentifier{
+				ResourceId:   aws.String("d1abcxyz"),
+				ResourceName: aws.String("my-app"),
+			},
+			wantID: "d1abcxyz",
+			wantOK: true,
+		},
+		{
+			name:         "override_amplify_app_id_missing",
+			resourceType: "AWS::Amplify::App",
+			rec:          configtypes.ResourceIdentifier{ResourceName: aws.String("my-app")},
+			wantID:       "",
+			wantOK:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := trans.Translate(tc.resourceType, tc.rec, tc.accountID, tc.region)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantID, got)
+		})
+	}
+}

--- a/pkg/aws/enumeration/ec2_image_enumerator.go
+++ b/pkg/aws/enumeration/ec2_image_enumerator.go
@@ -105,6 +105,9 @@ func (l *EC2ImageEnumerator) listImagesInRegion(region, accountID string, out *p
 		Owners: []string{"self"},
 	})
 	if err != nil {
+		if handled := handleListError(err, "AWS::EC2::Image", region); handled == nil {
+			return nil
+		}
 		return fmt.Errorf("describe images in %s: %w", region, err)
 	}
 

--- a/pkg/aws/enumeration/ec2_image_enumerator.go
+++ b/pkg/aws/enumeration/ec2_image_enumerator.go
@@ -105,7 +105,7 @@ func (l *EC2ImageEnumerator) listImagesInRegion(region, accountID string, out *p
 		Owners: []string{"self"},
 	})
 	if err != nil {
-		if handled := handleListError(err, "AWS::EC2::Image", region); handled == nil {
+		if handled := handleListError(err, "AWS::EC2::Image", region, nil); handled == nil {
 			return nil
 		}
 		return fmt.Errorf("describe images in %s: %w", region, err)

--- a/pkg/aws/enumeration/enumerator.go
+++ b/pkg/aws/enumeration/enumerator.go
@@ -38,13 +38,17 @@ type Enumerator struct {
 func NewEnumerator(opts plugin.AWSCommonRecon) *Enumerator {
 	provider := NewAWSConfigProvider(opts)
 	cc := NewCloudControlEnumeratorWithProvider(opts, provider)
+	fallback := NewConfigFallback(provider, cc)
+
+	// Wire fallback into cc for its own EnumerateByType path.
+	cc.fallback = fallback
+
 	e := &Enumerator{
 		enumerators: make(map[string]ResourceEnumerator),
 		cc:          cc,
 	}
-	// Register built-in enumerators here as they are implemented.
-	e.Register(NewAmplifyAppEnumerator(opts, provider))
-	e.Register(NewS3Enumerator(opts, provider))
+	e.Register(NewAmplifyAppEnumerator(opts, provider, fallback))
+	e.Register(NewS3Enumerator(opts, provider, fallback))
 
 	iamEnum := NewIAMEnumerator(opts, provider)
 	e.Register(iamEnum.RoleEnumerator())

--- a/pkg/aws/enumeration/iam_enumerator.go
+++ b/pkg/aws/enumeration/iam_enumerator.go
@@ -137,7 +137,7 @@ func (e *IAMEnumerator) listRoles(out *pipeline.P[output.AWSResource]) error {
 
 		result, err := client.ListRoles(context.Background(), input)
 		if err != nil {
-			if handled := handleListError(err, "AWS::IAM::Role", "global"); handled == nil {
+			if handled := handleListError(err, "AWS::IAM::Role", "global", nil); handled == nil {
 				return false, nil
 			}
 			return false, fmt.Errorf("list IAM roles: %w", err)
@@ -189,7 +189,7 @@ func (e *IAMEnumerator) listPolicies(out *pipeline.P[output.AWSResource]) error 
 
 		result, err := client.ListPolicies(context.Background(), input)
 		if err != nil {
-			if handled := handleListError(err, "AWS::IAM::Policy", "global"); handled == nil {
+			if handled := handleListError(err, "AWS::IAM::Policy", "global", nil); handled == nil {
 				return false, nil
 			}
 			return false, fmt.Errorf("list IAM policies: %w", err)
@@ -239,7 +239,7 @@ func (e *IAMEnumerator) listUsers(out *pipeline.P[output.AWSResource]) error {
 
 		result, err := client.ListUsers(context.Background(), input)
 		if err != nil {
-			if handled := handleListError(err, "AWS::IAM::User", "global"); handled == nil {
+			if handled := handleListError(err, "AWS::IAM::User", "global", nil); handled == nil {
 				return false, nil
 			}
 			return false, fmt.Errorf("list IAM users: %w", err)

--- a/pkg/aws/enumeration/iam_enumerator.go
+++ b/pkg/aws/enumeration/iam_enumerator.go
@@ -137,6 +137,9 @@ func (e *IAMEnumerator) listRoles(out *pipeline.P[output.AWSResource]) error {
 
 		result, err := client.ListRoles(context.Background(), input)
 		if err != nil {
+			if handled := handleListError(err, "AWS::IAM::Role", "global"); handled == nil {
+				return false, nil
+			}
 			return false, fmt.Errorf("list IAM roles: %w", err)
 		}
 
@@ -186,6 +189,9 @@ func (e *IAMEnumerator) listPolicies(out *pipeline.P[output.AWSResource]) error 
 
 		result, err := client.ListPolicies(context.Background(), input)
 		if err != nil {
+			if handled := handleListError(err, "AWS::IAM::Policy", "global"); handled == nil {
+				return false, nil
+			}
 			return false, fmt.Errorf("list IAM policies: %w", err)
 		}
 
@@ -233,6 +239,9 @@ func (e *IAMEnumerator) listUsers(out *pipeline.P[output.AWSResource]) error {
 
 		result, err := client.ListUsers(context.Background(), input)
 		if err != nil {
+			if handled := handleListError(err, "AWS::IAM::User", "global"); handled == nil {
+				return false, nil
+			}
 			return false, fmt.Errorf("list IAM users: %w", err)
 		}
 

--- a/pkg/aws/enumeration/s3_enumerator.go
+++ b/pkg/aws/enumeration/s3_enumerator.go
@@ -18,14 +18,16 @@ import (
 type S3Enumerator struct {
 	plugin.AWSCommonRecon
 	provider  *AWSConfigProvider
+	fallback  *ConfigFallback
 	accountID string
 }
 
 // NewS3Enumerator creates an S3Enumerator that uses the native S3 SDK.
-func NewS3Enumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider) *S3Enumerator {
+func NewS3Enumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider, fallback *ConfigFallback) *S3Enumerator {
 	return &S3Enumerator{
 		AWSCommonRecon: opts,
 		provider:       provider,
+		fallback:       fallback,
 	}
 }
 
@@ -128,7 +130,13 @@ func (l *S3Enumerator) listBucketsInRegion(region string, out *pipeline.P[output
 
 		result, err := client.ListBuckets(context.Background(), input)
 		if err != nil {
-			if handled := handleListError(err, "AWS::S3::Bucket", region); handled == nil {
+			var fb fallbackFn
+			if l.fallback != nil {
+				fb = func() error {
+					return l.fallback.Attempt(context.Background(), "AWS::S3::Bucket", region, out)
+				}
+			}
+			if handled := handleListError(err, "AWS::S3::Bucket", region, fb); handled == nil {
 				return false, nil
 			}
 			return false, fmt.Errorf("list buckets in %s: %w", region, err)

--- a/pkg/aws/enumeration/s3_enumerator.go
+++ b/pkg/aws/enumeration/s3_enumerator.go
@@ -128,6 +128,9 @@ func (l *S3Enumerator) listBucketsInRegion(region string, out *pipeline.P[output
 
 		result, err := client.ListBuckets(context.Background(), input)
 		if err != nil {
+			if handled := handleListError(err, "AWS::S3::Bucket", region); handled == nil {
+				return false, nil
+			}
 			return false, fmt.Errorf("list buckets in %s: %w", region, err)
 		}
 

--- a/pkg/aws/enumeration/skippable_errors.go
+++ b/pkg/aws/enumeration/skippable_errors.go
@@ -1,0 +1,95 @@
+package enumeration
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+
+	smithy "github.com/aws/smithy-go"
+)
+
+// isAccessDeniedError reports whether err is an AWS access-denied response
+// (including IAM denials and SCP explicit denies). Callers treat these as a
+// warning so a single deny doesn't abort enumeration across other regions or
+// resource types.
+func isAccessDeniedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "AccessDeniedException", "AccessDenied", "UnauthorizedOperation":
+			return true
+		}
+	}
+	s := err.Error()
+	return strings.Contains(s, "AccessDeniedException") ||
+		strings.Contains(s, "UnauthorizedOperation") ||
+		strings.Contains(s, "is not authorized to perform")
+}
+
+// isUnsupportedTypeError reports whether err indicates the resource type or
+// action is not supported in this region (CloudControl-specific).
+func isUnsupportedTypeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "TypeNotFoundException", "UnsupportedActionException":
+			return true
+		}
+	}
+	s := err.Error()
+	return strings.Contains(s, "TypeNotFoundException") ||
+		strings.Contains(s, "UnsupportedActionException")
+}
+
+// isRegionUnsupportedError reports whether err indicates the AWS service is
+// not available in the target region (DNS resolution failure or explicit
+// region-not-supported response).
+func isRegionUnsupportedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "could not resolve endpoint") ||
+		strings.Contains(msg, "EndpointNotFound")
+}
+
+// handleListError classifies err returned from a per-region list call and
+// decides whether enumeration for other regions / resource types should
+// continue. It returns nil (logging at the appropriate level) if the error is
+// a known per-region condition, or the original error if enumeration should
+// abort.
+//
+//   - Region not available → Debug, continue (routine, some services are
+//     missing from some regions).
+//   - Unsupported resource type / action → Debug, continue (CloudControl only).
+//   - Access denied (IAM or SCP) → Warn, continue (the user sees why a region
+//     or service produced no data).
+//   - Anything else → returned as-is; caller decides whether to abort.
+func handleListError(err error, resourceType, region string) error {
+	if err == nil {
+		return nil
+	}
+	if isRegionUnsupportedError(err) {
+		slog.Debug("service not available in region, skipping",
+			"type", resourceType, "region", region)
+		return nil
+	}
+	if isUnsupportedTypeError(err) {
+		slog.Debug("resource type not supported, skipping",
+			"type", resourceType, "region", region)
+		return nil
+	}
+	if isAccessDeniedError(err) {
+		slog.Warn("access denied listing resources, skipping",
+			"type", resourceType, "region", region, "error", err)
+		return nil
+	}
+	return err
+}

--- a/pkg/aws/enumeration/skippable_errors.go
+++ b/pkg/aws/enumeration/skippable_errors.go
@@ -60,19 +60,31 @@ func isRegionUnsupportedError(err error) bool {
 		strings.Contains(msg, "EndpointNotFound")
 }
 
+// fallbackFn is invoked by handleListError when the primary list call returned
+// an AccessDenied response and the call site opted into a fallback. It must
+// return nil on success, errFallbackExhausted on expected failure (fallback
+// tried but produced nothing), or any other error to propagate as-is.
+type fallbackFn func() error
+
+// errFallbackExhausted is the sentinel a fallbackFn returns when the fallback
+// path ran to completion but could not produce resources (Config denied, no
+// recorder, or CloudControl GetResource denied).
+var errFallbackExhausted = errors.New("fallback exhausted")
+
 // handleListError classifies err returned from a per-region list call and
 // decides whether enumeration for other regions / resource types should
-// continue. It returns nil (logging at the appropriate level) if the error is
-// a known per-region condition, or the original error if enumeration should
-// abort.
+// continue. When err is AccessDenied and a fallback is supplied, the fallback
+// is invoked; the returned behavior is:
 //
-//   - Region not available → Debug, continue (routine, some services are
-//     missing from some regions).
-//   - Unsupported resource type / action → Debug, continue (CloudControl only).
-//   - Access denied (IAM or SCP) → Warn, continue (the user sees why a region
-//     or service produced no data).
-//   - Anything else → returned as-is; caller decides whether to abort.
-func handleListError(err error, resourceType, region string) error {
+//   - Region not available → Debug, return nil.
+//   - Unsupported resource type → Debug, return nil (CloudControl only).
+//   - Access denied with fallback == nil → Warn, return nil (PR #178 behavior).
+//   - Access denied with fallback returning nil → Debug, return nil.
+//   - Access denied with fallback returning errFallbackExhausted → Warn
+//     "unable to list resources" with both primary and fallback errors, return nil.
+//   - Access denied with fallback returning any other error → return that error.
+//   - Anything else → return err as-is.
+func handleListError(err error, resourceType, region string, fallback fallbackFn) error {
 	if err == nil {
 		return nil
 	}
@@ -87,9 +99,28 @@ func handleListError(err error, resourceType, region string) error {
 		return nil
 	}
 	if isAccessDeniedError(err) {
-		slog.Warn("access denied listing resources, skipping",
-			"type", resourceType, "region", region, "error", err)
-		return nil
+		if fallback == nil {
+			slog.Warn("access denied listing resources, skipping",
+				"type", resourceType, "region", region, "error", err)
+			return nil
+		}
+		fbErr := fallback()
+		switch {
+		case fbErr == nil:
+			slog.Debug("fell back to config, listed resources",
+				"type", resourceType, "region", region)
+			return nil
+		case errors.Is(fbErr, errFallbackExhausted):
+			slog.Warn("unable to list resources",
+				"type", resourceType,
+				"region", region,
+				"primary", err,
+				"fallback", fbErr,
+			)
+			return nil
+		default:
+			return fbErr
+		}
 	}
 	return err
 }

--- a/pkg/aws/enumeration/skippable_errors_test.go
+++ b/pkg/aws/enumeration/skippable_errors_test.go
@@ -1,0 +1,126 @@
+package enumeration
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	smithy "github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAccessDeniedError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("connection reset"), false},
+		{
+			"smithy AccessDeniedException",
+			&smithy.GenericAPIError{Code: "AccessDeniedException", Message: "no perms"},
+			true,
+		},
+		{
+			"smithy AccessDenied",
+			&smithy.GenericAPIError{Code: "AccessDenied", Message: "no perms"},
+			true,
+		},
+		{
+			"smithy UnauthorizedOperation",
+			&smithy.GenericAPIError{Code: "UnauthorizedOperation", Message: "no perms"},
+			true,
+		},
+		{
+			"wrapped smithy AccessDeniedException",
+			fmt.Errorf("list apps: %w", &smithy.GenericAPIError{Code: "AccessDeniedException"}),
+			true,
+		},
+		{
+			"substring AccessDeniedException (non-smithy)",
+			errors.New("operation error Amplify: ListApps, ... api error AccessDeniedException: explicit deny"),
+			true,
+		},
+		{
+			"not authorized phrase",
+			errors.New("User: arn:aws:... is not authorized to perform: amplify:ListApps"),
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isAccessDeniedError(tc.err))
+		})
+	}
+}
+
+func TestIsUnsupportedTypeError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("boom"), false},
+		{
+			"smithy TypeNotFoundException",
+			&smithy.GenericAPIError{Code: "TypeNotFoundException"},
+			true,
+		},
+		{
+			"smithy UnsupportedActionException",
+			&smithy.GenericAPIError{Code: "UnsupportedActionException"},
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isUnsupportedTypeError(tc.err))
+		})
+	}
+}
+
+func TestIsRegionUnsupportedError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("boom"), false},
+		{"no such host", errors.New("dial tcp: lookup amplify.zz-weird-1.amazonaws.com: no such host"), true},
+		{"could not resolve endpoint", errors.New("could not resolve endpoint: bad region"), true},
+		{"EndpointNotFound", errors.New("EndpointNotFound: region not available"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isRegionUnsupportedError(tc.err))
+		})
+	}
+}
+
+func TestHandleListError_NilReturnsNil(t *testing.T) {
+	assert.NoError(t, handleListError(nil, "AWS::Amplify::App", "us-east-1"))
+}
+
+func TestHandleListError_SkipsAccessDenied(t *testing.T) {
+	err := &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "explicit deny"}
+	assert.NoError(t, handleListError(err, "AWS::Amplify::App", "ap-northeast-1"))
+}
+
+func TestHandleListError_SkipsRegionUnsupported(t *testing.T) {
+	err := errors.New("dial tcp: lookup amplify.zz-weird-1.amazonaws.com: no such host")
+	assert.NoError(t, handleListError(err, "AWS::Amplify::App", "zz-weird-1"))
+}
+
+func TestHandleListError_SkipsUnsupportedType(t *testing.T) {
+	err := &smithy.GenericAPIError{Code: "TypeNotFoundException"}
+	assert.NoError(t, handleListError(err, "AWS::Some::Type", "us-east-1"))
+}
+
+func TestHandleListError_PropagatesOtherErrors(t *testing.T) {
+	err := errors.New("throttled: retry later")
+	got := handleListError(err, "AWS::Amplify::App", "us-east-1")
+	assert.ErrorIs(t, got, err)
+}

--- a/pkg/aws/enumeration/skippable_errors_test.go
+++ b/pkg/aws/enumeration/skippable_errors_test.go
@@ -101,26 +101,71 @@ func TestIsRegionUnsupportedError(t *testing.T) {
 }
 
 func TestHandleListError_NilReturnsNil(t *testing.T) {
-	assert.NoError(t, handleListError(nil, "AWS::Amplify::App", "us-east-1"))
+	assert.NoError(t, handleListError(nil, "AWS::Amplify::App", "us-east-1", nil))
 }
 
 func TestHandleListError_SkipsAccessDenied(t *testing.T) {
 	err := &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "explicit deny"}
-	assert.NoError(t, handleListError(err, "AWS::Amplify::App", "ap-northeast-1"))
+	assert.NoError(t, handleListError(err, "AWS::Amplify::App", "ap-northeast-1", nil))
 }
 
 func TestHandleListError_SkipsRegionUnsupported(t *testing.T) {
 	err := errors.New("dial tcp: lookup amplify.zz-weird-1.amazonaws.com: no such host")
-	assert.NoError(t, handleListError(err, "AWS::Amplify::App", "zz-weird-1"))
+	assert.NoError(t, handleListError(err, "AWS::Amplify::App", "zz-weird-1", nil))
 }
 
 func TestHandleListError_SkipsUnsupportedType(t *testing.T) {
 	err := &smithy.GenericAPIError{Code: "TypeNotFoundException"}
-	assert.NoError(t, handleListError(err, "AWS::Some::Type", "us-east-1"))
+	assert.NoError(t, handleListError(err, "AWS::Some::Type", "us-east-1", nil))
 }
 
 func TestHandleListError_PropagatesOtherErrors(t *testing.T) {
 	err := errors.New("throttled: retry later")
-	got := handleListError(err, "AWS::Amplify::App", "us-east-1")
+	got := handleListError(err, "AWS::Amplify::App", "us-east-1", nil)
 	assert.ErrorIs(t, got, err)
+}
+
+func TestHandleListError_NilFallbackPreservesWarnAndSkip(t *testing.T) {
+	// PR #178 behavior: AccessDenied + nil fallback → Warn + skip, return nil.
+	err := &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "scp"}
+	got := handleListError(err, "AWS::Amplify::App", "us-east-1", nil)
+	assert.NoError(t, got)
+}
+
+func TestHandleListError_FallbackSuccessReturnsNil(t *testing.T) {
+	err := &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "scp"}
+	called := false
+	fb := func() error { called = true; return nil }
+
+	got := handleListError(err, "AWS::Amplify::App", "us-east-1", fb)
+	assert.NoError(t, got)
+	assert.True(t, called, "fallback must be invoked on AccessDenied")
+}
+
+func TestHandleListError_FallbackExhaustedWarnsAndReturnsNil(t *testing.T) {
+	primary := &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "scp"}
+	fallback := errFallbackExhausted
+	fb := func() error { return fallback }
+
+	got := handleListError(primary, "AWS::Amplify::App", "us-east-1", fb)
+	assert.NoError(t, got)
+}
+
+func TestHandleListError_FallbackUnexpectedErrorPropagates(t *testing.T) {
+	primary := &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "scp"}
+	boom := errors.New("fallback bug")
+	fb := func() error { return boom }
+
+	got := handleListError(primary, "AWS::Amplify::App", "us-east-1", fb)
+	assert.ErrorIs(t, got, boom)
+}
+
+func TestHandleListError_NonAccessDeniedIgnoresFallback(t *testing.T) {
+	err := errors.New("throttled")
+	called := false
+	fb := func() error { called = true; return nil }
+
+	got := handleListError(err, "AWS::Amplify::App", "us-east-1", fb)
+	assert.ErrorIs(t, got, err)
+	assert.False(t, called, "fallback must only fire on AccessDenied")
 }

--- a/pkg/aws/enumeration/ssm_document_enumerator.go
+++ b/pkg/aws/enumeration/ssm_document_enumerator.go
@@ -115,7 +115,7 @@ func (e *SSMDocumentEnumerator) listDocumentsInRegion(region, accountID string, 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.Background())
 		if err != nil {
-			if handled := handleListError(err, "AWS::SSM::Document", region); handled == nil {
+			if handled := handleListError(err, "AWS::SSM::Document", region, nil); handled == nil {
 				return nil
 			}
 			return fmt.Errorf("list documents in %s: %w", region, err)

--- a/pkg/aws/enumeration/ssm_document_enumerator.go
+++ b/pkg/aws/enumeration/ssm_document_enumerator.go
@@ -115,6 +115,9 @@ func (e *SSMDocumentEnumerator) listDocumentsInRegion(region, accountID string, 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.Background())
 		if err != nil {
+			if handled := handleListError(err, "AWS::SSM::Document", region); handled == nil {
+				return nil
+			}
 			return fmt.Errorf("list documents in %s: %w", region, err)
 		}
 

--- a/test/terraform/aws/enumeration/config-fallback/main.tf
+++ b/test/terraform/aws/enumeration/config-fallback/main.tf
@@ -1,0 +1,130 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+
+  backend "s3" {
+    # All configured via -backend-config at init time
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+locals {
+  tags = {
+    aurelian-fixture = "config-fallback"
+    aurelian-issue   = "LAB-2525"
+  }
+}
+
+# --- Target resource we want to discover via Config fallback ---
+
+resource "aws_s3_bucket" "target" {
+  bucket        = "${var.name_prefix}-${random_id.suffix.hex}"
+  force_destroy = true
+  tags          = local.tags
+}
+
+# --- Config recorder wiring ---
+# Minimal viable config: delivery channel to an S3 bucket + recorder + recording group.
+
+# The delivery bucket name MUST start with "aws-config-" or "config-bucket-"
+# for the AWS-managed AWS_ConfigRole policy to grant s3:PutObject. Renaming this
+# bucket without also broadening the role's permissions will cause the recorder
+# to silently fail to deliver configuration snapshots.
+resource "aws_s3_bucket" "config_delivery" {
+  bucket        = "aws-config-${var.name_prefix}-${random_id.suffix.hex}"
+  force_destroy = true
+  tags          = local.tags
+}
+
+resource "aws_s3_bucket_policy" "config_delivery" {
+  bucket = aws_s3_bucket.config_delivery.id
+  policy = data.aws_iam_policy_document.config_delivery.json
+}
+
+data "aws_iam_policy_document" "config_delivery" {
+  statement {
+    sid    = "AllowConfigWrite"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.config_delivery.arn}/AWSLogs/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+  statement {
+    sid    = "AllowConfigRead"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    actions   = ["s3:GetBucketAcl"]
+    resources = [aws_s3_bucket.config_delivery.arn]
+  }
+}
+
+resource "aws_iam_role" "config" {
+  name               = "${var.name_prefix}-${random_id.suffix.hex}-role"
+  assume_role_policy = data.aws_iam_policy_document.config_assume.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "config_assume" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "config" {
+  role       = aws_iam_role.config.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+}
+
+resource "aws_config_configuration_recorder" "main" {
+  name     = "${var.name_prefix}-${random_id.suffix.hex}"
+  role_arn = aws_iam_role.config.arn
+
+  recording_group {
+    all_supported                 = false
+    include_global_resource_types = false
+    resource_types                = ["AWS::S3::Bucket"]
+  }
+}
+
+resource "aws_config_delivery_channel" "main" {
+  name           = "${var.name_prefix}-${random_id.suffix.hex}"
+  s3_bucket_name = aws_s3_bucket.config_delivery.bucket
+  depends_on     = [aws_config_configuration_recorder.main]
+}
+
+resource "aws_config_configuration_recorder_status" "main" {
+  name       = aws_config_configuration_recorder.main.name
+  is_enabled = true
+  depends_on = [aws_config_delivery_channel.main]
+}

--- a/test/terraform/aws/enumeration/config-fallback/outputs.tf
+++ b/test/terraform/aws/enumeration/config-fallback/outputs.tf
@@ -1,0 +1,7 @@
+output "target_bucket_name" {
+  value = aws_s3_bucket.target.bucket
+}
+
+output "region" {
+  value = var.region
+}

--- a/test/terraform/aws/enumeration/config-fallback/variables.tf
+++ b/test/terraform/aws/enumeration/config-fallback/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  type        = string
+  description = "AWS region for the fixture."
+  default     = "us-east-1"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix applied to all named resources for uniqueness."
+  default     = "aurelian-cfg-fallback"
+}


### PR DESCRIPTION
## Summary

- `aurelian aws recon list-all` aborts the entire run as soon as any single region returns `AccessDeniedException` (e.g. an SCP explicit deny) for any native enumerator. The user's observed symptom was `Error: list amplify apps in ap-northeast-1: ... explicit deny in a service control policy` with nothing after it — the remaining 16 regions and 31 other resource types were abandoned.
- Root cause: the native enumerators (Amplify, S3, IAM, EC2 image, SSM document) propagate raw SDK errors; `pipeline.Pipe` captures the first one as fatal. Only `CloudControlEnumerator` had an `isSkippableError` that treated AccessDenied as non-fatal, and its logs were at `Debug` so even that path silently dropped data.
- Adds `pkg/aws/enumeration/skippable_errors.go` with shared classifiers (`isAccessDeniedError`, `isUnsupportedTypeError`, `isRegionUnsupportedError`) and a `handleListError(err, resourceType, region)` helper that logs at `Debug` for region/type unsupported, **`Warn`** for access-denied (skipping both), and returns the original error for anything else.
- Routes every native enumerator through `handleListError` and replaces CloudControl's private `isSkippableError` with calls to the shared helpers, so its AccessDenied path is also upgraded from silent `Debug` to user-visible `Warn`.

## Behavior change

Before:
```
[*] running module AWS List All Resources
[*] enumerating 32 resource types across 17 regions
Error: list amplify apps in ap-northeast-1: ... AccessDeniedException: explicit deny in a service control policy
```

After:
```
[*] running module AWS List All Resources
[*] enumerating 32 resource types across 17 regions
WARN access denied listing resources, skipping type=AWS::Amplify::App region=ap-northeast-1 error="..."
... (remaining regions / resource types continue) ...
[+] enumerated N resources
```