### PR TITLE
chore(ci): bump public-workflows to v2.0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ci:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@e7c1f39e9219a3256df321445d558e18cf3027c0  # v2.0.11
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@3dcf34cfbe5e1332d490d28ed1bd119cd86cf81b  # v2.0.13
     permissions:
       contents: read
     with:

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   notify:
-    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@e7c1f39e9219a3256df321445d558e18cf3027c0  # v2.0.11
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@3dcf34cfbe5e1332d490d28ed1bd119cd86cf81b  # v2.0.13
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
## Summary
- Bumps `public-workflows` SHA pin from `v2.0.11` to `v2.0.13`
- Picks up harden-runner block mode on `external-contrib-notify` workflow (https://github.com/praetorian-inc/public-workflows/pull/34)
- Egress now restricted to `api.github.com`, `api.linear.app`, `slack.com` on `pull_request_target` workflows

## Test plan
- [ ] CI passes
- [ ] External contribution workflow still functions on next external PR/issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)