### PR TITLE
chore(ci): pin codex-code.yml to public-workflows v2.1.1

### DIFF
--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   codex-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@c53011b16f91273b2e8bf7b3981d5e64a9d4ad31  # v2.1.0 (codex-code.yml)
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@5fe31f5bfb48b12d7b05201f2d1b1bf006b6a3e5  # v2.1.1 (hardened sandbox)
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Bumps reusable Codex PR reviewer from `v2.1.0` to `v2.1.1` (hardened sandbox)
- SHA: `c53011b...` → `5fe31f5...`

## Test plan
- [ ] Verify preflight + codex-review jobs trigger correctly on a test PR
- [ ] Confirm docs-only PRs still skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)