### PR TITLE
chore: bump AI reviewer workflows to public-workflows v2.1.0

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -2,13 +2,13 @@ name: Claude PR Assistant
 
 on:
   pull_request:
-    types: [synchronize, opened, ready_for_review]
+    types: [opened, ready_for_review]
   pull_request_review_comment:
     types: [created]
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@e64522990f20da94ab7554985ae3c27f1e552d85  # v2.0.12
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.0.12
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -8,7 +8,7 @@ name: Codex PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, ready_for_review]
   pull_request_review_comment:
     types: [created]
 
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   codex-review:
-    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@4b6e7658373571aa4b4d1a57ee14ad183353ce49  # v2.1.2 (private repo pre-fetch fix)
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.1.2 (private repo pre-fetch fix)
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event_name != 'pull_request_review_comment' || contains(github.event.comment.body, '@gemini'))
-    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@cde8b58405ce8b7ebd30a8b478a32921aba49215  # v2.1.0
+    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.1.0
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Bumps claude-code, codex-code, and gemini-code callers to public-workflows v2.1.0.

Picks up:
- Shared preflight consolidation (3 duplicate preflights → 1 reusable)
- Harden-Runner v2.18.0 → v2.19.0
- actions/checkout v5.0.1 → v6.0.2
- ubuntu-latest → ubuntu-24.04
- Workflow-level permissions safety net
- disable-sudo-and-containers on all Harden-Runner instances
- env-pass hardening in preflight shells
- CODEOWNERS removed from SKIP_RE (security-sensitive file now triggers reviews)

Also fixes `synchronize`/`reopened` in `types:` where present (eliminates ghost workflow runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)