### PR TITLE
fix(ci): drop invalid timeout-minutes from claude-md-drift caller

### DIFF
--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -11,7 +11,6 @@ concurrency:
 jobs:
   drift-check:
     uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@87c0808aa16862a7ffef0cd94c516a02eb48242b  # v2.3.0
-    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- The `claude-md-drift.yml` caller workflow set `timeout-minutes: 15` on a job that uses `uses:` to invoke a reusable workflow. That key is not permitted on reusable-workflow caller jobs, so the file failed to parse on push to `main` and produced a synthetic failed run ([example](https://github.com/praetorian-inc/aurelian/actions/runs/25015825566)).
- Removes the offending key. Any timeout enforcement should live inside the called workflow at `praetorian-inc/public-workflows`.

## Test plan
- [ ] CI parses the workflow file (no synthetic failed run on this push)
- [ ] PR triggers `CLAUDE.md Drift Detection` job successfully