### PR TITLE
fix(aws/recon): continue enumeration on per-region AccessDenied/SCP errors

### DIFF
--- a/pkg/aws/enumeration/amplify_enumerator.go
+++ b/pkg/aws/enumeration/amplify_enumerator.go
@@ -19,13 +19,15 @@ import (
 // because CloudControl does not support AWS::Amplify::App.
 type AmplifyAppEnumerator struct {
 	plugin.AWSCommonRecon
-	provider *AWSConfigProvider
+	provider   *AWSConfigProvider
+	skipReport *SkipReport
 }
 
-func NewAmplifyAppEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider) *AmplifyAppEnumerator {
+func NewAmplifyAppEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider, skipReport *SkipReport) *AmplifyAppEnumerator {
 	return &AmplifyAppEnumerator{
 		AWSCommonRecon: opts,
 		provider:       provider,
+		skipReport:     skipReport,
 	}
 }
 
@@ -96,16 +98,6 @@ func (e *AmplifyAppEnumerator) EnumerateByARN(arn string, out *pipeline.P[output
 	return nil
 }
 
-// isRegionUnsupportedError returns true when the error indicates the AWS service
-// is not available in the target region (DNS resolution failure or explicit
-// region-not-supported response).
-func isRegionUnsupportedError(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "no such host") ||
-		strings.Contains(msg, "could not resolve endpoint") ||
-		strings.Contains(msg, "EndpointNotFound")
-}
-
 func (e *AmplifyAppEnumerator) listAppsInRegion(region, accountID string, out *pipeline.P[output.AWSResource]) error {
 	cfg, err := e.provider.GetAWSConfig(region)
 	if err != nil {
@@ -120,8 +112,16 @@ func (e *AmplifyAppEnumerator) listAppsInRegion(region, accountID string, out *p
 			NextToken: nextToken,
 		})
 		if err != nil {
-			if isRegionUnsupportedError(err) {
-				slog.Debug("amplify not available in region, skipping", "region", region)
+			if IsSkippableAWSError(err) {
+				code := SkipReason(err)
+				slog.Warn("skipping amplify ListApps", "region", region, "code", code, "error", err)
+				e.skipReport.Record(SkippedOp{
+					Region:    region,
+					Service:   "amplify",
+					Operation: "ListApps",
+					ErrorCode: code,
+					Detail:    err.Error(),
+				})
 				return false, nil
 			}
 			return false, fmt.Errorf("list amplify apps in %s: %w", region, err)

--- a/pkg/aws/enumeration/amplify_enumerator.go
+++ b/pkg/aws/enumeration/amplify_enumerator.go
@@ -3,7 +3,6 @@ package enumeration
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -112,16 +111,7 @@ func (e *AmplifyAppEnumerator) listAppsInRegion(region, accountID string, out *p
 			NextToken: nextToken,
 		})
 		if err != nil {
-			if IsSkippableAWSError(err) {
-				code := SkipReason(err)
-				slog.Warn("skipping amplify ListApps", "region", region, "code", code, "error", err)
-				e.skipReport.Record(SkippedOp{
-					Region:    region,
-					Service:   "amplify",
-					Operation: "ListApps",
-					ErrorCode: code,
-					Detail:    err.Error(),
-				})
+			if e.skipReport.RecordSkippable(err, "amplify", "ListApps", region) {
 				return false, nil
 			}
 			return false, fmt.Errorf("list amplify apps in %s: %w", region, err)

--- a/pkg/aws/enumeration/cloud_control_enumerator.go
+++ b/pkg/aws/enumeration/cloud_control_enumerator.go
@@ -54,22 +54,14 @@ func (cc *CloudControlEnumerator) List(identifier string, out *pipeline.P[output
 
 func (cc *CloudControlEnumerator) EnumerateByARN(resourceARN string, out *pipeline.P[output.AWSResource]) error {
 	region, resource, err := cc.getResourceByARN(resourceARN)
-	if IsSkippableAWSError(err) {
-		code := SkipReason(err)
-		slog.Warn("skipping cloudcontrol GetResource", "arn", resourceARN, "region", region, "code", code, "error", err)
-		if region == "" {
-			region = "unknown"
-		}
-		cc.skipReport.Record(SkippedOp{
-			Region:    region,
-			Service:   "cloudcontrol",
-			Operation: "GetResource",
-			ErrorCode: code,
-			Detail:    err.Error(),
-		})
-		return nil
-	}
 	if err != nil {
+		recordRegion := region
+		if recordRegion == "" {
+			recordRegion = "unknown"
+		}
+		if cc.skipReport.RecordSkippable(err, "cloudcontrol", "GetResource", recordRegion, "arn", resourceARN) {
+			return nil
+		}
 		return err
 	}
 
@@ -252,19 +244,10 @@ func (cc *CloudControlEnumerator) listInRegionByType(region, resourceType string
 	}
 
 	err = cc.listByType(client, accountID, region, resourceType, out)
-	if IsSkippableAWSError(err) {
-		code := SkipReason(err)
-		slog.Warn("skipping cloudcontrol ListResources", "type", resourceType, "region", region, "code", code, "error", err)
-		cc.skipReport.Record(SkippedOp{
-			Region:    region,
-			Service:   "cloudcontrol",
-			Operation: "ListResources:" + resourceType,
-			ErrorCode: code,
-			Detail:    err.Error(),
-		})
-		return nil
-	}
 	if err != nil {
+		if cc.skipReport.RecordSkippable(err, "cloudcontrol", "ListResources:"+resourceType, region) {
+			return nil
+		}
 		slog.Warn("error listing resources", "type", resourceType, "region", region, "error", err)
 		return err
 	}

--- a/pkg/aws/enumeration/cloud_control_enumerator.go
+++ b/pkg/aws/enumeration/cloud_control_enumerator.go
@@ -3,6 +3,9 @@ package enumeration
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsaarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
@@ -13,25 +16,25 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
 	"github.com/praetorian-inc/aurelian/pkg/types"
-	"log/slog"
-	"strings"
 )
 
 type CloudControlEnumerator struct {
 	plugin.AWSCommonRecon
 	CrossRegionActor *ratelimit.CrossRegionActor
 	provider         *AWSConfigProvider
+	skipReport       *SkipReport
 }
 
 func NewCloudControlEnumerator(options plugin.AWSCommonRecon) *CloudControlEnumerator {
-	return NewCloudControlEnumeratorWithProvider(options, NewAWSConfigProvider(options))
+	return NewCloudControlEnumeratorWithProvider(options, NewAWSConfigProvider(options), NewSkipReport())
 }
 
-func NewCloudControlEnumeratorWithProvider(options plugin.AWSCommonRecon, provider *AWSConfigProvider) *CloudControlEnumerator {
+func NewCloudControlEnumeratorWithProvider(options plugin.AWSCommonRecon, provider *AWSConfigProvider, skipReport *SkipReport) *CloudControlEnumerator {
 	return &CloudControlEnumerator{
 		AWSCommonRecon:   options,
 		CrossRegionActor: ratelimit.NewCrossRegionActor(options.Concurrency),
 		provider:         provider,
+		skipReport:       skipReport,
 	}
 }
 
@@ -50,9 +53,20 @@ func (cc *CloudControlEnumerator) List(identifier string, out *pipeline.P[output
 }
 
 func (cc *CloudControlEnumerator) EnumerateByARN(resourceARN string, out *pipeline.P[output.AWSResource]) error {
-	resource, err := cc.getResourceByARN(resourceARN)
-	if cc.isSkippableError(err) {
-		slog.Debug("skipping arn", "arn", resourceARN, "error", err)
+	region, resource, err := cc.getResourceByARN(resourceARN)
+	if IsSkippableAWSError(err) {
+		code := SkipReason(err)
+		slog.Warn("skipping cloudcontrol GetResource", "arn", resourceARN, "region", region, "code", code, "error", err)
+		if region == "" {
+			region = "unknown"
+		}
+		cc.skipReport.Record(SkippedOp{
+			Region:    region,
+			Service:   "cloudcontrol",
+			Operation: "GetResource",
+			ErrorCode: code,
+			Detail:    err.Error(),
+		})
 		return nil
 	}
 	if err != nil {
@@ -63,20 +77,20 @@ func (cc *CloudControlEnumerator) EnumerateByARN(resourceARN string, out *pipeli
 	return nil
 }
 
-func (cc *CloudControlEnumerator) getResourceByARN(arn string) (output.AWSResource, error) {
+func (cc *CloudControlEnumerator) getResourceByARN(arn string) (string, output.AWSResource, error) {
 	region, resourceType, identifier, err := cc.resolveARNTarget(arn)
 	if err != nil {
-		return output.AWSResource{}, err
+		return "", output.AWSResource{}, err
 	}
 
 	client, err := cc.newCloudControlClient(region)
 	if err != nil {
-		return output.AWSResource{}, fmt.Errorf("create client: %w", err)
+		return region, output.AWSResource{}, fmt.Errorf("create client: %w", err)
 	}
 
 	accountID, err := cc.provider.GetAccountID(region)
 	if err != nil {
-		return output.AWSResource{}, err
+		return region, output.AWSResource{}, err
 	}
 
 	result, err := client.GetResource(context.Background(), &cloudcontrol.GetResourceInput{
@@ -84,11 +98,11 @@ func (cc *CloudControlEnumerator) getResourceByARN(arn string) (output.AWSResour
 		Identifier: aws.String(identifier),
 	})
 	if err != nil {
-		return output.AWSResource{}, fmt.Errorf("get %s %s: %w", resourceType, identifier, err)
+		return region, output.AWSResource{}, fmt.Errorf("get %s %s: %w", resourceType, identifier, err)
 	}
 
 	cr := awshelpers.CloudControlToAWSResource(*result.ResourceDescription, resourceType, accountID, region)
-	return cr, nil
+	return region, cr, nil
 }
 
 func (cc *CloudControlEnumerator) resolveARNTarget(resourceARN string) (string, string, string, error) {
@@ -238,8 +252,16 @@ func (cc *CloudControlEnumerator) listInRegionByType(region, resourceType string
 	}
 
 	err = cc.listByType(client, accountID, region, resourceType, out)
-	if cc.isSkippableError(err) {
-		slog.Debug("skipping resource type", "type", resourceType, "region", region, "error", err)
+	if IsSkippableAWSError(err) {
+		code := SkipReason(err)
+		slog.Warn("skipping cloudcontrol ListResources", "type", resourceType, "region", region, "code", code, "error", err)
+		cc.skipReport.Record(SkippedOp{
+			Region:    region,
+			Service:   "cloudcontrol",
+			Operation: "ListResources:" + resourceType,
+			ErrorCode: code,
+			Detail:    err.Error(),
+		})
 		return nil
 	}
 	if err != nil {
@@ -281,16 +303,6 @@ func (cc *CloudControlEnumerator) listByType(
 		nextToken = result.NextToken
 		return nextToken != nil, nil
 	})
-}
-
-func (cc *CloudControlEnumerator) isSkippableError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	return strings.Contains(s, "TypeNotFoundException") ||
-		strings.Contains(s, "UnsupportedActionException") ||
-		strings.Contains(s, "AccessDeniedException")
 }
 
 func (cc *CloudControlEnumerator) newCloudControlClient(region string) (*cloudcontrol.Client, error) {

--- a/pkg/aws/enumeration/continue_on_denied_test.go
+++ b/pkg/aws/enumeration/continue_on_denied_test.go
@@ -1,0 +1,252 @@
+package enumeration
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// LAB-3328: AWS recon must continue past SCP/AccessDenied/OptInRequired errors
+// returned from a single (region, service) call. The enumerator pattern is:
+//
+//	if IsSkippableAWSError(err) {
+//	    skipReport.Record(SkippedOp{...})
+//	    return nil   // <-- swallow so CrossRegionActor's errgroup doesn't cancel siblings
+//	}
+//	return err       // fatal -> propagate
+//
+// These tests simulate that decision point by driving CrossRegionActor with a
+// fake per-region action that returns the AWS error shapes the enumerators see
+// in production, then assert on the post-run state (errgroup result + SkipReport
+// contents). This is the integration-style seam that proves the loop continues.
+
+// regionErrPlan controls what error each region's fake action returns.
+type regionErrPlan map[string]error
+
+// runWithSkipHandling simulates the wrapper every real enumerator now performs:
+// errors that pass IsSkippableAWSError are recorded into the SkipReport and
+// converted to nil; everything else propagates.
+func runWithSkipHandling(t *testing.T, regions []string, plan regionErrPlan, report *SkipReport) (error, int) {
+	t.Helper()
+
+	var invoked int64
+	actor := ratelimit.NewCrossRegionActor(len(regions))
+	err := actor.ActInRegions(regions, func(region string) error {
+		atomic.AddInt64(&invoked, 1)
+		regionErr, hasErr := plan[region]
+		if !hasErr {
+			return nil
+		}
+		if IsSkippableAWSError(regionErr) {
+			report.Record(SkippedOp{
+				Region:    region,
+				Service:   "amplify",
+				Operation: "ListApps",
+				ErrorCode: SkipReason(regionErr),
+				Detail:    regionErr.Error(),
+			})
+			return nil
+		}
+		return regionErr
+	})
+	return err, int(atomic.LoadInt64(&invoked))
+}
+
+// TP1: one region denied (AccessDeniedException), one region succeeds.
+// Both region actions must be invoked, and ActInRegions must return nil so the
+// caller (the recon module) keeps processing results from the surviving region.
+func TestContinueOnDenied_AccessDenied_AcrossTwoRegions_LoopCompletes(t *testing.T) {
+	report := NewSkipReport()
+	plan := regionErrPlan{
+		"us-east-1": &fakeAPIError{code: "AccessDeniedException", msg: "denied by SCP"},
+		// "us-east-2" has no plan entry -> succeeds.
+	}
+
+	err, invoked := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+
+	require.NoError(t, err, "errgroup should return nil when only skippable errors occurred")
+	assert.Equal(t, 2, invoked, "both region actions must run; sibling must not be cancelled")
+}
+
+// TP2: the denied region records the (region, service, op, code) tuple. This
+// is what surfaces in the operator-facing SkipReport.Summary().
+func TestContinueOnDenied_AccessDenied_RecordsSkipTuple(t *testing.T) {
+	report := NewSkipReport()
+	plan := regionErrPlan{
+		"us-east-1": &fakeAPIError{code: "AccessDeniedException", msg: "denied by SCP"},
+	}
+
+	err, _ := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, report.Len(), "exactly one region should have been recorded")
+	snap := report.Snapshot()
+	require.Len(t, snap, 1)
+	got := snap[0]
+	assert.Equal(t, "us-east-1", got.Region)
+	assert.Equal(t, "amplify", got.Service)
+	assert.Equal(t, "ListApps", got.Operation)
+	assert.Equal(t, "AccessDeniedException", got.ErrorCode)
+	assert.Contains(t, got.Detail, "denied by SCP")
+}
+
+// TP3: every skippable error code class is exercised together. All regions must
+// complete; the SkipReport must hold all three distinct codes.
+func TestContinueOnDenied_MultipleSkippableCodes_AllRegionsComplete(t *testing.T) {
+	report := NewSkipReport()
+	plan := regionErrPlan{
+		"us-east-1":      &fakeAPIError{code: "AccessDeniedException", msg: "scp deny"},
+		"us-west-2":      &fakeAPIError{code: "OptInRequired", msg: "region not opted in"},
+		"ap-northeast-3": errors.New("dial tcp: lookup amplify.ap-northeast-3.amazonaws.com: no such host"),
+		"eu-west-1":      nil, // success
+	}
+
+	regions := []string{"us-east-1", "us-west-2", "ap-northeast-3", "eu-west-1"}
+	err, invoked := runWithSkipHandling(t, regions, plan, report)
+
+	require.NoError(t, err, "all errors were skippable, errgroup must return nil")
+	assert.Equal(t, 4, invoked, "every region action must run")
+	require.Equal(t, 3, report.Len(), "three regions recorded skips; one was a clean success")
+
+	// Collect codes for assertion, order-independent.
+	codes := make([]string, 0, 3)
+	for _, op := range report.Snapshot() {
+		codes = append(codes, op.ErrorCode)
+	}
+	sort.Strings(codes)
+	assert.Equal(t, []string{"AccessDeniedException", "OptInRequired", "RegionUnsupported"}, codes)
+}
+
+// TP4: smithy errors wrapped via fmt.Errorf("...: %w", apiErr) -- the shape SDK
+// callers actually produce -- must still be classified as skippable and not
+// abort the loop.
+func TestContinueOnDenied_WrappedSmithyError_IsClassifiedSkippable(t *testing.T) {
+	report := NewSkipReport()
+	wrapped := fmt.Errorf("list amplify apps in us-east-1: %w", &fakeAPIError{code: "AccessDeniedException", msg: "denied"})
+	plan := regionErrPlan{"us-east-1": wrapped}
+
+	err, invoked := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+
+	require.NoError(t, err, "wrapped skippable errors must not abort the loop")
+	assert.Equal(t, 2, invoked, "sibling region must still run")
+	require.Equal(t, 1, report.Len())
+	assert.Equal(t, "AccessDeniedException", report.Snapshot()[0].ErrorCode,
+		"errors.As must unwrap and find the original smithy code")
+}
+
+// TP5: SkipReport.Summary() exposes the populated report in the
+// operator-facing format. This is the line the recon module prints via the
+// deferred summary in list_all_resources.go.
+func TestContinueOnDenied_Summary_RendersGroupedReport(t *testing.T) {
+	report := NewSkipReport()
+	plan := regionErrPlan{
+		"us-east-1": &fakeAPIError{code: "AccessDeniedException", msg: "denied"},
+		"us-west-2": &fakeAPIError{code: "AccessDeniedException", msg: "denied"},
+	}
+	_, _ = runWithSkipHandling(t, []string{"us-east-1", "us-west-2", "us-east-2"}, plan, report)
+
+	summary := report.Summary()
+	assert.Contains(t, summary, "skipped 2 operations across 2 regions",
+		"header should reflect total skips and unique regions")
+	assert.Contains(t, summary, "amplify ListApps")
+	assert.Contains(t, summary, "us-east-1, us-west-2")
+	assert.Contains(t, summary, "[AccessDeniedException]")
+}
+
+// FP1: a non-AWS, non-skippable error (e.g. a plain network failure that
+// doesn't match the region-unsupported substrings) must NOT be swallowed --
+// it should propagate up to the recon module so the operator sees a real
+// failure rather than a silent loss of coverage.
+func TestContinueOnDenied_NonSkippableError_PropagatesFatal(t *testing.T) {
+	report := NewSkipReport()
+	plan := regionErrPlan{
+		"us-east-1": errors.New("network connection refused"),
+	}
+
+	err, _ := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+
+	require.Error(t, err, "non-skippable errors must propagate so operators see them")
+	assert.Contains(t, err.Error(), "network connection refused")
+	assert.Equal(t, 0, report.Len(),
+		"non-skippable errors must NOT be recorded as skips -- that would mask real failures")
+}
+
+// FP2: a smithy error with a code that is intentionally NOT in
+// skippableErrorCodes (e.g. ThrottlingException) must propagate as fatal so the
+// caller can decide whether to retry. The fix must not over-classify.
+func TestContinueOnDenied_NonListedSmithyCode_PropagatesFatal(t *testing.T) {
+	report := NewSkipReport()
+	plan := regionErrPlan{
+		"us-east-1": &fakeAPIError{code: "ThrottlingException", msg: "rate exceeded"},
+	}
+
+	err, _ := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+
+	require.Error(t, err, "ThrottlingException is intentionally not in skippableErrorCodes")
+	assert.Contains(t, err.Error(), "ThrottlingException")
+	assert.Equal(t, 0, report.Len())
+}
+
+// FP3: an empty smithy error code (no actual ErrorCode set) combined with a
+// non-region-unsupported message must propagate. Round-2 review tightened
+// extractAPIErrorCode to return ok=false on empty code so this exact shape no
+// longer leaks past IsSkippableAWSError.
+func TestContinueOnDenied_EmptySmithyCode_PropagatesFatal(t *testing.T) {
+	report := NewSkipReport()
+	plan := regionErrPlan{
+		"us-east-1": &fakeAPIError{code: "", msg: "weird coreless smithy error"},
+	}
+
+	err, _ := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+
+	require.Error(t, err, "empty smithy code with non-DNS message must NOT be classified as skippable")
+	assert.Equal(t, 0, report.Len())
+}
+
+// Concurrency check: drive many regions in parallel, mixing skippable and
+// successful outcomes, and assert the SkipReport is correctly aggregated under
+// race conditions. This complements the existing TestSkipReport_ConcurrentRecord
+// by exercising the full path (actor -> action -> classify -> record).
+func TestContinueOnDenied_HighConcurrency_AllRecorded(t *testing.T) {
+	report := NewSkipReport()
+
+	regions := make([]string, 0, 32)
+	plan := regionErrPlan{}
+	expectSkips := 0
+	for i := 0; i < 32; i++ {
+		r := fmt.Sprintf("region-%d", i)
+		regions = append(regions, r)
+		if i%2 == 0 {
+			plan[r] = &fakeAPIError{code: "AccessDeniedException", msg: "denied"}
+			expectSkips++
+		}
+	}
+
+	// Run multiple iterations to flush out races.
+	const iterations = 5
+	var wg sync.WaitGroup
+	errs := make(chan error, iterations)
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err, _ := runWithSkipHandling(t, regions, plan, report)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for e := range errs {
+		require.NoError(t, e, "skippable-only runs must not propagate errors")
+	}
+	assert.Equal(t, expectSkips*iterations, report.Len(),
+		"every per-iteration skip should be recorded exactly once")
+}

--- a/pkg/aws/enumeration/continue_on_denied_test.go
+++ b/pkg/aws/enumeration/continue_on_denied_test.go
@@ -33,7 +33,7 @@ type regionErrPlan map[string]error
 // runWithSkipHandling simulates the wrapper every real enumerator now performs:
 // errors that pass IsSkippableAWSError are recorded into the SkipReport and
 // converted to nil; everything else propagates.
-func runWithSkipHandling(t *testing.T, regions []string, plan regionErrPlan, report *SkipReport) (error, int) {
+func runWithSkipHandling(t *testing.T, regions []string, plan regionErrPlan, report *SkipReport) (int, error) {
 	t.Helper()
 
 	var invoked int64
@@ -56,7 +56,7 @@ func runWithSkipHandling(t *testing.T, regions []string, plan regionErrPlan, rep
 		}
 		return regionErr
 	})
-	return err, int(atomic.LoadInt64(&invoked))
+	return int(atomic.LoadInt64(&invoked)), err
 }
 
 // TP1: one region denied (AccessDeniedException), one region succeeds.
@@ -69,7 +69,7 @@ func TestContinueOnDenied_AccessDenied_AcrossTwoRegions_LoopCompletes(t *testing
 		// "us-east-2" has no plan entry -> succeeds.
 	}
 
-	err, invoked := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+	invoked, err := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
 
 	require.NoError(t, err, "errgroup should return nil when only skippable errors occurred")
 	assert.Equal(t, 2, invoked, "both region actions must run; sibling must not be cancelled")
@@ -83,7 +83,7 @@ func TestContinueOnDenied_AccessDenied_RecordsSkipTuple(t *testing.T) {
 		"us-east-1": &fakeAPIError{code: "AccessDeniedException", msg: "denied by SCP"},
 	}
 
-	err, _ := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+	_, err := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, report.Len(), "exactly one region should have been recorded")
@@ -109,7 +109,7 @@ func TestContinueOnDenied_MultipleSkippableCodes_AllRegionsComplete(t *testing.T
 	}
 
 	regions := []string{"us-east-1", "us-west-2", "ap-northeast-3", "eu-west-1"}
-	err, invoked := runWithSkipHandling(t, regions, plan, report)
+	invoked, err := runWithSkipHandling(t, regions, plan, report)
 
 	require.NoError(t, err, "all errors were skippable, errgroup must return nil")
 	assert.Equal(t, 4, invoked, "every region action must run")
@@ -132,7 +132,7 @@ func TestContinueOnDenied_WrappedSmithyError_IsClassifiedSkippable(t *testing.T)
 	wrapped := fmt.Errorf("list amplify apps in us-east-1: %w", &fakeAPIError{code: "AccessDeniedException", msg: "denied"})
 	plan := regionErrPlan{"us-east-1": wrapped}
 
-	err, invoked := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+	invoked, err := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
 
 	require.NoError(t, err, "wrapped skippable errors must not abort the loop")
 	assert.Equal(t, 2, invoked, "sibling region must still run")
@@ -170,7 +170,7 @@ func TestContinueOnDenied_NonSkippableError_PropagatesFatal(t *testing.T) {
 		"us-east-1": errors.New("network connection refused"),
 	}
 
-	err, _ := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+	_, err := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
 
 	require.Error(t, err, "non-skippable errors must propagate so operators see them")
 	assert.Contains(t, err.Error(), "network connection refused")
@@ -187,7 +187,7 @@ func TestContinueOnDenied_NonListedSmithyCode_PropagatesFatal(t *testing.T) {
 		"us-east-1": &fakeAPIError{code: "ThrottlingException", msg: "rate exceeded"},
 	}
 
-	err, _ := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+	_, err := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
 
 	require.Error(t, err, "ThrottlingException is intentionally not in skippableErrorCodes")
 	assert.Contains(t, err.Error(), "ThrottlingException")
@@ -204,7 +204,7 @@ func TestContinueOnDenied_EmptySmithyCode_PropagatesFatal(t *testing.T) {
 		"us-east-1": &fakeAPIError{code: "", msg: "weird coreless smithy error"},
 	}
 
-	err, _ := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
+	_, err := runWithSkipHandling(t, []string{"us-east-1", "us-east-2"}, plan, report)
 
 	require.Error(t, err, "empty smithy code with non-DNS message must NOT be classified as skippable")
 	assert.Equal(t, 0, report.Len())
@@ -237,7 +237,7 @@ func TestContinueOnDenied_HighConcurrency_AllRecorded(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			err, _ := runWithSkipHandling(t, regions, plan, report)
+			_, err := runWithSkipHandling(t, regions, plan, report)
 			errs <- err
 		}()
 	}

--- a/pkg/aws/enumeration/ec2_image_enumerator.go
+++ b/pkg/aws/enumeration/ec2_image_enumerator.go
@@ -21,14 +21,16 @@ import (
 // native EC2 SDK, enriching each image with launch permissions and usage data.
 type EC2ImageEnumerator struct {
 	plugin.AWSCommonRecon
-	provider *AWSConfigProvider
+	provider   *AWSConfigProvider
+	skipReport *SkipReport
 }
 
 // NewEC2ImageEnumerator creates an EC2ImageEnumerator that uses the native EC2 SDK.
-func NewEC2ImageEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider) *EC2ImageEnumerator {
+func NewEC2ImageEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider, skipReport *SkipReport) *EC2ImageEnumerator {
 	return &EC2ImageEnumerator{
 		AWSCommonRecon: opts,
 		provider:       provider,
+		skipReport:     skipReport,
 	}
 }
 
@@ -105,6 +107,18 @@ func (l *EC2ImageEnumerator) listImagesInRegion(region, accountID string, out *p
 		Owners: []string{"self"},
 	})
 	if err != nil {
+		if IsSkippableAWSError(err) {
+			code := SkipReason(err)
+			slog.Warn("skipping ec2 DescribeImages", "region", region, "code", code, "error", err)
+			l.skipReport.Record(SkippedOp{
+				Region:    region,
+				Service:   "ec2",
+				Operation: "DescribeImages",
+				ErrorCode: code,
+				Detail:    err.Error(),
+			})
+			return nil
+		}
 		return fmt.Errorf("describe images in %s: %w", region, err)
 	}
 
@@ -116,8 +130,21 @@ func (l *EC2ImageEnumerator) listImagesInRegion(region, accountID string, out *p
 	for _, image := range result.Images {
 		resource, err := buildResource(context.Background(), client, image, accountID, region)
 		if err != nil {
+			imageID := aws.ToString(image.ImageId)
+			if IsSkippableAWSError(err) {
+				code := SkipReason(err)
+				slog.Warn("skipping ec2 DescribeImageAttribute", "region", region, "image_id", imageID, "code", code, "error", err)
+				l.skipReport.Record(SkippedOp{
+					Region:    region,
+					Service:   "ec2",
+					Operation: "DescribeImageAttribute",
+					ErrorCode: code,
+					Detail:    err.Error(),
+				})
+				continue
+			}
 			slog.Warn("failed to build EC2 image resource",
-				"image_id", aws.ToString(image.ImageId),
+				"image_id", imageID,
 				"region", region,
 				"error", err,
 			)

--- a/pkg/aws/enumeration/ec2_image_enumerator.go
+++ b/pkg/aws/enumeration/ec2_image_enumerator.go
@@ -107,16 +107,7 @@ func (l *EC2ImageEnumerator) listImagesInRegion(region, accountID string, out *p
 		Owners: []string{"self"},
 	})
 	if err != nil {
-		if IsSkippableAWSError(err) {
-			code := SkipReason(err)
-			slog.Warn("skipping ec2 DescribeImages", "region", region, "code", code, "error", err)
-			l.skipReport.Record(SkippedOp{
-				Region:    region,
-				Service:   "ec2",
-				Operation: "DescribeImages",
-				ErrorCode: code,
-				Detail:    err.Error(),
-			})
+		if l.skipReport.RecordSkippable(err, "ec2", "DescribeImages", region) {
 			return nil
 		}
 		return fmt.Errorf("describe images in %s: %w", region, err)
@@ -131,16 +122,7 @@ func (l *EC2ImageEnumerator) listImagesInRegion(region, accountID string, out *p
 		resource, err := buildResource(context.Background(), client, image, accountID, region)
 		if err != nil {
 			imageID := aws.ToString(image.ImageId)
-			if IsSkippableAWSError(err) {
-				code := SkipReason(err)
-				slog.Warn("skipping ec2 DescribeImageAttribute", "region", region, "image_id", imageID, "code", code, "error", err)
-				l.skipReport.Record(SkippedOp{
-					Region:    region,
-					Service:   "ec2",
-					Operation: "DescribeImageAttribute",
-					ErrorCode: code,
-					Detail:    err.Error(),
-				})
+			if l.skipReport.RecordSkippable(err, "ec2", "DescribeImageAttribute", region, "image_id", imageID) {
 				continue
 			}
 			slog.Warn("failed to build EC2 image resource",

--- a/pkg/aws/enumeration/ec2_image_enumerator_integration_test.go
+++ b/pkg/aws/enumeration/ec2_image_enumerator_integration_test.go
@@ -24,7 +24,7 @@ func TestEC2ImageEnumerator(t *testing.T) {
 	enum := NewEC2ImageEnumerator(plugin.AWSCommonRecon{
 		Regions:     []string{"us-east-1"},
 		Concurrency: 2,
-	}, provider)
+	}, provider, NewSkipReport())
 
 	t.Run("EnumerateAll discovers owned AMIs", func(t *testing.T) {
 		results, err := collectImageResults(func(out *pipeline.P[output.AWSResource]) error {

--- a/pkg/aws/enumeration/enumerator.go
+++ b/pkg/aws/enumeration/enumerator.go
@@ -31,30 +31,41 @@ type ResourceEnumerator interface {
 type Enumerator struct {
 	enumerators map[string]ResourceEnumerator
 	cc          *CloudControlEnumerator
+	skipReport  *SkipReport
 }
 
 // NewEnumerator creates an Enumerator with CloudControl fallback and registers
-// all built-in resource-specific enumerators.
+// all built-in resource-specific enumerators. The SkipReport is shared across
+// all sub-enumerators so a single Summary() call surfaces every skipped
+// (region, service) pair to the operator.
 func NewEnumerator(opts plugin.AWSCommonRecon) *Enumerator {
 	provider := NewAWSConfigProvider(opts)
-	cc := NewCloudControlEnumeratorWithProvider(opts, provider)
+	skipReport := NewSkipReport()
+	cc := NewCloudControlEnumeratorWithProvider(opts, provider, skipReport)
 	e := &Enumerator{
 		enumerators: make(map[string]ResourceEnumerator),
 		cc:          cc,
+		skipReport:  skipReport,
 	}
 	// Register built-in enumerators here as they are implemented.
-	e.Register(NewAmplifyAppEnumerator(opts, provider))
-	e.Register(NewS3Enumerator(opts, provider))
+	e.Register(NewAmplifyAppEnumerator(opts, provider, skipReport))
+	e.Register(NewS3Enumerator(opts, provider, skipReport))
 
-	iamEnum := NewIAMEnumerator(opts, provider)
+	iamEnum := NewIAMEnumerator(opts, provider, skipReport)
 	e.Register(iamEnum.RoleEnumerator())
 	e.Register(iamEnum.PolicyEnumerator())
 	e.Register(iamEnum.UserEnumerator())
 
-	e.Register(NewEC2ImageEnumerator(opts, provider))
-	e.Register(NewSSMDocumentEnumerator(opts, provider))
+	e.Register(NewEC2ImageEnumerator(opts, provider, skipReport))
+	e.Register(NewSSMDocumentEnumerator(opts, provider, skipReport))
 
 	return e
+}
+
+// SkipReport returns the report aggregating all skipped per-region calls. It
+// is safe to call concurrently with enumeration in progress.
+func (e *Enumerator) SkipReport() *SkipReport {
+	return e.skipReport
 }
 
 // Register adds a ResourceEnumerator to the registry.

--- a/pkg/aws/enumeration/iam_enumerator.go
+++ b/pkg/aws/enumeration/iam_enumerator.go
@@ -3,6 +3,7 @@ package enumeration
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -20,8 +21,9 @@ import (
 // fetches once per lifetime via sync.Once.
 type IAMEnumerator struct {
 	plugin.AWSCommonRecon
-	provider  *AWSConfigProvider
-	accountID string
+	provider   *AWSConfigProvider
+	accountID  string
+	skipReport *SkipReport
 }
 
 // iamSubEnumerator implements ResourceEnumerator for a single IAM resource type.
@@ -49,10 +51,11 @@ func (s *iamSubEnumerator) EnumerateByARN(arn string, out *pipeline.P[output.AWS
 }
 
 // NewIAMEnumerator creates an IAMEnumerator.
-func NewIAMEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider) *IAMEnumerator {
+func NewIAMEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider, skipReport *SkipReport) *IAMEnumerator {
 	return &IAMEnumerator{
 		AWSCommonRecon: opts,
 		provider:       provider,
+		skipReport:     skipReport,
 	}
 }
 
@@ -117,6 +120,20 @@ func (e *IAMEnumerator) getIAMClient() (*iam.Client, error) {
 	return iam.NewFromConfig(*cfg), nil
 }
 
+// recordSkip captures a skippable IAM list failure so that a missing
+// permission on one IAM resource type doesn't abort enumeration of the others.
+func (e *IAMEnumerator) recordSkip(operation string, err error) {
+	code := SkipReason(err)
+	slog.Warn("skipping iam call", "operation", operation, "code", code, "error", err)
+	e.skipReport.Record(SkippedOp{
+		Region:    "global",
+		Service:   "iam",
+		Operation: operation,
+		ErrorCode: code,
+		Detail:    err.Error(),
+	})
+}
+
 // listRoles fetches all IAM roles with pagination.
 func (e *IAMEnumerator) listRoles(out *pipeline.P[output.AWSResource]) error {
 	if err := e.resolveAccountID(); err != nil {
@@ -137,6 +154,10 @@ func (e *IAMEnumerator) listRoles(out *pipeline.P[output.AWSResource]) error {
 
 		result, err := client.ListRoles(context.Background(), input)
 		if err != nil {
+			if IsSkippableAWSError(err) {
+				e.recordSkip("ListRoles", err)
+				return false, nil
+			}
 			return false, fmt.Errorf("list IAM roles: %w", err)
 		}
 
@@ -186,6 +207,10 @@ func (e *IAMEnumerator) listPolicies(out *pipeline.P[output.AWSResource]) error 
 
 		result, err := client.ListPolicies(context.Background(), input)
 		if err != nil {
+			if IsSkippableAWSError(err) {
+				e.recordSkip("ListPolicies", err)
+				return false, nil
+			}
 			return false, fmt.Errorf("list IAM policies: %w", err)
 		}
 
@@ -233,6 +258,10 @@ func (e *IAMEnumerator) listUsers(out *pipeline.P[output.AWSResource]) error {
 
 		result, err := client.ListUsers(context.Background(), input)
 		if err != nil {
+			if IsSkippableAWSError(err) {
+				e.recordSkip("ListUsers", err)
+				return false, nil
+			}
 			return false, fmt.Errorf("list IAM users: %w", err)
 		}
 

--- a/pkg/aws/enumeration/iam_enumerator.go
+++ b/pkg/aws/enumeration/iam_enumerator.go
@@ -3,7 +3,6 @@ package enumeration
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 	"sync"
 
@@ -120,20 +119,6 @@ func (e *IAMEnumerator) getIAMClient() (*iam.Client, error) {
 	return iam.NewFromConfig(*cfg), nil
 }
 
-// recordSkip captures a skippable IAM list failure so that a missing
-// permission on one IAM resource type doesn't abort enumeration of the others.
-func (e *IAMEnumerator) recordSkip(operation string, err error) {
-	code := SkipReason(err)
-	slog.Warn("skipping iam call", "operation", operation, "code", code, "error", err)
-	e.skipReport.Record(SkippedOp{
-		Region:    "global",
-		Service:   "iam",
-		Operation: operation,
-		ErrorCode: code,
-		Detail:    err.Error(),
-	})
-}
-
 // listRoles fetches all IAM roles with pagination.
 func (e *IAMEnumerator) listRoles(out *pipeline.P[output.AWSResource]) error {
 	if err := e.resolveAccountID(); err != nil {
@@ -154,8 +139,7 @@ func (e *IAMEnumerator) listRoles(out *pipeline.P[output.AWSResource]) error {
 
 		result, err := client.ListRoles(context.Background(), input)
 		if err != nil {
-			if IsSkippableAWSError(err) {
-				e.recordSkip("ListRoles", err)
+			if e.skipReport.RecordSkippable(err, "iam", "ListRoles", "global") {
 				return false, nil
 			}
 			return false, fmt.Errorf("list IAM roles: %w", err)
@@ -207,8 +191,7 @@ func (e *IAMEnumerator) listPolicies(out *pipeline.P[output.AWSResource]) error 
 
 		result, err := client.ListPolicies(context.Background(), input)
 		if err != nil {
-			if IsSkippableAWSError(err) {
-				e.recordSkip("ListPolicies", err)
+			if e.skipReport.RecordSkippable(err, "iam", "ListPolicies", "global") {
 				return false, nil
 			}
 			return false, fmt.Errorf("list IAM policies: %w", err)
@@ -258,8 +241,7 @@ func (e *IAMEnumerator) listUsers(out *pipeline.P[output.AWSResource]) error {
 
 		result, err := client.ListUsers(context.Background(), input)
 		if err != nil {
-			if IsSkippableAWSError(err) {
-				e.recordSkip("ListUsers", err)
+			if e.skipReport.RecordSkippable(err, "iam", "ListUsers", "global") {
 				return false, nil
 			}
 			return false, fmt.Errorf("list IAM users: %w", err)

--- a/pkg/aws/enumeration/s3_enumerator.go
+++ b/pkg/aws/enumeration/s3_enumerator.go
@@ -3,6 +3,7 @@ package enumeration
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -17,15 +18,17 @@ import (
 // region filtering, avoiding the duplicate enumeration that CloudControl causes.
 type S3Enumerator struct {
 	plugin.AWSCommonRecon
-	provider  *AWSConfigProvider
-	accountID string
+	provider   *AWSConfigProvider
+	accountID  string
+	skipReport *SkipReport
 }
 
 // NewS3Enumerator creates an S3Enumerator that uses the native S3 SDK.
-func NewS3Enumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider) *S3Enumerator {
+func NewS3Enumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider, skipReport *SkipReport) *S3Enumerator {
 	return &S3Enumerator{
 		AWSCommonRecon: opts,
 		provider:       provider,
+		skipReport:     skipReport,
 	}
 }
 
@@ -128,6 +131,18 @@ func (l *S3Enumerator) listBucketsInRegion(region string, out *pipeline.P[output
 
 		result, err := client.ListBuckets(context.Background(), input)
 		if err != nil {
+			if IsSkippableAWSError(err) {
+				code := SkipReason(err)
+				slog.Warn("skipping s3 ListBuckets", "region", region, "code", code, "error", err)
+				l.skipReport.Record(SkippedOp{
+					Region:    region,
+					Service:   "s3",
+					Operation: "ListBuckets",
+					ErrorCode: code,
+					Detail:    err.Error(),
+				})
+				return false, nil
+			}
 			return false, fmt.Errorf("list buckets in %s: %w", region, err)
 		}
 

--- a/pkg/aws/enumeration/s3_enumerator.go
+++ b/pkg/aws/enumeration/s3_enumerator.go
@@ -3,7 +3,6 @@ package enumeration
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -131,16 +130,7 @@ func (l *S3Enumerator) listBucketsInRegion(region string, out *pipeline.P[output
 
 		result, err := client.ListBuckets(context.Background(), input)
 		if err != nil {
-			if IsSkippableAWSError(err) {
-				code := SkipReason(err)
-				slog.Warn("skipping s3 ListBuckets", "region", region, "code", code, "error", err)
-				l.skipReport.Record(SkippedOp{
-					Region:    region,
-					Service:   "s3",
-					Operation: "ListBuckets",
-					ErrorCode: code,
-					Detail:    err.Error(),
-				})
+			if l.skipReport.RecordSkippable(err, "s3", "ListBuckets", region) {
 				return false, nil
 			}
 			return false, fmt.Errorf("list buckets in %s: %w", region, err)

--- a/pkg/aws/enumeration/skip_report.go
+++ b/pkg/aws/enumeration/skip_report.go
@@ -1,0 +1,144 @@
+package enumeration
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// SkippedOp captures a single skipped (region, service) operation so the
+// operator can see, after the run, which AWS calls were denied or unsupported
+// without losing them in the noise.
+type SkippedOp struct {
+	Region    string // AWS region (or "global" for IAM and other non-regional services)
+	Service   string // short service name, e.g. "amplify", "ec2", "iam"
+	Operation string // AWS API operation, e.g. "ListApps", "DescribeImages"
+	ErrorCode string // smithy code or "RegionUnsupported" / "Unknown"
+	Detail    string // truncated raw error string (<= 500 chars)
+}
+
+const maxDetailLen = 500
+
+// SkipReport is a thread-safe aggregator for SkippedOp records emitted from
+// multiple goroutines during cross-region enumeration.
+type SkipReport struct {
+	mu  sync.Mutex
+	ops []SkippedOp
+}
+
+// NewSkipReport returns an empty SkipReport ready for concurrent use.
+func NewSkipReport() *SkipReport {
+	return &SkipReport{}
+}
+
+// Record appends a SkippedOp to the report. The Detail field is truncated to
+// at most 500 characters before storage.
+func (r *SkipReport) Record(op SkippedOp) {
+	if len(op.Detail) > maxDetailLen {
+		op.Detail = op.Detail[:maxDetailLen]
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ops = append(r.ops, op)
+}
+
+// Snapshot returns a copy of the current set of recorded ops, safe for use
+// without holding the lock.
+func (r *SkipReport) Snapshot() []SkippedOp {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]SkippedOp, len(r.ops))
+	copy(cp, r.ops)
+	return cp
+}
+
+// Len returns the number of recorded skips.
+func (r *SkipReport) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.ops)
+}
+
+// Summary renders a human-readable, deterministic summary grouped by
+// "<service> <operation>" with all affected regions and the dominant error
+// code per group. Returns an empty string if no ops were recorded.
+func (r *SkipReport) Summary() string {
+	ops := r.Snapshot()
+	if len(ops) == 0 {
+		return ""
+	}
+
+	type groupKey struct {
+		service   string
+		operation string
+	}
+	type groupVal struct {
+		regions map[string]struct{}
+		codes   map[string]int
+	}
+
+	groups := make(map[groupKey]*groupVal)
+	for _, op := range ops {
+		k := groupKey{service: op.Service, operation: op.Operation}
+		g, ok := groups[k]
+		if !ok {
+			g = &groupVal{
+				regions: make(map[string]struct{}),
+				codes:   make(map[string]int),
+			}
+			groups[k] = g
+		}
+		g.regions[op.Region] = struct{}{}
+		g.codes[op.ErrorCode]++
+	}
+
+	keys := make([]groupKey, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].service != keys[j].service {
+			return keys[i].service < keys[j].service
+		}
+		return keys[i].operation < keys[j].operation
+	})
+
+	allRegions := make(map[string]struct{})
+	for _, g := range groups {
+		for region := range g.regions {
+			allRegions[region] = struct{}{}
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "skipped %d operations across %d regions:\n", len(ops), len(allRegions))
+	for _, k := range keys {
+		g := groups[k]
+
+		regions := make([]string, 0, len(g.regions))
+		for r := range g.regions {
+			regions = append(regions, r)
+		}
+		sort.Strings(regions)
+
+		code := dominantCode(g.codes)
+
+		fmt.Fprintf(&b, "  %s %s: %s [%s]\n", k.service, k.operation, strings.Join(regions, ", "), code)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// dominantCode returns the code with the highest count; ties broken
+// alphabetically to keep output stable.
+func dominantCode(counts map[string]int) string {
+	best := ""
+	bestN := -1
+	for code, n := range counts {
+		if n > bestN || (n == bestN && code < best) {
+			best = code
+			bestN = n
+		}
+	}
+	return best
+}

--- a/pkg/aws/enumeration/skip_report.go
+++ b/pkg/aws/enumeration/skip_report.go
@@ -2,6 +2,7 @@ package enumeration
 
 import (
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -30,6 +31,30 @@ type SkipReport struct {
 // NewSkipReport returns an empty SkipReport ready for concurrent use.
 func NewSkipReport() *SkipReport {
 	return &SkipReport{}
+}
+
+// RecordSkippable classifies err and, if it represents a non-fatal
+// per-(region, service) failure, logs at Warn and records the skip. Returns
+// true when the error was handled (skippable) and the caller should treat it
+// as a soft success; false when err is fatal and the caller must propagate it.
+//
+// extraLogAttrs are appended to the standard Warn attributes ("region",
+// "code", "error"); pass them as key/value pairs, e.g. "arn", resourceARN.
+func (r *SkipReport) RecordSkippable(err error, service, operation, region string, extraLogAttrs ...any) bool {
+	if !IsSkippableAWSError(err) {
+		return false
+	}
+	code := SkipReason(err)
+	attrs := append([]any{"region", region, "code", code, "error", err}, extraLogAttrs...)
+	slog.Warn("skipping "+service+" "+operation, attrs...)
+	r.Record(SkippedOp{
+		Region:    region,
+		Service:   service,
+		Operation: operation,
+		ErrorCode: code,
+		Detail:    err.Error(),
+	})
+	return true
 }
 
 // Record appends a SkippedOp to the report. The Detail field is truncated to

--- a/pkg/aws/enumeration/skip_report_test.go
+++ b/pkg/aws/enumeration/skip_report_test.go
@@ -1,0 +1,90 @@
+package enumeration
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipReport_Empty(t *testing.T) {
+	r := NewSkipReport()
+	assert.Equal(t, 0, r.Len())
+	assert.Empty(t, r.Snapshot())
+	assert.Empty(t, r.Summary())
+}
+
+func TestSkipReport_RecordTruncatesDetail(t *testing.T) {
+	r := NewSkipReport()
+	long := strings.Repeat("x", 600)
+	r.Record(SkippedOp{Region: "us-east-1", Service: "amplify", Operation: "ListApps", ErrorCode: "AccessDeniedException", Detail: long})
+
+	snap := r.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Len(t, snap[0].Detail, 500)
+}
+
+func TestSkipReport_ConcurrentRecord(t *testing.T) {
+	r := NewSkipReport()
+
+	const goroutines = 20
+	const perGoroutine = 50
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				r.Record(SkippedOp{
+					Region:    "us-east-1",
+					Service:   "amplify",
+					Operation: "ListApps",
+					ErrorCode: "AccessDeniedException",
+				})
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, goroutines*perGoroutine, r.Len())
+}
+
+func TestSkipReport_SummaryGroupsAndSorts(t *testing.T) {
+	r := NewSkipReport()
+	r.Record(SkippedOp{Region: "ap-northeast-3", Service: "amplify", Operation: "ListApps", ErrorCode: "AccessDeniedException"})
+	r.Record(SkippedOp{Region: "eu-south-1", Service: "amplify", Operation: "ListApps", ErrorCode: "AccessDeniedException"})
+	r.Record(SkippedOp{Region: "ap-east-1", Service: "amplify", Operation: "ListApps", ErrorCode: "AccessDeniedException"})
+	r.Record(SkippedOp{Region: "me-south-1", Service: "ec2", Operation: "DescribeImages", ErrorCode: "OptInRequired"})
+
+	got := r.Summary()
+	expected := strings.Join([]string{
+		"skipped 4 operations across 4 regions:",
+		"  amplify ListApps: ap-east-1, ap-northeast-3, eu-south-1 [AccessDeniedException]",
+		"  ec2 DescribeImages: me-south-1 [OptInRequired]",
+	}, "\n")
+	assert.Equal(t, expected, got)
+}
+
+func TestSkipReport_SummaryDominantCode(t *testing.T) {
+	r := NewSkipReport()
+	r.Record(SkippedOp{Region: "us-east-1", Service: "iam", Operation: "ListRoles", ErrorCode: "AccessDenied"})
+	r.Record(SkippedOp{Region: "us-east-2", Service: "iam", Operation: "ListRoles", ErrorCode: "AccessDenied"})
+	r.Record(SkippedOp{Region: "us-east-3", Service: "iam", Operation: "ListRoles", ErrorCode: "RegionUnsupported"})
+
+	got := r.Summary()
+	assert.Contains(t, got, "[AccessDenied]")
+}
+
+func TestSkipReport_SummaryDominantCodeTieBreak(t *testing.T) {
+	r := NewSkipReport()
+	// Equal counts: one AccessDenied, one OptInRequired in the same group.
+	// Alphabetically AccessDenied < OptInRequired, so AccessDenied wins.
+	r.Record(SkippedOp{Region: "us-east-1", Service: "iam", Operation: "ListRoles", ErrorCode: "OptInRequired"})
+	r.Record(SkippedOp{Region: "us-east-2", Service: "iam", Operation: "ListRoles", ErrorCode: "AccessDenied"})
+
+	got := r.Summary()
+	assert.Contains(t, got, "[AccessDenied]")
+	assert.NotContains(t, got, "[OptInRequired]")
+}

--- a/pkg/aws/enumeration/skiperror.go
+++ b/pkg/aws/enumeration/skiperror.go
@@ -1,0 +1,81 @@
+package enumeration
+
+import (
+	"errors"
+	"strings"
+
+	smithy "github.com/aws/smithy-go"
+)
+
+// skippableErrorCodes lists smithy/AWS error codes that indicate a single
+// (region, service) call should be skipped rather than failing the whole
+// enumeration run. Covers SCP explicit denies, missing permissions, opt-in
+// regions, and CloudControl type-not-supported responses.
+var skippableErrorCodes = map[string]struct{}{
+	"AccessDenied":                {},
+	"AccessDeniedException":       {},
+	"UnauthorizedOperation":       {},
+	"AuthFailure":                 {},
+	"OptInRequired":               {},
+	"InvalidClientTokenId":        {},
+	"UnrecognizedClientException": {},
+	"TypeNotFoundException":       {},
+	"UnsupportedActionException":  {},
+}
+
+// IsSkippableAWSError reports whether the error is a non-fatal AWS API failure
+// for a single (region, service) call: a known auth/opt-in/type code, or a
+// DNS/endpoint resolution failure indicating the service is unavailable in the
+// region.
+func IsSkippableAWSError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if code, ok := extractAPIErrorCode(err); ok {
+		if _, found := skippableErrorCodes[code]; found {
+			return true
+		}
+	}
+	return isRegionUnsupportedError(err)
+}
+
+// SkipReason returns the smithy error code if the error has one, otherwise
+// "RegionUnsupported" for DNS/endpoint failures, or "Unknown" for any other
+// non-coded error. Caller is expected to use this only after IsSkippableAWSError.
+func SkipReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	if code, ok := extractAPIErrorCode(err); ok {
+		return code
+	}
+	if isRegionUnsupportedError(err) {
+		return "RegionUnsupported"
+	}
+	return "Unknown"
+}
+
+// extractAPIErrorCode unwraps err looking for a smithy.APIError and returns
+// (code, true) only when a non-empty smithy error code is present.
+func extractAPIErrorCode(err error) (string, bool) {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		code := apiErr.ErrorCode()
+		return code, code != ""
+	}
+	return "", false
+}
+
+// isRegionUnsupportedError returns true when the error indicates the AWS
+// service is not available in the target region (DNS resolution failure or
+// explicit region-not-supported response). These errors aren't smithy-coded,
+// so substring matching is the only signal available.
+func isRegionUnsupportedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "could not resolve endpoint") ||
+		strings.Contains(msg, "EndpointNotFound")
+}

--- a/pkg/aws/enumeration/skiperror_test.go
+++ b/pkg/aws/enumeration/skiperror_test.go
@@ -1,0 +1,72 @@
+package enumeration
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	smithy "github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeAPIError implements smithy.APIError for tests.
+type fakeAPIError struct {
+	code string
+	msg  string
+}
+
+func (e *fakeAPIError) Error() string                 { return fmt.Sprintf("%s: %s", e.code, e.msg) }
+func (e *fakeAPIError) ErrorCode() string             { return e.code }
+func (e *fakeAPIError) ErrorMessage() string          { return e.msg }
+func (e *fakeAPIError) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
+
+func TestIsSkippableAWSError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"AccessDenied", &fakeAPIError{code: "AccessDenied"}, true},
+		{"AccessDeniedException", &fakeAPIError{code: "AccessDeniedException"}, true},
+		{"UnauthorizedOperation", &fakeAPIError{code: "UnauthorizedOperation"}, true},
+		{"AuthFailure", &fakeAPIError{code: "AuthFailure"}, true},
+		{"OptInRequired", &fakeAPIError{code: "OptInRequired"}, true},
+		{"InvalidClientTokenId", &fakeAPIError{code: "InvalidClientTokenId"}, true},
+		{"UnrecognizedClientException", &fakeAPIError{code: "UnrecognizedClientException"}, true},
+		{"TypeNotFoundException", &fakeAPIError{code: "TypeNotFoundException"}, true},
+		{"UnsupportedActionException", &fakeAPIError{code: "UnsupportedActionException"}, true},
+		{"unrelated smithy code", &fakeAPIError{code: "ThrottlingException"}, false},
+		{"wrapped AccessDenied", fmt.Errorf("list amplify apps: %w", &fakeAPIError{code: "AccessDeniedException"}), true},
+		{"region unsupported - no such host", errors.New("dial tcp: lookup amplify.eu-south-1.amazonaws.com: no such host"), true},
+		{"region unsupported - resolve endpoint", errors.New("could not resolve endpoint"), true},
+		{"region unsupported - EndpointNotFound", errors.New("EndpointNotFound for service in region"), true},
+		{"plain unrelated error", errors.New("network connection refused"), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsSkippableAWSError(tc.err))
+		})
+	}
+}
+
+func TestSkipReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"smithy code", &fakeAPIError{code: "AccessDeniedException"}, "AccessDeniedException"},
+		{"wrapped smithy code", fmt.Errorf("ctx: %w", &fakeAPIError{code: "OptInRequired"}), "OptInRequired"},
+		{"region unsupported", errors.New("no such host"), "RegionUnsupported"},
+		{"unknown", errors.New("something else"), "Unknown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, SkipReason(tc.err))
+		})
+	}
+}

--- a/pkg/aws/enumeration/ssm_document_enumerator.go
+++ b/pkg/aws/enumeration/ssm_document_enumerator.go
@@ -3,6 +3,7 @@ package enumeration
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,13 +21,15 @@ import (
 // documents.
 type SSMDocumentEnumerator struct {
 	plugin.AWSCommonRecon
-	provider *AWSConfigProvider
+	provider   *AWSConfigProvider
+	skipReport *SkipReport
 }
 
-func NewSSMDocumentEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider) *SSMDocumentEnumerator {
+func NewSSMDocumentEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider, skipReport *SkipReport) *SSMDocumentEnumerator {
 	return &SSMDocumentEnumerator{
 		AWSCommonRecon: opts,
 		provider:       provider,
+		skipReport:     skipReport,
 	}
 }
 
@@ -115,6 +118,18 @@ func (e *SSMDocumentEnumerator) listDocumentsInRegion(region, accountID string, 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.Background())
 		if err != nil {
+			if IsSkippableAWSError(err) {
+				code := SkipReason(err)
+				slog.Warn("skipping ssm ListDocuments", "region", region, "code", code, "error", err)
+				e.skipReport.Record(SkippedOp{
+					Region:    region,
+					Service:   "ssm",
+					Operation: "ListDocuments",
+					ErrorCode: code,
+					Detail:    err.Error(),
+				})
+				return nil
+			}
 			return fmt.Errorf("list documents in %s: %w", region, err)
 		}
 

--- a/pkg/aws/enumeration/ssm_document_enumerator.go
+++ b/pkg/aws/enumeration/ssm_document_enumerator.go
@@ -3,7 +3,6 @@ package enumeration
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -118,16 +117,7 @@ func (e *SSMDocumentEnumerator) listDocumentsInRegion(region, accountID string, 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.Background())
 		if err != nil {
-			if IsSkippableAWSError(err) {
-				code := SkipReason(err)
-				slog.Warn("skipping ssm ListDocuments", "region", region, "code", code, "error", err)
-				e.skipReport.Record(SkippedOp{
-					Region:    region,
-					Service:   "ssm",
-					Operation: "ListDocuments",
-					ErrorCode: code,
-					Detail:    err.Error(),
-				})
+			if e.skipReport.RecordSkippable(err, "ssm", "ListDocuments", region) {
 				return nil
 			}
 			return fmt.Errorf("list documents in %s: %w", region, err)

--- a/pkg/aws/enumeration/ssm_document_enumerator_test.go
+++ b/pkg/aws/enumeration/ssm_document_enumerator_test.go
@@ -15,7 +15,7 @@ func TestSSMDocumentEnumerator_ResourceType(t *testing.T) {
 	enum := NewSSMDocumentEnumerator(plugin.AWSCommonRecon{
 		Regions:     []string{"us-east-1"},
 		Concurrency: 2,
-	}, provider)
+	}, provider, NewSkipReport())
 
 	assert.Equal(t, "AWS::SSM::Document", enum.ResourceType())
 }

--- a/pkg/modules/aws/recon/list_all_resources.go
+++ b/pkg/modules/aws/recon/list_all_resources.go
@@ -84,9 +84,16 @@ func (m *AWSListAllResourcesModule) Run(cfg plugin.Config, out *pipeline.P[model
 		out.Send(r)
 	}
 
+	defer func() {
+		if lister.SkipReport().Len() > 0 {
+			cfg.Info("%s", lister.SkipReport().Summary())
+		}
+	}()
+
 	if err := enriched.Wait(); err != nil {
 		return err
 	}
+
 	cfg.Success("enumerated %d resources", count)
 	return nil
 }


### PR DESCRIPTION
## Summary

- AWS recon previously halted on the first `AccessDeniedException` (e.g. an SCP `explicit deny` on a single region/service), making the tool fragile against partitioned, SCP-restricted AWS environments
- Adds a shared smithy-code-based `IsSkippableAWSError` classifier + thread-safe `SkipReport` aggregator, wired through every native enumerator (Amplify, S3, EC2, SSM, IAM) and CloudControl
- The `list-all` module now emits a grouped skip summary via `defer` so operators see the skipped `(region, service)` pairs on both success and partial-failure paths

Skippable error codes: `AccessDenied`, `AccessDeniedException`, `UnauthorizedOperation`, `AuthFailure`, `OptInRequired`, `InvalidClientTokenId`, `UnrecognizedClientException`, `TypeNotFoundException`, `UnsupportedActionException`, plus DNS/endpoint-not-found (region unsupported).

Fatal errors (STS `GetAccountID`, AWS config setup, no configured regions) remain fatal.

Closes [LAB-3328](https://linear.app/praetorianlabs/issue/LAB-3328)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags=integration ./...`
- [x] `go test ./pkg/aws/enumeration/... ./pkg/modules/aws/recon/...`
- [x] `go test -race ./pkg/aws/enumeration/...`
- [x] New unit tests in `pkg/aws/enumeration/continue_on_denied_test.go` (9 cases) — verify the loop continues across regions when one returns `AccessDeniedException`, and that `SkipReport` is populated with the correct tuple
- [x] Full real-AWS integration suite (`AWS_PROFILE=bfr go test -tags=integration -timeout 30m ./pkg/modules/aws/recon/...`): `TestAWSList` 7/7 sub-tests PASS in 28s; logs confirm the fix engaging on real AWS — `WARN skipping cloudcontrol ListResources type=AWS::OpenSearchService::Domain code=UnsupportedActionException` and the run continued through downstream tests
- [x] Two pre-existing failures (`TestAWSFindSecrets/detects_secret_in_ECS_Task_Def`, `TestAWSIAMQuickAnalyze`) reproduced on `main` (commit `ecccd05f`) — unrelated to this fix