### PR TITLE
fix(azure/apim): silence errcheck on deferred resp.Body.Close

### DIFF
--- a/pkg/azure/apim/list.go
+++ b/pkg/azure/apim/list.go
@@ -115,7 +115,7 @@ func ListAPIs(ctx context.Context, cred azcore.TokenCredential, subscriptionID, 
 			// runtime helper consumes resp.Body on our behalf.
 			return false, runtime.NewResponseError(resp)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		page, nextLink, perr := parsePager(resp)
 		if perr != nil {
@@ -160,7 +160,7 @@ func redactURL(u *url.URL) string {
 // parsePager reads the response body into an apiListResponse via the existing
 // page-parsing path.
 func parsePager(resp *http.Response) ([]APIInventoryItem, string, error) {
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	dec := json.NewDecoder(resp.Body)
 	var listResp apiListResponse
 	if err := dec.Decode(&listResp); err != nil {


### PR DESCRIPTION
## Summary

- `golangci-lint`'s `errcheck` is currently failing on every open PR with two unchecked `defer resp.Body.Close()` errors in `pkg/azure/apim/list.go` (lines 118, 163).
- Wraps each `defer` in `func() { _ = resp.Body.Close() }()`, the form already used in `pkg/azure/armenum/policy_raw.go`, `pkg/azure/extraction/extract_*.go`, `pkg/utils/http.go`, `pkg/aws/dnstakeover/check_eip.go`, `pkg/modules/aws/recon/get_console.go`, etc.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/azure/apim/...`
- [x] `golangci-lint run --timeout=5m pkg/azure/apim/...` → `0 issues`