### PR TITLE
ci: add Claude, Codex, and Gemini PR reviewer workflows

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,20 @@
+name: Claude PR Assistant
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: claude-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude-code-action:
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.0.12
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/codex-code.yml
+++ b/.github/workflows/codex-code.yml
@@ -1,0 +1,28 @@
+name: Codex PR Review
+
+# Thin caller of the centralized hardened Codex PR reviewer
+# (praetorian-inc/public-workflows). All security posture lives there:
+# same-repo gate, anti-injection prompt, drop-sudo sandbox, Harden-Runner,
+# CODEOWNERS on the reusable workflow file. Do not copy security settings
+# back into this file — always widen via a PR to public-workflows.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: codex-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codex-review:
+    uses: praetorian-inc/public-workflows/.github/workflows/codex-code.yml@25c08fbd15a931e275f207ecee1758c931f89ea5  # v2.1.0  # v2.1.2 (private repo pre-fetch fix)
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      model: "gpt-5.4"
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -1,0 +1,23 @@
+name: Gemini PR Assistant
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: gemini-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gemini-review:
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event_name != 'pull_request_review_comment' || contains(github.event.comment.body, '@gemini'))
+    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.1.0
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Adds the three AI PR-reviewer caller workflows, matching the pattern used by the capability repos (brutus, cato, …) and guard-core.

- `claude-code.yml` → public-workflows `claude-code.yml@v2.1.0`
- `codex-code.yml` → public-workflows `codex-code.yml@25c08fbd` (private-repo pre-fetch fix; model gpt-5.4)
- `gemini-code.yml` → public-workflows `gemini-code.yml@v2.1.0`

Closes the AI-reviewer coverage gap (aurelian was the only capability repo with no reviewers). Requires org secrets `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` to be available to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)