### PR TITLE
fix(ci): grant pull-requests: read to secrets-scan (fixes startup_failure)

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -23,5 +23,6 @@ jobs:
       contents: read
       security-events: write
       actions: read
+      pull-requests: read
     secrets: inherit
 


### PR DESCRIPTION
titus-scan preflight needs pull-requests: read; caller didn't grant it -> startup_failure. Public repo: upload to Security tab works once started.