### PR TITLE
Improve Cognito user pool collection (pagination + tests)

### DIFF
--- a/pkg/modules/aws/enrichers/cognito.go
+++ b/pkg/modules/aws/enrichers/cognito.go
@@ -3,8 +3,8 @@ package enrichers
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"fmt"
+	"log/slog"
 
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	cognitotypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
@@ -81,75 +81,95 @@ func EnrichCognitoUserPool(cfg plugin.EnricherConfig, r *output.AWSResource, cli
 	}
 
 	// List and describe user pool clients
-	clientsOut, err := client.ListUserPoolClients(cfg.Context, &cognitoidentityprovider.ListUserPoolClientsInput{
-		UserPoolId: &poolID,
-		MaxResults: int32Ptr(60),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list user pool clients: %w", err)
-	}
-
 	var clientProps []map[string]any
-	for _, clientDesc := range clientsOut.UserPoolClients {
-		if clientDesc.ClientId == nil {
-			continue
-		}
-		clientOut, err := client.DescribeUserPoolClient(cfg.Context, &cognitoidentityprovider.DescribeUserPoolClientInput{
+	var clientsToken *string
+	for {
+		clientsOut, err := client.ListUserPoolClients(cfg.Context, &cognitoidentityprovider.ListUserPoolClientsInput{
 			UserPoolId: &poolID,
-			ClientId:   clientDesc.ClientId,
+			MaxResults: int32Ptr(60),
+			NextToken:  clientsToken,
 		})
 		if err != nil {
-			slog.Warn("failed to describe user pool client",
-				"pool_id", poolID,
-				"client_id", stringVal(clientDesc.ClientId),
-				"error", err,
-			)
-			continue
+			return fmt.Errorf("failed to list user pool clients: %w", err)
 		}
 
-		c := clientOut.UserPoolClient
-		prop := map[string]any{
-			"ClientId":   stringVal(c.ClientId),
-			"ClientName": stringVal(c.ClientName),
-		}
-		if len(c.AllowedOAuthFlows) > 0 {
-			var flows []string
-			for _, f := range c.AllowedOAuthFlows {
-				flows = append(flows, string(f))
+		for _, clientDesc := range clientsOut.UserPoolClients {
+			if clientDesc.ClientId == nil {
+				continue
 			}
-			prop["AllowedOAuthFlows"] = flows
+			clientOut, err := client.DescribeUserPoolClient(cfg.Context, &cognitoidentityprovider.DescribeUserPoolClientInput{
+				UserPoolId: &poolID,
+				ClientId:   clientDesc.ClientId,
+			})
+			if err != nil {
+				slog.Warn("failed to describe user pool client",
+					"pool_id", poolID,
+					"client_id", stringVal(clientDesc.ClientId),
+					"error", err,
+				)
+				continue
+			}
+
+			c := clientOut.UserPoolClient
+			prop := map[string]any{
+				"ClientId":   stringVal(c.ClientId),
+				"ClientName": stringVal(c.ClientName),
+			}
+			if len(c.AllowedOAuthFlows) > 0 {
+				var flows []string
+				for _, f := range c.AllowedOAuthFlows {
+					flows = append(flows, string(f))
+				}
+				prop["AllowedOAuthFlows"] = flows
+			}
+			if len(c.CallbackURLs) > 0 {
+				prop["CallbackURLs"] = c.CallbackURLs
+			}
+			if len(c.AllowedOAuthScopes) > 0 {
+				prop["AllowedOAuthScopes"] = c.AllowedOAuthScopes
+			}
+			clientProps = append(clientProps, prop)
 		}
-		if len(c.CallbackURLs) > 0 {
-			prop["CallbackURLs"] = c.CallbackURLs
+
+		if clientsOut.NextToken == nil {
+			break
 		}
-		if len(c.AllowedOAuthScopes) > 0 {
-			prop["AllowedOAuthScopes"] = c.AllowedOAuthScopes
-		}
-		clientProps = append(clientProps, prop)
+		clientsToken = clientsOut.NextToken
 	}
 	if len(clientProps) > 0 {
 		r.Properties["ClientProperties"] = clientProps
 	}
 
-	// Collect IAM roles from user pool groups
-	groupsOut, err := client.ListGroups(cfg.Context, &cognitoidentityprovider.ListGroupsInput{
-		UserPoolId: &poolID,
-	})
-	if err != nil {
-		slog.Warn("failed to list user pool groups",
-			"pool_id", poolID,
-			"error", err,
-		)
-	} else if groupsOut != nil {
-		var roles []string
+	// Collect IAM roles from user pool groups. Duplicate ARNs across groups are preserved.
+	var roles []string
+	var nextToken *string
+	for {
+		groupsOut, err := client.ListGroups(cfg.Context, &cognitoidentityprovider.ListGroupsInput{
+			UserPoolId: &poolID,
+			NextToken:  nextToken,
+		})
+		if err != nil {
+			slog.Warn("failed to list user pool groups",
+				"pool_id", poolID,
+				"error", err,
+			)
+			break
+		}
+		if groupsOut == nil {
+			break
+		}
 		for _, group := range groupsOut.Groups {
 			if group.RoleArn != nil && *group.RoleArn != "" {
 				roles = append(roles, *group.RoleArn)
 			}
 		}
-		if len(roles) > 0 {
-			r.Properties["Roles"] = roles
+		if groupsOut.NextToken == nil {
+			break
 		}
+		nextToken = groupsOut.NextToken
+	}
+	if len(roles) > 0 {
+		r.Properties["Roles"] = roles
 	}
 
 	return nil

--- a/pkg/modules/aws/enrichers/cognito_test.go
+++ b/pkg/modules/aws/enrichers/cognito_test.go
@@ -52,16 +52,9 @@ func (m *mockCognitoClient) ListUserPoolClients(ctx context.Context, params *cog
 
 func (m *mockCognitoClient) DescribeUserPoolClient(ctx context.Context, params *cognitoidentityprovider.DescribeUserPoolClientInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.DescribeUserPoolClientOutput, error) {
 	if m.describeClientFunc != nil {
-		return m.describeClientFunc(stringPtrVal(params.ClientId))
+		return m.describeClientFunc(aws.ToString(params.ClientId))
 	}
 	return m.describeClientOutput, m.describeClientError
-}
-
-func stringPtrVal(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
 }
 
 func (m *mockCognitoClient) ListGroups(ctx context.Context, params *cognitoidentityprovider.ListGroupsInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.ListGroupsOutput, error) {

--- a/pkg/modules/aws/enrichers/cognito_test.go
+++ b/pkg/modules/aws/enrichers/cognito_test.go
@@ -2,6 +2,7 @@ package enrichers_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -18,11 +19,16 @@ type mockCognitoClient struct {
 	describePoolOutput   *cognitoidentityprovider.DescribeUserPoolOutput
 	describePoolError    error
 	listClientsOutput    *cognitoidentityprovider.ListUserPoolClientsOutput
+	listClientsOutputs   []*cognitoidentityprovider.ListUserPoolClientsOutput
 	listClientsError     error
+	listClientsInputs    []*cognitoidentityprovider.ListUserPoolClientsInput
 	describeClientOutput *cognitoidentityprovider.DescribeUserPoolClientOutput
 	describeClientError  error
+	describeClientFunc   func(clientID string) (*cognitoidentityprovider.DescribeUserPoolClientOutput, error)
 	listGroupsOutput     *cognitoidentityprovider.ListGroupsOutput
+	listGroupsOutputs    []*cognitoidentityprovider.ListGroupsOutput
 	listGroupsError      error
+	listGroupsInputs     []*cognitoidentityprovider.ListGroupsInput
 }
 
 func (m *mockCognitoClient) DescribeUserPool(ctx context.Context, params *cognitoidentityprovider.DescribeUserPoolInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.DescribeUserPoolOutput, error) {
@@ -30,14 +36,46 @@ func (m *mockCognitoClient) DescribeUserPool(ctx context.Context, params *cognit
 }
 
 func (m *mockCognitoClient) ListUserPoolClients(ctx context.Context, params *cognitoidentityprovider.ListUserPoolClientsInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.ListUserPoolClientsOutput, error) {
-	return m.listClientsOutput, m.listClientsError
+	m.listClientsInputs = append(m.listClientsInputs, params)
+	if m.listClientsError != nil {
+		return nil, m.listClientsError
+	}
+	if len(m.listClientsOutputs) > 0 {
+		idx := len(m.listClientsInputs) - 1
+		if idx >= len(m.listClientsOutputs) {
+			return nil, nil
+		}
+		return m.listClientsOutputs[idx], nil
+	}
+	return m.listClientsOutput, nil
 }
 
 func (m *mockCognitoClient) DescribeUserPoolClient(ctx context.Context, params *cognitoidentityprovider.DescribeUserPoolClientInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.DescribeUserPoolClientOutput, error) {
+	if m.describeClientFunc != nil {
+		return m.describeClientFunc(stringPtrVal(params.ClientId))
+	}
 	return m.describeClientOutput, m.describeClientError
 }
 
+func stringPtrVal(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
 func (m *mockCognitoClient) ListGroups(ctx context.Context, params *cognitoidentityprovider.ListGroupsInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.ListGroupsOutput, error) {
+	m.listGroupsInputs = append(m.listGroupsInputs, params)
+	if m.listGroupsError != nil {
+		return nil, m.listGroupsError
+	}
+	if len(m.listGroupsOutputs) > 0 {
+		idx := len(m.listGroupsInputs) - 1
+		if idx >= len(m.listGroupsOutputs) {
+			return nil, nil
+		}
+		return m.listGroupsOutputs[idx], nil
+	}
 	return m.listGroupsOutput, m.listGroupsError
 }
 
@@ -141,10 +179,10 @@ func TestEnrichCognitoUserPool_WithClients(t *testing.T) {
 		},
 		describeClientOutput: &cognitoidentityprovider.DescribeUserPoolClientOutput{
 			UserPoolClient: &cognitotypes.UserPoolClientType{
-				ClientId:          aws.String("client-1"),
-				ClientName:        aws.String("WebApp"),
-				AllowedOAuthFlows: []cognitotypes.OAuthFlowType{cognitotypes.OAuthFlowTypeCode},
-				CallbackURLs:      []string{"https://app.example.com/callback"},
+				ClientId:           aws.String("client-1"),
+				ClientName:         aws.String("WebApp"),
+				AllowedOAuthFlows:  []cognitotypes.OAuthFlowType{cognitotypes.OAuthFlowTypeCode},
+				CallbackURLs:       []string{"https://app.example.com/callback"},
 				AllowedOAuthScopes: []string{"openid", "profile"},
 			},
 		},
@@ -268,6 +306,83 @@ func TestEnrichCognitoUserPool_NoGroupRoles(t *testing.T) {
 	assert.False(t, exists, "Roles should not be set when no groups have roles")
 }
 
+func TestEnrichCognitoUserPool_GroupRolesPagination(t *testing.T) {
+	mockClient := &mockCognitoClient{
+		describePoolOutput: &cognitoidentityprovider.DescribeUserPoolOutput{
+			UserPool: &cognitotypes.UserPoolType{
+				AdminCreateUserConfig: &cognitotypes.AdminCreateUserConfigType{
+					AllowAdminCreateUserOnly: true,
+				},
+			},
+		},
+		listClientsOutput: &cognitoidentityprovider.ListUserPoolClientsOutput{
+			UserPoolClients: []cognitotypes.UserPoolClientDescription{},
+		},
+		listGroupsOutputs: []*cognitoidentityprovider.ListGroupsOutput{
+			{
+				Groups: []cognitotypes.GroupType{
+					{GroupName: aws.String("no-role")},
+				},
+				NextToken: aws.String("page-2"),
+			},
+			{
+				Groups: []cognitotypes.GroupType{
+					{GroupName: aws.String("admins"), RoleArn: aws.String("arn:aws:iam::123456789012:role/AdminRole")},
+				},
+			},
+		},
+	}
+
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Cognito::UserPool",
+		ResourceID:   "us-east-1_abc123",
+		Properties:   map[string]any{"UserPoolId": "us-east-1_abc123"},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichCognitoUserPool(cfg, resource, mockClient)
+	require.NoError(t, err)
+
+	roles, ok := resource.Properties["Roles"].([]string)
+	require.True(t, ok)
+	assert.Equal(t, []string{"arn:aws:iam::123456789012:role/AdminRole"}, roles)
+
+	require.Len(t, mockClient.listGroupsInputs, 2)
+	assert.Nil(t, mockClient.listGroupsInputs[0].NextToken)
+	require.NotNil(t, mockClient.listGroupsInputs[1].NextToken)
+	assert.Equal(t, "page-2", *mockClient.listGroupsInputs[1].NextToken)
+}
+
+func TestEnrichCognitoUserPool_ListGroupsErrorContinues(t *testing.T) {
+	mockClient := &mockCognitoClient{
+		describePoolOutput: &cognitoidentityprovider.DescribeUserPoolOutput{
+			UserPool: &cognitotypes.UserPoolType{
+				AdminCreateUserConfig: &cognitotypes.AdminCreateUserConfigType{
+					AllowAdminCreateUserOnly: true,
+				},
+			},
+		},
+		listClientsOutput: &cognitoidentityprovider.ListUserPoolClientsOutput{
+			UserPoolClients: []cognitotypes.UserPoolClientDescription{},
+		},
+		listGroupsError: errors.New("access denied"),
+	}
+
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Cognito::UserPool",
+		ResourceID:   "us-east-1_abc123",
+		Properties:   map[string]any{"UserPoolId": "us-east-1_abc123"},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichCognitoUserPool(cfg, resource, mockClient)
+	require.NoError(t, err)
+
+	_, exists := resource.Properties["Roles"]
+	assert.False(t, exists, "Roles should not be set when ListGroups fails")
+	require.Len(t, mockClient.listGroupsInputs, 1)
+}
+
 func TestEnrichCognitoUserPool_BothDomains(t *testing.T) {
 	mockClient := &mockCognitoClient{
 		describePoolOutput: &cognitoidentityprovider.DescribeUserPoolOutput{
@@ -299,4 +414,102 @@ func TestEnrichCognitoUserPool_BothDomains(t *testing.T) {
 	assert.Len(t, domains, 2)
 	assert.Contains(t, domains, "my-domain")
 	assert.Contains(t, domains, "auth.example.com")
+}
+
+func TestEnrichCognitoUserPool_ClientsPagination(t *testing.T) {
+	mockClient := &mockCognitoClient{
+		describePoolOutput: &cognitoidentityprovider.DescribeUserPoolOutput{
+			UserPool: &cognitotypes.UserPoolType{
+				AdminCreateUserConfig: &cognitotypes.AdminCreateUserConfigType{
+					AllowAdminCreateUserOnly: true,
+				},
+			},
+		},
+		listClientsOutputs: []*cognitoidentityprovider.ListUserPoolClientsOutput{
+			{
+				UserPoolClients: []cognitotypes.UserPoolClientDescription{
+					{ClientId: aws.String("client-1"), ClientName: aws.String("WebApp")},
+				},
+				NextToken: aws.String("page-2"),
+			},
+			{
+				UserPoolClients: []cognitotypes.UserPoolClientDescription{
+					{ClientId: aws.String("client-2"), ClientName: aws.String("MobileApp")},
+				},
+			},
+		},
+		describeClientFunc: func(clientID string) (*cognitoidentityprovider.DescribeUserPoolClientOutput, error) {
+			return &cognitoidentityprovider.DescribeUserPoolClientOutput{
+				UserPoolClient: &cognitotypes.UserPoolClientType{
+					ClientId:   aws.String(clientID),
+					ClientName: aws.String(clientID + "-name"),
+				},
+			}, nil
+		},
+	}
+
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Cognito::UserPool",
+		ResourceID:   "us-east-1_abc123",
+		Properties:   map[string]any{"UserPoolId": "us-east-1_abc123"},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichCognitoUserPool(cfg, resource, mockClient)
+	require.NoError(t, err)
+
+	clientProps, ok := resource.Properties["ClientProperties"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, clientProps, 2)
+	assert.Equal(t, "client-1", clientProps[0]["ClientId"])
+	assert.Equal(t, "client-2", clientProps[1]["ClientId"])
+
+	require.Len(t, mockClient.listClientsInputs, 2)
+	assert.Nil(t, mockClient.listClientsInputs[0].NextToken)
+	require.NotNil(t, mockClient.listClientsInputs[1].NextToken)
+	assert.Equal(t, "page-2", *mockClient.listClientsInputs[1].NextToken)
+}
+
+func TestEnrichCognitoUserPool_PartialClientDescribeFailure(t *testing.T) {
+	mockClient := &mockCognitoClient{
+		describePoolOutput: &cognitoidentityprovider.DescribeUserPoolOutput{
+			UserPool: &cognitotypes.UserPoolType{
+				AdminCreateUserConfig: &cognitotypes.AdminCreateUserConfigType{
+					AllowAdminCreateUserOnly: true,
+				},
+			},
+		},
+		listClientsOutput: &cognitoidentityprovider.ListUserPoolClientsOutput{
+			UserPoolClients: []cognitotypes.UserPoolClientDescription{
+				{ClientId: aws.String("client-ok"), ClientName: aws.String("Good")},
+				{ClientId: aws.String("client-bad"), ClientName: aws.String("Bad")},
+			},
+		},
+		describeClientFunc: func(clientID string) (*cognitoidentityprovider.DescribeUserPoolClientOutput, error) {
+			if clientID == "client-bad" {
+				return nil, errors.New("access denied")
+			}
+			return &cognitoidentityprovider.DescribeUserPoolClientOutput{
+				UserPoolClient: &cognitotypes.UserPoolClientType{
+					ClientId:   aws.String(clientID),
+					ClientName: aws.String("Good"),
+				},
+			}, nil
+		},
+	}
+
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Cognito::UserPool",
+		ResourceID:   "us-east-1_abc123",
+		Properties:   map[string]any{"UserPoolId": "us-east-1_abc123"},
+	}
+
+	cfg := plugin.EnricherConfig{Context: context.Background(), AWSConfig: aws.Config{}}
+	err := enrichers.EnrichCognitoUserPool(cfg, resource, mockClient)
+	require.NoError(t, err)
+
+	clientProps, ok := resource.Properties["ClientProperties"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, clientProps, 1)
+	assert.Equal(t, "client-ok", clientProps[0]["ClientId"])
 }

--- a/pkg/modules/aws/recon/cognito_enricher_integration_test.go
+++ b/pkg/modules/aws/recon/cognito_enricher_integration_test.go
@@ -1,0 +1,54 @@
+//go:build integration
+
+package recon
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	"github.com/praetorian-inc/aurelian/pkg/modules/aws/enrichers"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCognitoUserPoolEnricherGroupRoles(t *testing.T) {
+	fixture := testutil.NewAWSFixture(t, "aws/recon/cognito-enricher")
+	fixture.Setup()
+
+	ctx := context.Background()
+	loadOpts := []func(*config.LoadOptions) error{
+		config.WithRegion("us-east-1"),
+	}
+	if profile := os.Getenv("AWS_PROFILE"); profile != "" {
+		loadOpts = append(loadOpts, config.WithSharedConfigProfile(profile))
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(ctx, loadOpts...)
+	require.NoError(t, err)
+
+	poolID := fixture.Output("cognito_pool_id")
+	expectedRoleArn := fixture.Output("cognito_group_role_arn")
+	resource := &output.AWSResource{
+		ResourceType: "AWS::Cognito::UserPool",
+		ResourceID:   poolID,
+		Region:       "us-east-1",
+		Properties:   map[string]any{"UserPoolId": poolID},
+	}
+
+	client := cognitoidentityprovider.NewFromConfig(awsCfg)
+	err = enrichers.EnrichCognitoUserPool(plugin.EnricherConfig{
+		Context:   ctx,
+		AWSConfig: awsCfg,
+	}, resource, client)
+	require.NoError(t, err)
+
+	roles, ok := resource.Properties["Roles"].([]string)
+	require.True(t, ok, "expected Cognito enricher to add Roles property")
+	assert.Contains(t, roles, expectedRoleArn)
+}

--- a/pkg/modules/aws/recon/cognito_enricher_integration_test.go
+++ b/pkg/modules/aws/recon/cognito_enricher_integration_test.go
@@ -4,7 +4,6 @@ package recon
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -22,14 +21,7 @@ func TestCognitoUserPoolEnricherGroupRoles(t *testing.T) {
 	fixture.Setup()
 
 	ctx := context.Background()
-	loadOpts := []func(*config.LoadOptions) error{
-		config.WithRegion("us-east-1"),
-	}
-	if profile := os.Getenv("AWS_PROFILE"); profile != "" {
-		loadOpts = append(loadOpts, config.WithSharedConfigProfile(profile))
-	}
-
-	awsCfg, err := config.LoadDefaultConfig(ctx, loadOpts...)
+	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-east-1"))
 	require.NoError(t, err)
 
 	poolID := fixture.Output("cognito_pool_id")

--- a/test/terraform/aws/recon/cognito-enricher/main.tf
+++ b/test/terraform/aws/recon/cognito-enricher/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+
+  backend "s3" {
+    # All configured via -backend-config at init time
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  default = "us-east-1"
+}
+
+resource "random_id" "run" {
+  byte_length = 4
+}
+
+locals {
+  prefix = "aurelian-cognito-enricher-${random_id.run.hex}"
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = "${local.prefix}-pool"
+
+  admin_create_user_config {
+    allow_admin_create_user_only = true
+  }
+}
+
+resource "aws_iam_role" "group" {
+  name = "${local.prefix}-group-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "cognito-idp.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_cognito_user_group" "admins" {
+  name         = "${local.prefix}-admins"
+  user_pool_id = aws_cognito_user_pool.test.id
+  role_arn     = aws_iam_role.group.arn
+  precedence   = 1
+}

--- a/test/terraform/aws/recon/cognito-enricher/outputs.tf
+++ b/test/terraform/aws/recon/cognito-enricher/outputs.tf
@@ -1,0 +1,15 @@
+output "cognito_pool_id" {
+  value = aws_cognito_user_pool.test.id
+}
+
+output "cognito_group_name" {
+  value = aws_cognito_user_group.admins.name
+}
+
+output "cognito_group_role_arn" {
+  value = aws_iam_role.group.arn
+}
+
+output "prefix" {
+  value = local.prefix
+}


### PR DESCRIPTION
## Summary
Builds on the Cognito enricher work to improve completeness of collected data.

- **Paginate `ListUserPoolClients`** — previously capped at `MaxResults=60` with no `NextToken` follow-up, so pools with >60 app clients silently dropped clients (callback URLs, OAuth flows/scopes). Now loops over all pages.
- **Paginate `ListGroups`** — collects group IAM role ARNs across all pages (was first page only).
- **Tests** — added unit tests for client pagination and partial `DescribeUserPoolClient` failure (one client errors, others still collected). Moved the integration test next to the module (`pkg/modules/aws/recon/cognito_enricher_integration_test.go`) per project convention, with a terraform fixture under `test/terraform/aws/recon/cognito-enricher/`.

## Notes
- Group role ARN dedup was considered and intentionally **not** included — duplicate ARNs across groups are preserved.
- No empty-string `NextToken` guard (not in the AWS SDK Go v2 contract; tokens are nil when exhausted).

## Testing
- `go test ./pkg/modules/aws/enrichers/` — pass
- `go vet -tags=integration ./pkg/modules/aws/recon/` — clean
- Live integration: `TestCognitoUserPoolEnricherGroupRoles` PASS against AWS, fixture provisioned and torn down.