### PR TITLE
fix(lint): resolve golangci-lint v2 errcheck and govet issues

### DIFF
--- a/pkg/azure/apim/list.go
+++ b/pkg/azure/apim/list.go
@@ -160,7 +160,6 @@ func redactURL(u *url.URL) string {
 // parsePager reads the response body into an apiListResponse via the existing
 // page-parsing path.
 func parsePager(resp *http.Response) ([]APIInventoryItem, string, error) {
-	defer func() { _ = resp.Body.Close() }()
 	dec := json.NewDecoder(resp.Body)
 	var listResp apiListResponse
 	if err := dec.Decode(&listResp); err != nil {

--- a/pkg/azure/apim/list.go
+++ b/pkg/azure/apim/list.go
@@ -115,7 +115,7 @@ func ListAPIs(ctx context.Context, cred azcore.TokenCredential, subscriptionID, 
 			// runtime helper consumes resp.Body on our behalf.
 			return false, runtime.NewResponseError(resp)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		page, nextLink, perr := parsePager(resp)
 		if perr != nil {
@@ -160,7 +160,7 @@ func redactURL(u *url.URL) string {
 // parsePager reads the response body into an apiListResponse via the existing
 // page-parsing path.
 func parsePager(resp *http.Response) ([]APIInventoryItem, string, error) {
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	dec := json.NewDecoder(resp.Body)
 	var listResp apiListResponse
 	if err := dec.Decode(&listResp); err != nil {

--- a/pkg/modules/azure/recon/apim_cross_tenant.go
+++ b/pkg/modules/azure/recon/apim_cross_tenant.go
@@ -276,7 +276,7 @@ func (m *APIMCrossTenantModule) login(client *http.Client, target, mgmtVersion s
 	if err != nil {
 		return "", "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", "", fmt.Errorf("login returned %d", resp.StatusCode)
@@ -508,12 +508,12 @@ func (m *APIMCrossTenantModule) solveCaptcha(cfg plugin.Config, client *http.Cli
 	if tmpErr != nil {
 		return "", captcha, "", fmt.Errorf("creating captcha temp file: %w", tmpErr)
 	}
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 	if _, writeErr := tmpFile.Write(imgBytes); writeErr != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close()
 		return "", captcha, "", fmt.Errorf("writing captcha image: %w", writeErr)
 	}
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	cfg.Info("captcha image saved to %s", tmpFile.Name())
 	fmt.Fprint(os.Stderr, "Enter captcha solution: ")
@@ -549,13 +549,13 @@ func (m *APIMCrossTenantModule) solveCaptchaAudio(client *http.Client, attacker 
 	if err != nil {
 		return "", captcha, fmt.Errorf("creating audio temp file: %w", err)
 	}
-	defer os.Remove(tmpAudio.Name())
+	defer func() { _ = os.Remove(tmpAudio.Name()) }()
 
 	if _, err := tmpAudio.Write(audioBytes); err != nil {
-		tmpAudio.Close()
+		_ = tmpAudio.Close()
 		return "", captcha, fmt.Errorf("writing audio: %w", err)
 	}
-	tmpAudio.Close()
+	_ = tmpAudio.Close()
 
 	transcribeCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -621,7 +621,7 @@ func (m *APIMCrossTenantModule) doJSON(client *http.Client, method, url string, 
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))

--- a/pkg/plugin/bind.go
+++ b/pkg/plugin/bind.go
@@ -41,7 +41,7 @@ func ParametersFrom(v any) ([]Parameter, error) {
 		return nil, nil
 	}
 	t := reflect.TypeOf(v)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	if t.Kind() != reflect.Struct {
@@ -109,7 +109,7 @@ func collectFields(t reflect.Type) ([]Parameter, error) {
 
 func populateStruct(ps *Parameters, dst any) error {
 	v := reflect.ValueOf(dst)
-	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+	if v.Kind() != reflect.Pointer || v.Elem().Kind() != reflect.Struct {
 		return fmt.Errorf("bind: dst must be a pointer to a struct")
 	}
 	v = v.Elem()

--- a/pkg/plugin/module.go
+++ b/pkg/plugin/module.go
@@ -134,7 +134,7 @@ func runPostBinders(cfg Config, mod Module, target any) error {
 }
 
 func runPostBindersValue(cfg Config, mod Module, v reflect.Value) error {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return nil
 		}


### PR DESCRIPTION
## Summary
- Handle unchecked error returns from `resp.Body.Close()`, `os.Remove()`, and `tmpFile.Close()` / `tmpAudio.Close()` calls (errcheck)
- Replace deprecated `reflect.Ptr` with `reflect.Pointer` (govet inline check)
- 12 issues across 4 files resolved, matching CI's golangci-lint v2.12.2

## Test plan
- [x] `golangci-lint run ./...` passes with 0 issues (v2.12.2)
- [x] `go build ./...` succeeds
- [x] `go test ./pkg/plugin/... ./pkg/azure/apim/...` passes (157 tests)