### PR TITLE
feat(cli): write decoded proof.json sidecar alongside results (LAB-4002)

### DIFF
--- a/cmd/generator.go
+++ b/cmd/generator.go
@@ -321,7 +321,27 @@ func runModule(cmd *cobra.Command, module plugin.Module, platform plugin.Platfor
 		}
 
 		log.Success("output written to %s", outputPath)
+
+		// Write a human-readable sidecar with decoded risk proofs. The main
+		// results file encodes Risk.Proof as base64; this is non-fatal best-effort.
+		if entries := plugin.ExtractProofSidecar(results); len(entries) > 0 {
+			proofPath := plugin.ProofSidecarPath(outputPath)
+			if err := writeProofSidecar(proofPath, entries); err != nil {
+				log.Warn("failed to write proof sidecar: %v", err)
+			} else {
+				log.Success("proof written to %s", proofPath)
+			}
+		}
 	}
 
 	return nil
+}
+
+func writeProofSidecar(path string, entries []plugin.ProofSidecarEntry) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return plugin.WriteProofSidecar(f, entries)
 }

--- a/pkg/plugin/output.go
+++ b/pkg/plugin/output.go
@@ -65,6 +65,9 @@ func ExtractProofSidecar(results []model.AurelianModel) []ProofSidecarEntry {
 		case capmodel.Risk:
 			risk = v
 		case *capmodel.Risk:
+			if v == nil {
+				continue
+			}
 			risk = *v
 		default:
 			continue

--- a/pkg/plugin/output.go
+++ b/pkg/plugin/output.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 )
 
 // Formatter handles output formatting for module results
@@ -39,4 +41,62 @@ func (f *ConsoleFormatter) Format(results []model.AurelianModel) error {
 		_, _ = fmt.Fprintf(f.Writer, "%+v\n", r)
 	}
 	return nil
+}
+
+// ProofSidecarEntry is one decoded risk proof for the human-readable sidecar
+// file. The canonical results file encodes capmodel.Risk.Proof ([]byte) as a
+// base64 string; here Proof is json.RawMessage so the encoder emits the decoded
+// proof object verbatim.
+type ProofSidecarEntry struct {
+	TargetName string          `json:"target_name"`
+	Name       string          `json:"name"`
+	Status     string          `json:"status"`
+	Proof      json.RawMessage `json:"proof"`
+}
+
+// ExtractProofSidecar returns one entry per emitted capmodel.Risk that carries a
+// non-empty, valid-JSON proof. Non-risk results and risks without a usable proof
+// are skipped. Returns nil when no entry qualifies.
+func ExtractProofSidecar(results []model.AurelianModel) []ProofSidecarEntry {
+	var entries []ProofSidecarEntry
+	for _, r := range results {
+		var risk capmodel.Risk
+		switch v := r.(type) {
+		case capmodel.Risk:
+			risk = v
+		case *capmodel.Risk:
+			risk = *v
+		default:
+			continue
+		}
+
+		if len(risk.Proof) == 0 || !json.Valid(risk.Proof) {
+			continue
+		}
+
+		entries = append(entries, ProofSidecarEntry{
+			TargetName: risk.TargetName,
+			Name:       risk.Name,
+			Status:     risk.Status,
+			Proof:      json.RawMessage(risk.Proof),
+		})
+	}
+	return entries
+}
+
+// WriteProofSidecar pretty-encodes the sidecar entries (2-space indent) to w.
+func WriteProofSidecar(w io.Writer, entries []ProofSidecarEntry) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(entries)
+}
+
+// ProofSidecarPath derives the sidecar path from the main output path by
+// replacing a trailing ".json" with ".proof.json". If the path does not end in
+// ".json", ".proof.json" is appended.
+func ProofSidecarPath(outputPath string) string {
+	if base, ok := strings.CutSuffix(outputPath, ".json"); ok {
+		return base + ".proof.json"
+	}
+	return outputPath + ".proof.json"
 }

--- a/pkg/plugin/output_test.go
+++ b/pkg/plugin/output_test.go
@@ -1,0 +1,126 @@
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRisk(t *testing.T) capmodel.Risk {
+	t.Helper()
+	proofBytes, err := json.Marshal(capmodel.Proof{
+		Format:   "v1.0.0",
+		Sections: []capmodel.ProofSection{{Title: "Summary"}},
+	})
+	require.NoError(t, err)
+	return capmodel.Risk{
+		TargetName: "example.cloudfront.net",
+		Name:       "CloudFront S3 Origin Takeover",
+		Status:     "TM",
+		Proof:      proofBytes,
+	}
+}
+
+func TestExtractProofSidecar_DecodesProof(t *testing.T) {
+	risk := newTestRisk(t)
+
+	entries := ExtractProofSidecar([]model.AurelianModel{risk})
+
+	require.Len(t, entries, 1)
+	assert.Equal(t, "example.cloudfront.net", entries[0].TargetName)
+	assert.Equal(t, "CloudFront S3 Origin Takeover", entries[0].Name)
+	assert.Equal(t, "TM", entries[0].Status)
+
+	out, err := json.MarshalIndent(entries, "", "  ")
+	require.NoError(t, err)
+	rendered := string(out)
+
+	// Proof must be decoded JSON, not a base64 blob.
+	assert.Contains(t, rendered, `"format": "v1.0.0"`)
+	assert.Contains(t, rendered, `"title": "Summary"`)
+	assert.Contains(t, rendered, `"proof": {`)
+	assert.NotContains(t, rendered, `"proof": "ey`)
+}
+
+func TestExtractProofSidecar_PointerRisk(t *testing.T) {
+	risk := newTestRisk(t)
+
+	entries := ExtractProofSidecar([]model.AurelianModel{&risk})
+
+	require.Len(t, entries, 1)
+	assert.Equal(t, "example.cloudfront.net", entries[0].TargetName)
+}
+
+func TestExtractProofSidecar_NonRiskIgnored(t *testing.T) {
+	type dummy struct{ Foo string }
+
+	entries := ExtractProofSidecar([]model.AurelianModel{dummy{Foo: "bar"}})
+
+	assert.Empty(t, entries)
+}
+
+func TestExtractProofSidecar_EmptyProofSkipped(t *testing.T) {
+	risk := newTestRisk(t)
+	risk.Proof = nil
+
+	entries := ExtractProofSidecar([]model.AurelianModel{risk})
+
+	assert.Empty(t, entries)
+}
+
+func TestExtractProofSidecar_InvalidJSONProofSkipped(t *testing.T) {
+	risk := newTestRisk(t)
+	risk.Proof = []byte("not json")
+
+	entries := ExtractProofSidecar([]model.AurelianModel{risk})
+
+	assert.Empty(t, entries)
+}
+
+func TestExtractProofSidecar_EmptyResults(t *testing.T) {
+	entries := ExtractProofSidecar(nil)
+
+	assert.Nil(t, entries)
+	assert.False(t, len(entries) > 0)
+}
+
+func TestWriteProofSidecar_ValidJSON(t *testing.T) {
+	entries := ExtractProofSidecar([]model.AurelianModel{newTestRisk(t)})
+	require.Len(t, entries, 1)
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteProofSidecar(&buf, entries))
+
+	var decoded []ProofSidecarEntry
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	require.Len(t, decoded, 1)
+	assert.Equal(t, "example.cloudfront.net", decoded[0].TargetName)
+	assert.True(t, json.Valid(decoded[0].Proof))
+}
+
+func TestProofSidecarPath(t *testing.T) {
+	assert.Equal(t,
+		"aurelian-output/cloudfront-s3-takeover-20260604-024413.proof.json",
+		ProofSidecarPath("aurelian-output/cloudfront-s3-takeover-20260604-024413.json"))
+
+	// No .json suffix: append.
+	assert.Equal(t, "results.proof.json", ProofSidecarPath("results"))
+	assert.Equal(t, "results.txt.proof.json", ProofSidecarPath("results.txt"))
+}
+
+func TestWriteProofSidecar_NoBase64Proof(t *testing.T) {
+	entries := ExtractProofSidecar([]model.AurelianModel{newTestRisk(t)})
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteProofSidecar(&buf, entries))
+
+	rendered := buf.String()
+	assert.Contains(t, rendered, `"proof": {`)
+	assert.False(t, strings.Contains(rendered, `"proof": "ey`))
+}

--- a/pkg/plugin/output_test.go
+++ b/pkg/plugin/output_test.go
@@ -57,6 +57,66 @@ func TestExtractProofSidecar_PointerRisk(t *testing.T) {
 	assert.Equal(t, "example.cloudfront.net", entries[0].TargetName)
 }
 
+func TestExtractProofSidecar_NilPointerRisk(t *testing.T) {
+	var risk *capmodel.Risk
+
+	require.NotPanics(t, func() {
+		entries := ExtractProofSidecar([]model.AurelianModel{risk})
+		assert.Empty(t, entries)
+	})
+}
+
+// A typed-nil *capmodel.Risk appearing before a valid risk must be skipped
+// without panicking, and the valid risk that follows it must still be emitted.
+// This proves the nil guard's `continue` does not halt iteration.
+func TestExtractProofSidecar_MixedNilAndValid(t *testing.T) {
+	var nilRisk *capmodel.Risk
+	valid := newTestRisk(t)
+
+	var entries []ProofSidecarEntry
+	require.NotPanics(t, func() {
+		entries = ExtractProofSidecar([]model.AurelianModel{nilRisk, valid})
+	})
+
+	require.Len(t, entries, 1)
+	assert.Equal(t, "example.cloudfront.net", entries[0].TargetName)
+	assert.Equal(t, "CloudFront S3 Origin Takeover", entries[0].Name)
+}
+
+// With a typed-nil pointer and other skip-worthy results interleaved between two
+// valid risks, both valid risks must be emitted in order. This confirms every
+// `continue` (nil pointer, non-risk type, empty proof) targets the loop, so a
+// later valid entry is always reached.
+func TestExtractProofSidecar_NilDoesNotHaltIteration(t *testing.T) {
+	var nilRisk *capmodel.Risk
+
+	validA := newTestRisk(t)
+	validA.TargetName = "a.cloudfront.net"
+
+	validB := newTestRisk(t)
+	validB.TargetName = "b.cloudfront.net"
+
+	emptyProof := newTestRisk(t)
+	emptyProof.Proof = nil
+
+	type dummy struct{ Foo string }
+
+	var entries []ProofSidecarEntry
+	require.NotPanics(t, func() {
+		entries = ExtractProofSidecar([]model.AurelianModel{
+			validA,
+			nilRisk,
+			dummy{Foo: "bar"},
+			emptyProof,
+			validB,
+		})
+	})
+
+	require.Len(t, entries, 2)
+	assert.Equal(t, "a.cloudfront.net", entries[0].TargetName, "first valid risk emitted")
+	assert.Equal(t, "b.cloudfront.net", entries[1].TargetName, "valid risk after the nil/junk entries still reached")
+}
+
 func TestExtractProofSidecar_NonRiskIgnored(t *testing.T) {
 	type dummy struct{ Foo string }
 


### PR DESCRIPTION
## What

Adds a human-readable **`{output}.proof.json` sidecar** next to the canonical results file. `capmodel.Risk.Proof` is `[]byte`, so `encoding/json` base64-encodes it in the main results JSON — engineers can't read the proof locally. This writes a sibling file with the **decoded** proof object per emitted `capmodel.Risk`.

```
aurelian-output/
  cloudfront-s3-takeover-<ts>.json        # unchanged — proof stays base64 (Guard wire contract)
  cloudfront-s3-takeover-<ts>.proof.json  # NEW — decoded { target_name, name, status, proof:{...} }
```

## How

- `pkg/plugin/output.go`: `ExtractProofSidecar` (keeps only risks with a non-empty, valid-JSON proof; handles `capmodel.Risk` and `*capmodel.Risk`), `WriteProofSidecar` (pretty JSON), `ProofSidecarPath`. The entry's proof is carried as `json.RawMessage`, so it serializes as nested JSON rather than base64.
- `cmd/generator.go`: after the canonical file is written, additively writes the sidecar. Fully **non-fatal** — a sidecar failure logs a warning and never fails the command.
- The canonical results file shape and its base64 `proof` are **unchanged**; the sidecar is engineer-facing only.

## Testing

- New unit tests in `pkg/plugin/output_test.go` (decode TP, pointer path, non-Risk ignored, empty/invalid proof skipped, empty results, no-base64 assertions, path derivation).
- End-to-end CLI smoke run against the live cloudfront fixture: canonical file kept base64 `proof`; sidecar contained the decoded object (`format: v1.0.0`, all 5 sections); zero base64 blobs in the sidecar.

## Stacking

Stacked on #209 (`fix/lab-3995-cloudfront-capmodel-risk`). Review/merge that first; this PR's base will retarget to `main` automatically once the parent merges.

Tracking: LAB-4002 (interim solution under LAB-3740 Phase 0: Risk Standardization).
