### PR TITLE
feat(aws/recon): migrate subdomain-takeover to capmodel.Risk (LAB-3992)

### DIFF
--- a/pkg/aws/dnstakeover/check_eb.go
+++ b/pkg/aws/dnstakeover/check_eb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/model"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 )
 
 func init() {
@@ -20,6 +21,11 @@ func init() {
 // ebCNAMEPattern matches Elastic Beanstalk CNAME targets.
 // Captures: [1] prefix, [2] region
 var ebCNAMEPattern = regexp.MustCompile(`^([a-zA-Z0-9-]+)\.((?:[a-z]{2}(?:-[a-z]+)+-\d+))\.elasticbeanstalk\.com\.?$`)
+
+var ebReferences = []string{
+	"https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_CheckDNSAvailability.html",
+	"https://hackerone.com/reports/473888",
+}
 
 func checkEB(ctx CheckContext, rec Route53Record, out *pipeline.P[model.AurelianModel]) error {
 	for _, val := range rec.Values {
@@ -45,27 +51,33 @@ func checkEB(ctx CheckContext, rec Route53Record, out *pipeline.P[model.Aurelian
 			continue
 		}
 
-		out.Send(NewTakeoverRisk(
-			"eb-subdomain-takeover",
-			output.RiskSeverityHigh,
-			rec,
-			ctx.AccountID,
-			map[string]any{
-				"cname_target": val,
-				"eb_prefix":    prefix,
-				"eb_region":    region,
-				"description": fmt.Sprintf(
-					"Route53 CNAME %q points to unclaimed EB prefix %q in %s. "+
-						"An attacker can register this prefix and serve arbitrary content.",
-					rec.RecordName, prefix, region,
-				),
-				"recommendation": "Remove the stale CNAME record or recreate the EB environment with the original prefix.",
-				"references": []string{
-					"https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_CheckDNSAvailability.html",
-					"https://hackerone.com/reports/473888",
-				},
+		risk, err := NewTakeoverRisk(takeoverFinding{
+			riskName:  "Elastic Beanstalk Subdomain Takeover",
+			severity:  output.RiskSeverityHigh,
+			rec:       rec,
+			accountID: ctx.AccountID,
+			summary: fmt.Sprintf(
+				"Route53 CNAME %q points to unclaimed EB prefix %q in %s. "+
+					"An attacker can register this prefix and serve arbitrary content.",
+				rec.RecordName, prefix, region,
+			),
+			detailRows: []capmodel.ProofKeyValueRow{
+				{Key: "CNAME Target", Value: val, Copyable: true},
+				{Key: "EB Prefix", Value: prefix, Copyable: true},
+				{Key: "EB Region", Value: region},
 			},
-		))
+			impact: "An attacker who registers the unclaimed Elastic Beanstalk prefix gains control of the " +
+				"subdomain and can serve arbitrary content to its visitors.",
+			recommendation: []string{
+				"Remove the stale CNAME record or recreate the EB environment with the original prefix.",
+			},
+			references: ebReferences,
+		})
+		if err != nil {
+			slog.Warn("failed to build takeover risk", "record", rec.RecordName, "error", err)
+			continue
+		}
+		out.Send(risk)
 	}
 
 	return nil

--- a/pkg/aws/dnstakeover/check_eip.go
+++ b/pkg/aws/dnstakeover/check_eip.go
@@ -17,6 +17,7 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 )
 
 func init() {
@@ -24,6 +25,11 @@ func init() {
 }
 
 const awsIPRangesURL = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+
+var eipReferences = []string{
+	"https://bishopfox.com/blog/fishing-the-aws-ip-pool-for-dangling-domains",
+	"https://kmsec.uk/blog/passive-takeover/",
+}
 
 type ipPrefixEntry struct {
 	IPPrefix string `json:"ip_prefix"`
@@ -53,27 +59,33 @@ func checkEIP(ctx CheckContext, rec Route53Record, out *pipeline.P[model.Aurelia
 			continue
 		}
 
-		out.Send(NewTakeoverRisk(
-			"eip-dangling-a-record",
-			output.RiskSeverityMedium,
-			rec,
-			ctx.AccountID,
-			map[string]any{
-				"dangling_ip": ip,
-				"aws_region":  awsRegion,
-				"aws_service": awsService,
-				"description": fmt.Sprintf(
-					"Route53 A record %q points to %s which is in AWS IP space (%s/%s) "+
-						"but is not allocated as an EIP in this account.",
-					rec.RecordName, ip, awsService, awsRegion,
-				),
-				"recommendation": "Remove the stale A record or re-allocate the Elastic IP.",
-				"references": []string{
-					"https://bishopfox.com/blog/fishing-the-aws-ip-pool-for-dangling-domains",
-					"https://kmsec.uk/blog/passive-takeover/",
-				},
+		risk, err := NewTakeoverRisk(takeoverFinding{
+			riskName:  "Dangling Elastic IP A Record",
+			severity:  output.RiskSeverityMedium,
+			rec:       rec,
+			accountID: ctx.AccountID,
+			summary: fmt.Sprintf(
+				"Route53 A record %q points to %s which is in AWS IP space (%s/%s) "+
+					"but is not allocated as an EIP in this account.",
+				rec.RecordName, ip, awsService, awsRegion,
+			),
+			detailRows: []capmodel.ProofKeyValueRow{
+				{Key: "Dangling IP", Value: ip, Copyable: true},
+				{Key: "AWS Region", Value: awsRegion},
+				{Key: "AWS Service", Value: awsService},
 			},
-		))
+			impact: "An attacker can repeatedly allocate Elastic IPs until they obtain the dangling address, " +
+				"then serve arbitrary content on the subdomain.",
+			recommendation: []string{
+				"Remove the stale A record or re-allocate the Elastic IP.",
+			},
+			references: eipReferences,
+		})
+		if err != nil {
+			slog.Warn("failed to build takeover risk", "record", rec.RecordName, "error", err)
+			continue
+		}
+		out.Send(risk)
 	}
 
 	return nil

--- a/pkg/aws/dnstakeover/check_ns.go
+++ b/pkg/aws/dnstakeover/check_ns.go
@@ -13,6 +13,7 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/model"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 )
 
 func init() {
@@ -20,6 +21,12 @@ func init() {
 }
 
 var nsRoute53Pattern = regexp.MustCompile(`(?i)^ns-\d+\.awsdns-\d+\.\w+`)
+
+var nsReferences = []string{
+	"https://www.form3.tech/blog/engineering/dangling-danger",
+	"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/protection-from-dangling-dns.html",
+	"https://0xpatrik.com/subdomain-takeover-ns/",
+}
 
 func checkNS(ctx CheckContext, rec Route53Record, out *pipeline.P[model.AurelianModel]) error {
 	// Skip apex NS records — these are the zone's own nameservers, not delegations.
@@ -52,28 +59,33 @@ func checkNS(ctx CheckContext, rec Route53Record, out *pipeline.P[model.Aurelian
 		"error_type", queryErr,
 	)
 
-	out.Send(NewTakeoverRisk(
-		"ns-delegation-takeover",
-		output.RiskSeverityHigh,
-		rec,
-		ctx.AccountID,
-		map[string]any{
-			"nameservers": route53NSes,
-			"query_error": queryErr,
-			"description": fmt.Sprintf(
-				"Route53 NS delegation %q delegates to Route53 nameservers (%s) "+
-					"but the hosted zone no longer exists (DNS: %s). An attacker can "+
-					"exploit the Form3 bypass to gain full DNS control.",
-				rec.RecordName, strings.Join(route53NSes, ", "), queryErr,
-			),
-			"recommendation": "Remove the stale NS delegation record from zone " + rec.ZoneName + ".",
-			"references": []string{
-				"https://www.form3.tech/blog/engineering/dangling-danger",
-				"https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/protection-from-dangling-dns.html",
-				"https://0xpatrik.com/subdomain-takeover-ns/",
-			},
+	risk, err := NewTakeoverRisk(takeoverFinding{
+		riskName:  "Dangling NS Delegation Takeover",
+		severity:  output.RiskSeverityHigh,
+		rec:       rec,
+		accountID: ctx.AccountID,
+		summary: fmt.Sprintf(
+			"Route53 NS delegation %q delegates to Route53 nameservers (%s) "+
+				"but the hosted zone no longer exists (DNS: %s). An attacker can "+
+				"exploit the Form3 bypass to gain full DNS control.",
+			rec.RecordName, strings.Join(route53NSes, ", "), queryErr,
+		),
+		detailRows: []capmodel.ProofKeyValueRow{
+			{Key: "Nameservers", Value: strings.Join(route53NSes, ", ")},
+			{Key: "Query Error", Value: queryErr},
 		},
-	))
+		impact: "An attacker can recreate the delegated hosted zone in Route53 until they are assigned the " +
+			"same nameservers, gaining full DNS control over the delegated subdomain.",
+		recommendation: []string{
+			"Remove the stale NS delegation record from zone " + rec.ZoneName + ".",
+		},
+		references: nsReferences,
+	})
+	if err != nil {
+		slog.Warn("failed to build takeover risk", "record", rec.RecordName, "error", err)
+		return nil
+	}
+	out.Send(risk)
 
 	return nil
 }

--- a/pkg/aws/dnstakeover/risk.go
+++ b/pkg/aws/dnstakeover/risk.go
@@ -1,0 +1,124 @@
+package dnstakeover
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
+)
+
+const proofFormat = "v1.0.0"
+
+// takeoverFinding is the typed input each checker fills to build a takeover risk.
+// Per-checker differences are expressed as typed rows/strings, not separate proof
+// shapes — buildTakeoverProof renders a single shape for all three checkers.
+type takeoverFinding struct {
+	riskName       string                      // human-readable Risk.Name
+	severity       output.RiskSeverity         // mapped to a Chariot T* status
+	rec            Route53Record               // the dangling DNS record
+	accountID      string                      // owning AWS account
+	summary        string                      // Summary section paragraph
+	detailRows     []capmodel.ProofKeyValueRow // checker-specific Record Details rows
+	impact         string                      // Impact section paragraph
+	recommendation []string                    // Recommendation section list
+	references     []string                    // References section list (href)
+}
+
+// NewTakeoverRisk builds a platform capmodel.Risk for a subdomain-takeover finding.
+// It prepends the common Route53 detail rows (including a copyable Route53 ARN row,
+// preserving the old ImpactedResourceID value) to the checker-specific detailRows,
+// marshals the structured proof, and returns the risk keyed on the dangling record.
+func NewTakeoverRisk(f takeoverFinding) (capmodel.Risk, error) {
+	proof, err := json.Marshal(buildTakeoverProof(f))
+	if err != nil {
+		return capmodel.Risk{}, err
+	}
+
+	return capmodel.Risk{
+		TargetName: f.rec.RecordName,
+		Name:       f.riskName,
+		Source:     "aurelian",
+		Status:     severityToStatus(f.severity),
+		Proof:      proof,
+		// TODO(LAB-3740): populate a typed capmodel asset (e.g. capmodel.Domain for the
+		// dangling subdomain) once Aurelian emits the SDK `_type` envelope and Guard's
+		// ingest consumes Risk.Target. Inert until then — Guard's convertRisk falls back
+		// to a bare Asset without a `_type` discriminator.
+		Target: nil,
+	}, nil
+}
+
+// buildTakeoverProof assembles the structured proof: Summary, Record Details (common
+// Route53 rows + checker-specific rows), Impact, Recommendation, and References.
+func buildTakeoverProof(f takeoverFinding) capmodel.Proof {
+	rows := append(commonRecordRows(f.rec, f.accountID), f.detailRows...)
+
+	sections := []capmodel.ProofSection{
+		{Title: "Summary", Elements: []capmodel.ProofElement{paragraph(f.summary)}},
+		{Title: "Record Details", Elements: []capmodel.ProofElement{keyValue(rows)}},
+		{Title: "Impact", Elements: []capmodel.ProofElement{paragraph(f.impact)}},
+		{Title: "Recommendation", Elements: []capmodel.ProofElement{list(f.recommendation)}},
+		{Title: "References", Elements: []capmodel.ProofElement{referenceList(f.references)}},
+	}
+
+	return capmodel.Proof{Format: proofFormat, Sections: sections}
+}
+
+// commonRecordRows returns the Route53 detail rows shared by every checker, ending
+// with a copyable Route53 ARN row that preserves the legacy ImpactedResourceID value.
+func commonRecordRows(rec Route53Record, accountID string) []capmodel.ProofKeyValueRow {
+	arn := fmt.Sprintf("arn:aws:route53:::hostedzone/%s/recordset/%s/%s",
+		rec.ZoneID, rec.RecordName, rec.Type)
+
+	return []capmodel.ProofKeyValueRow{
+		{Key: "Zone Name", Value: rec.ZoneName},
+		{Key: "Zone ID", Value: rec.ZoneID, Copyable: true},
+		{Key: "Record Name", Value: rec.RecordName, Copyable: true},
+		{Key: "Record Type", Value: rec.Type},
+		{Key: "Record Values", Value: strings.Join(rec.Values, ", ")},
+		{Key: "Account ID", Value: accountID, Copyable: true},
+		{Key: "Route53 ARN", Value: arn, Copyable: true},
+	}
+}
+
+// severityToStatus maps a risk severity to a Chariot triage status code.
+func severityToStatus(sev output.RiskSeverity) string {
+	switch output.NormalizeSeverity(sev) {
+	case output.RiskSeverityCritical:
+		return "TC"
+	case output.RiskSeverityHigh:
+		return "TH"
+	case output.RiskSeverityMedium:
+		return "TM"
+	case output.RiskSeverityLow:
+		return "TL"
+	default:
+		return "TI"
+	}
+}
+
+func paragraph(text string) capmodel.ProofElement {
+	return capmodel.ProofElement{Type: "paragraph", Paragraph: &capmodel.ProofParagraph{Text: text}}
+}
+
+func keyValue(rows []capmodel.ProofKeyValueRow) capmodel.ProofElement {
+	return capmodel.ProofElement{Type: "key_value", KeyValue: &capmodel.ProofKeyValue{Rows: rows}}
+}
+
+func list(items []string) capmodel.ProofElement {
+	listItems := make([]capmodel.ProofListItem, 0, len(items))
+	for _, item := range items {
+		listItems = append(listItems, capmodel.ProofListItem{Label: item})
+	}
+	return capmodel.ProofElement{Type: "list", List: &capmodel.ProofList{Items: listItems}}
+}
+
+func referenceList(urls []string) capmodel.ProofElement {
+	items := make([]capmodel.ProofListItem, 0, len(urls))
+	for _, u := range urls {
+		items = append(items, capmodel.ProofListItem{Label: u, Href: u})
+	}
+	return capmodel.ProofElement{Type: "list", List: &capmodel.ProofList{Items: items}}
+}

--- a/pkg/aws/dnstakeover/risk_test.go
+++ b/pkg/aws/dnstakeover/risk_test.go
@@ -1,0 +1,241 @@
+package dnstakeover
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeProof unmarshals a Risk's Proof bytes into a structured capmodel.Proof.
+func decodeProof(t *testing.T, risk capmodel.Risk) capmodel.Proof {
+	t.Helper()
+	var proof capmodel.Proof
+	require.NoError(t, json.Unmarshal(risk.Proof, &proof))
+	return proof
+}
+
+// sectionByTitle returns the named proof section, requiring it to exist.
+func sectionByTitle(t *testing.T, proof capmodel.Proof, title string) capmodel.ProofSection {
+	t.Helper()
+	for _, s := range proof.Sections {
+		if s.Title == title {
+			return s
+		}
+	}
+	require.Failf(t, "section not found", "proof has no %q section", title)
+	return capmodel.ProofSection{}
+}
+
+// keyValueMap flattens a section's key/value rows into a map for assertions.
+func keyValueMap(t *testing.T, section capmodel.ProofSection) map[string]string {
+	t.Helper()
+	out := make(map[string]string)
+	for _, el := range section.Elements {
+		if el.KeyValue == nil {
+			continue
+		}
+		for _, row := range el.KeyValue.Rows {
+			out[row.Key] = row.Value
+		}
+	}
+	return out
+}
+
+// listLabels collects the labels of every list item across a section's elements.
+func listLabels(section capmodel.ProofSection) []string {
+	var labels []string
+	for _, el := range section.Elements {
+		if el.List == nil {
+			continue
+		}
+		for _, item := range el.List.Items {
+			labels = append(labels, item.Label)
+		}
+	}
+	return labels
+}
+
+// paragraphText concatenates the text of every paragraph element in a section.
+func paragraphText(section capmodel.ProofSection) string {
+	var text string
+	for _, el := range section.Elements {
+		if el.Paragraph != nil {
+			text += el.Paragraph.Text
+		}
+	}
+	return text
+}
+
+func TestNewTakeoverRisk(t *testing.T) {
+	cases := []struct {
+		name           string
+		finding        takeoverFinding
+		wantStatus     string
+		wantTargetName string
+		wantDetailRows map[string]string // checker-specific rows that must be present
+	}{
+		{
+			name: "elastic beanstalk subdomain takeover",
+			finding: takeoverFinding{
+				riskName:  "Elastic Beanstalk Subdomain Takeover",
+				severity:  output.RiskSeverityHigh,
+				accountID: "123456789012",
+				rec: Route53Record{
+					ZoneID:     "Z1EB",
+					ZoneName:   "example.com",
+					RecordName: "app.example.com",
+					Type:       "CNAME",
+					Values:     []string{"myapp.us-east-2.elasticbeanstalk.com"},
+				},
+				summary: "EB takeover summary",
+				detailRows: []capmodel.ProofKeyValueRow{
+					{Key: "CNAME Target", Value: "myapp.us-east-2.elasticbeanstalk.com"},
+					{Key: "EB Prefix", Value: "myapp"},
+					{Key: "EB Region", Value: "us-east-2"},
+				},
+				impact:         "EB impact",
+				recommendation: []string{"Remove the stale CNAME record."},
+				references:     ebReferences,
+			},
+			wantStatus:     "TH",
+			wantTargetName: "app.example.com",
+			wantDetailRows: map[string]string{
+				"CNAME Target": "myapp.us-east-2.elasticbeanstalk.com",
+				"EB Prefix":    "myapp",
+				"EB Region":    "us-east-2",
+			},
+		},
+		{
+			name: "dangling elastic ip a record",
+			finding: takeoverFinding{
+				riskName:  "Dangling Elastic IP A Record",
+				severity:  output.RiskSeverityMedium,
+				accountID: "123456789012",
+				rec: Route53Record{
+					ZoneID:     "Z1EIP",
+					ZoneName:   "example.com",
+					RecordName: "vpn.example.com",
+					Type:       "A",
+					Values:     []string{"52.1.2.3"},
+				},
+				summary: "EIP takeover summary",
+				detailRows: []capmodel.ProofKeyValueRow{
+					{Key: "Dangling IP", Value: "52.1.2.3"},
+					{Key: "AWS Region", Value: "us-east-1"},
+					{Key: "AWS Service", Value: "EC2"},
+				},
+				impact:         "EIP impact",
+				recommendation: []string{"Remove the stale A record."},
+				references:     eipReferences,
+			},
+			wantStatus:     "TM",
+			wantTargetName: "vpn.example.com",
+			wantDetailRows: map[string]string{
+				"Dangling IP": "52.1.2.3",
+				"AWS Region":  "us-east-1",
+				"AWS Service": "EC2",
+			},
+		},
+		{
+			name: "dangling ns delegation takeover",
+			finding: takeoverFinding{
+				riskName:  "Dangling NS Delegation Takeover",
+				severity:  output.RiskSeverityHigh,
+				accountID: "123456789012",
+				rec: Route53Record{
+					ZoneID:     "Z1NS",
+					ZoneName:   "example.com",
+					RecordName: "sub.example.com",
+					Type:       "NS",
+					Values:     []string{"ns-1.awsdns-01.org", "ns-2.awsdns-02.net"},
+				},
+				summary: "NS takeover summary",
+				detailRows: []capmodel.ProofKeyValueRow{
+					{Key: "Nameservers", Value: "ns-1.awsdns-01.org, ns-2.awsdns-02.net"},
+					{Key: "Query Error", Value: "NXDOMAIN"},
+				},
+				impact:         "NS impact",
+				recommendation: []string{"Remove the stale NS delegation record."},
+				references:     nsReferences,
+			},
+			wantStatus:     "TH",
+			wantTargetName: "sub.example.com",
+			wantDetailRows: map[string]string{
+				"Nameservers": "ns-1.awsdns-01.org, ns-2.awsdns-02.net",
+				"Query Error": "NXDOMAIN",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			risk, err := NewTakeoverRisk(tc.finding)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.finding.riskName, risk.Name)
+			assert.Equal(t, "aurelian", risk.Source)
+			assert.Equal(t, tc.wantStatus, risk.Status)
+			assert.Equal(t, tc.wantTargetName, risk.TargetName)
+			assert.Nil(t, risk.Target)
+			assert.NotEmpty(t, risk.Proof)
+
+			proof := decodeProof(t, risk)
+			assert.Equal(t, "v1.0.0", proof.Format)
+
+			// Section ordering: Summary, Record Details, Impact, Recommendation, References.
+			titles := make([]string, 0, len(proof.Sections))
+			for _, s := range proof.Sections {
+				titles = append(titles, s.Title)
+			}
+			assert.Equal(t,
+				[]string{"Summary", "Record Details", "Impact", "Recommendation", "References"},
+				titles,
+			)
+
+			details := keyValueMap(t, sectionByTitle(t, proof, "Record Details"))
+
+			// Common Route53 rows.
+			rec := tc.finding.rec
+			assert.Equal(t, rec.ZoneName, details["Zone Name"])
+			assert.Equal(t, rec.ZoneID, details["Zone ID"])
+			assert.Equal(t, rec.RecordName, details["Record Name"])
+			assert.Equal(t, rec.Type, details["Record Type"])
+			assert.NotEmpty(t, details["Record Values"])
+			assert.Equal(t, tc.finding.accountID, details["Account ID"])
+
+			// Route53 ARN row preserves the legacy ImpactedResourceID value.
+			wantARN := "arn:aws:route53:::hostedzone/" + rec.ZoneID +
+				"/recordset/" + rec.RecordName + "/" + rec.Type
+			assert.Equal(t, wantARN, details["Route53 ARN"])
+
+			// Checker-specific rows.
+			for key, want := range tc.wantDetailRows {
+				assert.Equal(t, want, details[key], "detail row %q", key)
+			}
+
+			assert.NotEmpty(t, paragraphText(sectionByTitle(t, proof, "Summary")))
+			assert.NotEmpty(t, paragraphText(sectionByTitle(t, proof, "Impact")))
+			assert.NotEmpty(t, listLabels(sectionByTitle(t, proof, "Recommendation")))
+			assert.NotEmpty(t, listLabels(sectionByTitle(t, proof, "References")))
+		})
+	}
+}
+
+func TestSeverityToStatus(t *testing.T) {
+	cases := map[string]string{
+		"critical": "TC",
+		"high":     "TH",
+		"medium":   "TM",
+		"low":      "TL",
+		"info":     "TI",
+		"":         "TI",
+		"bogus":    "TI",
+	}
+	for sev, want := range cases {
+		assert.Equalf(t, want, severityToStatus(output.RiskSeverity(sev)), "severity %q", sev)
+	}
+}

--- a/pkg/aws/dnstakeover/types.go
+++ b/pkg/aws/dnstakeover/types.go
@@ -2,13 +2,9 @@ package dnstakeover
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"maps"
 	"net"
 	"sync"
 
-	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 )
 
@@ -42,28 +38,4 @@ type CheckContext struct {
 	Opts      plugin.AWSCommonRecon
 	AccountID string
 	EIPCache  *eipCache
-}
-
-// NewTakeoverRisk builds an AurelianRisk for a subdomain takeover finding.
-func NewTakeoverRisk(name string, severity output.RiskSeverity, rec Route53Record, accountID string, extra map[string]any) output.AurelianRisk {
-	merged := maps.Clone(extra)
-	merged["account_id"] = accountID
-	merged["zone_id"] = rec.ZoneID
-	merged["zone_name"] = rec.ZoneName
-	merged["record_name"] = rec.RecordName
-	merged["record_type"] = rec.Type
-	merged["record_values"] = rec.Values
-
-	ctxBytes, _ := json.Marshal(merged)
-
-	resourceID := fmt.Sprintf("arn:aws:route53:::hostedzone/%s/recordset/%s/%s",
-		rec.ZoneID, rec.RecordName, rec.Type)
-
-	return output.AurelianRisk{
-		Name:               name,
-		Severity:           severity,
-		ImpactedResourceID: resourceID,
-		DeduplicationID:    fmt.Sprintf("%s:%s:%s", name, rec.ZoneID, rec.RecordName),
-		Context:            ctxBytes,
-	}
 }

--- a/pkg/modules/aws/recon/subdomain_takeover_integration_test.go
+++ b/pkg/modules/aws/recon/subdomain_takeover_integration_test.go
@@ -4,18 +4,60 @@ package recon
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/praetorian-inc/aurelian/pkg/model"
-	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// recordDetails flattens the "Record Details" key/value section into a map.
+// decodeProof is shared with cloudfront_s3_takeover_integration_test.go.
+func recordDetails(t *testing.T, risk capmodel.Risk) map[string]string {
+	t.Helper()
+	out := make(map[string]string)
+	for _, s := range decodeProof(t, risk).Sections {
+		if s.Title != "Record Details" {
+			continue
+		}
+		for _, el := range s.Elements {
+			if el.KeyValue == nil {
+				continue
+			}
+			for _, row := range el.KeyValue.Rows {
+				out[row.Key] = row.Value
+			}
+		}
+	}
+	return out
+}
+
+// sectionText concatenates paragraph text and list labels of the named section.
+func sectionText(t *testing.T, risk capmodel.Risk, title string) string {
+	t.Helper()
+	var text string
+	for _, s := range decodeProof(t, risk).Sections {
+		if s.Title != title {
+			continue
+		}
+		for _, el := range s.Elements {
+			if el.Paragraph != nil {
+				text += el.Paragraph.Text
+			}
+			if el.List != nil {
+				for _, item := range el.List.Items {
+					text += item.Label
+				}
+			}
+		}
+	}
+	return text
+}
 
 func TestAWSSubdomainTakeover(t *testing.T) {
 	fixture := testutil.NewAWSFixture(t, "aws/recon/subdomain-takeover")
@@ -37,108 +79,91 @@ func TestAWSSubdomainTakeover(t *testing.T) {
 	p2 := pipeline.New[model.AurelianModel]()
 	pipeline.Pipe(p1, mod.Run, p2)
 
-	var risks []output.AurelianRisk
+	var risks []capmodel.Risk
 	for m := range p2.Range() {
-		if r, ok := m.(output.AurelianRisk); ok {
+		if r, ok := m.(capmodel.Risk); ok {
 			risks = append(risks, r)
 		}
 	}
 	require.NoError(t, p2.Wait())
 
-	// The module scans ALL public hosted zones. Filter to risks from our test zone.
+	// The module scans ALL public hosted zones. Filter to risks from our test zone
+	// via the "Route53 ARN" detail row, which encodes the hosted zone ID.
 	zoneID := fixture.Output("zone_id")
-	var testRisks []output.AurelianRisk
+	var testRisks []capmodel.Risk
 	for _, r := range risks {
-		if strings.Contains(r.ImpactedResourceID, zoneID) {
+		if strings.Contains(recordDetails(t, r)["Route53 ARN"], zoneID) {
 			testRisks = append(testRisks, r)
 		}
 	}
 	require.NotEmpty(t, testRisks, "expected at least one risk from the test zone %s", zoneID)
 
+	// findByName returns the first test-zone risk with the given human-readable Name
+	// whose Record Name matches recordName.
+	findByName := func(name, recordName string) *capmodel.Risk {
+		for i := range testRisks {
+			if testRisks[i].Name == name &&
+				recordDetails(t, testRisks[i])["Record Name"] == recordName {
+				return &testRisks[i]
+			}
+		}
+		return nil
+	}
+
 	// --- Per-checker detection subtests ---
 
 	t.Run("detects EB CNAME takeover", func(t *testing.T) {
 		ebRecord := fixture.Output("eb_cname_record_name")
-		var matched *output.AurelianRisk
-		for i := range testRisks {
-			if testRisks[i].Name == "eb-subdomain-takeover" &&
-				strings.Contains(testRisks[i].ImpactedResourceID, ebRecord) {
-				matched = &testRisks[i]
-				break
-			}
-		}
-		require.NotNilf(t, matched, "expected eb-subdomain-takeover risk for record %s", ebRecord)
+		matched := findByName("Elastic Beanstalk Subdomain Takeover", ebRecord)
+		require.NotNilf(t, matched, "expected EB takeover risk for record %s", ebRecord)
 
-		assert.Equal(t, output.RiskSeverityHigh, matched.Severity)
+		assert.Equal(t, "TH", matched.Status)
 
-		var ctx map[string]any
-		require.NoError(t, json.Unmarshal(matched.Context, &ctx))
-		assert.Contains(t, ctx["cname_target"], "elasticbeanstalk.com",
-			"context should reference EB CNAME target")
-		assert.Equal(t, fixture.Output("eb_cname_prefix"), ctx["eb_prefix"],
-			"context should contain the EB prefix")
-		assert.Equal(t, "us-east-2", ctx["eb_region"],
-			"context should contain the EB region")
-		assert.NotEmpty(t, ctx["description"])
-		assert.NotEmpty(t, ctx["recommendation"])
-		assert.NotEmpty(t, ctx["references"])
+		details := recordDetails(t, *matched)
+		assert.Contains(t, details["CNAME Target"], "elasticbeanstalk.com",
+			"details should reference EB CNAME target")
+		assert.Equal(t, fixture.Output("eb_cname_prefix"), details["EB Prefix"],
+			"details should contain the EB prefix")
+		assert.Equal(t, "us-east-2", details["EB Region"],
+			"details should contain the EB region")
+		assert.NotEmpty(t, sectionText(t, *matched, "Summary"))
+		assert.NotEmpty(t, sectionText(t, *matched, "Recommendation"))
+		assert.NotEmpty(t, sectionText(t, *matched, "References"))
 	})
 
 	t.Run("detects EIP dangling A record", func(t *testing.T) {
 		eipRecord := fixture.Output("eip_a_record_name")
-		var matched *output.AurelianRisk
-		for i := range testRisks {
-			if testRisks[i].Name == "eip-dangling-a-record" &&
-				strings.Contains(testRisks[i].ImpactedResourceID, eipRecord) {
-				matched = &testRisks[i]
-				break
-			}
-		}
-		require.NotNilf(t, matched, "expected eip-dangling-a-record risk for record %s", eipRecord)
+		matched := findByName("Dangling Elastic IP A Record", eipRecord)
+		require.NotNilf(t, matched, "expected EIP dangling risk for record %s", eipRecord)
 
-		assert.Equal(t, output.RiskSeverityMedium, matched.Severity)
+		assert.Equal(t, "TM", matched.Status)
 
-		var ctx map[string]any
-		require.NoError(t, json.Unmarshal(matched.Context, &ctx))
-		assert.Equal(t, fixture.Output("dangling_ip"), ctx["dangling_ip"],
-			"context should contain the dangling IP")
-		assert.NotEmpty(t, ctx["aws_region"], "context should contain the AWS region")
-		assert.NotEmpty(t, ctx["aws_service"], "context should contain the AWS service")
-		assert.NotEmpty(t, ctx["description"])
-		assert.NotEmpty(t, ctx["recommendation"])
-		assert.NotEmpty(t, ctx["references"])
+		details := recordDetails(t, *matched)
+		assert.Equal(t, fixture.Output("dangling_ip"), details["Dangling IP"],
+			"details should contain the dangling IP")
+		assert.NotEmpty(t, details["AWS Region"], "details should contain the AWS region")
+		assert.NotEmpty(t, details["AWS Service"], "details should contain the AWS service")
+		assert.NotEmpty(t, sectionText(t, *matched, "Summary"))
+		assert.NotEmpty(t, sectionText(t, *matched, "Recommendation"))
+		assert.NotEmpty(t, sectionText(t, *matched, "References"))
 	})
 
 	t.Run("detects NS delegation takeover", func(t *testing.T) {
 		nsRecord := fixture.Output("ns_record_name")
-		var matched *output.AurelianRisk
-		for i := range testRisks {
-			if testRisks[i].Name == "ns-delegation-takeover" &&
-				strings.Contains(testRisks[i].ImpactedResourceID, nsRecord) {
-				matched = &testRisks[i]
-				break
-			}
-		}
-		require.NotNilf(t, matched, "expected ns-delegation-takeover risk for record %s", nsRecord)
+		matched := findByName("Dangling NS Delegation Takeover", nsRecord)
+		require.NotNilf(t, matched, "expected NS delegation risk for record %s", nsRecord)
 
-		assert.Equal(t, output.RiskSeverityHigh, matched.Severity)
+		assert.Equal(t, "TH", matched.Status)
 
-		var ctx map[string]any
-		require.NoError(t, json.Unmarshal(matched.Context, &ctx))
-		assert.NotEmpty(t, ctx["nameservers"], "context should list dangling nameservers")
-		assert.NotEmpty(t, ctx["query_error"], "context should contain the DNS error type")
-		assert.NotEmpty(t, ctx["description"])
-		assert.NotEmpty(t, ctx["recommendation"])
-		assert.NotEmpty(t, ctx["references"])
+		details := recordDetails(t, *matched)
+		assert.NotEmpty(t, details["Nameservers"], "details should list dangling nameservers")
 
-		// Verify query_error is one of the expected DNS error classifications.
-		validErrors := map[string]bool{
-			"NXDOMAIN": true,
-			"SERVFAIL": true,
-			"REFUSED":  true,
-		}
-		assert.True(t, validErrors[ctx["query_error"].(string)],
-			"query_error should be NXDOMAIN, SERVFAIL, or REFUSED, got %q", ctx["query_error"])
+		validErrors := map[string]bool{"NXDOMAIN": true, "SERVFAIL": true, "REFUSED": true}
+		assert.Truef(t, validErrors[details["Query Error"]],
+			"query error should be NXDOMAIN, SERVFAIL, or REFUSED, got %q", details["Query Error"])
+		assert.NotEmpty(t, sectionText(t, *matched, "Summary"))
+		assert.NotEmpty(t, sectionText(t, *matched, "Recommendation"))
+		assert.NotEmpty(t, sectionText(t, *matched, "References"))
 	})
 
 	// --- Negative testing ---
@@ -146,7 +171,7 @@ func TestAWSSubdomainTakeover(t *testing.T) {
 	t.Run("safe CNAME does not trigger finding", func(t *testing.T) {
 		safeCname := fixture.Output("safe_cname_record_name")
 		for _, r := range testRisks {
-			assert.False(t, strings.Contains(r.ImpactedResourceID, safeCname),
+			assert.NotEqualf(t, safeCname, recordDetails(t, r)["Record Name"],
 				"safe CNAME %s should not trigger a finding (got %s)", safeCname, r.Name)
 		}
 	})
@@ -154,83 +179,38 @@ func TestAWSSubdomainTakeover(t *testing.T) {
 	t.Run("safe A record does not trigger finding", func(t *testing.T) {
 		safeA := fixture.Output("safe_a_record_name")
 		for _, r := range testRisks {
-			assert.False(t, strings.Contains(r.ImpactedResourceID, safeA),
+			assert.NotEqualf(t, safeA, recordDetails(t, r)["Record Name"],
 				"safe A record %s should not trigger a finding (got %s)", safeA, r.Name)
 		}
 	})
 
-	// --- Cross-cutting field validation ---
+	// --- Cross-cutting contract validation ---
 
-	t.Run("all risks have valid risk names", func(t *testing.T) {
+	t.Run("all risks satisfy the capmodel.Risk contract", func(t *testing.T) {
 		validNames := map[string]bool{
-			"eb-subdomain-takeover":  true,
-			"eip-dangling-a-record":  true,
-			"ns-delegation-takeover": true,
+			"Elastic Beanstalk Subdomain Takeover": true,
+			"Dangling Elastic IP A Record":         true,
+			"Dangling NS Delegation Takeover":      true,
 		}
-		for _, r := range testRisks {
-			assert.True(t, validNames[r.Name],
-				"unexpected risk name %q", r.Name)
-		}
-	})
+		validStatus := map[string]bool{"TC": true, "TH": true, "TM": true, "TL": true, "TI": true}
 
-	t.Run("all risks have expected severity levels", func(t *testing.T) {
-		expectedSeverity := map[string]output.RiskSeverity{
-			"eb-subdomain-takeover":  output.RiskSeverityHigh,
-			"eip-dangling-a-record":  output.RiskSeverityMedium,
-			"ns-delegation-takeover": output.RiskSeverityHigh,
-		}
 		for _, r := range testRisks {
-			if expected, ok := expectedSeverity[r.Name]; ok {
-				assert.Equal(t, expected, r.Severity,
-					"severity mismatch for %s", r.Name)
-			}
-		}
-	})
+			assert.Truef(t, validNames[r.Name], "unexpected risk name %q", r.Name)
+			assert.Equalf(t, "aurelian", r.Source, "risk %q should have Source=aurelian", r.Name)
+			assert.Truef(t, validStatus[r.Status], "risk %q has invalid status %q", r.Name, r.Status)
+			assert.NotEmptyf(t, r.TargetName, "risk %q should have a TargetName", r.Name)
+			assert.NotEmptyf(t, r.Proof, "risk %q should have a non-empty Proof", r.Name)
 
-	t.Run("all risks have non-empty context", func(t *testing.T) {
-		for _, r := range testRisks {
-			assert.NotEmpty(t, r.Context,
-				"risk context should not be empty for %s (%s)", r.Name, r.ImpactedResourceID)
-		}
-	})
-
-	t.Run("all risks have non-empty DeduplicationID", func(t *testing.T) {
-		for _, r := range testRisks {
-			assert.NotEmpty(t, r.DeduplicationID,
-				"risk should have DeduplicationID for %s", r.Name)
-		}
-	})
-
-	t.Run("ImpactedResourceIDs follow Route53 ARN format", func(t *testing.T) {
-		for _, r := range testRisks {
-			assert.True(t, strings.HasPrefix(r.ImpactedResourceID, "arn:aws:route53:::hostedzone/"),
-				"ImpactedResourceID %q should start with arn:aws:route53:::hostedzone/", r.ImpactedResourceID)
-			assert.Contains(t, r.ImpactedResourceID, zoneID,
-				"ImpactedResourceID should contain zone ID %s", zoneID)
-			assert.Contains(t, r.ImpactedResourceID, "/recordset/",
-				"ImpactedResourceID should contain /recordset/")
-		}
-	})
-
-	t.Run("all risk contexts contain common Route53 fields", func(t *testing.T) {
-		for _, r := range testRisks {
-			var ctx map[string]any
-			require.NoError(t, json.Unmarshal(r.Context, &ctx))
-			assert.NotEmpty(t, ctx["account_id"], "context missing account_id for %s", r.Name)
-			assert.Equal(t, zoneID, ctx["zone_id"], "context zone_id mismatch for %s", r.Name)
-			assert.NotEmpty(t, ctx["zone_name"], "context missing zone_name for %s", r.Name)
-			assert.NotEmpty(t, ctx["record_name"], "context missing record_name for %s", r.Name)
-			assert.NotEmpty(t, ctx["record_type"], "context missing record_type for %s", r.Name)
-			assert.NotNil(t, ctx["record_values"], "context missing record_values for %s", r.Name)
-		}
-	})
-
-	t.Run("DeduplicationIDs are unique", func(t *testing.T) {
-		seen := make(map[string]bool)
-		for _, r := range testRisks {
-			assert.False(t, seen[r.DeduplicationID],
-				"duplicate DeduplicationID %q for %s", r.DeduplicationID, r.Name)
-			seen[r.DeduplicationID] = true
+			details := recordDetails(t, r)
+			assert.Equalf(t, zoneID, details["Zone ID"], "risk %q Zone ID mismatch", r.Name)
+			assert.NotEmptyf(t, details["Zone Name"], "risk %q missing Zone Name", r.Name)
+			assert.NotEmptyf(t, details["Record Name"], "risk %q missing Record Name", r.Name)
+			assert.NotEmptyf(t, details["Record Type"], "risk %q missing Record Type", r.Name)
+			assert.NotEmptyf(t, details["Account ID"], "risk %q missing Account ID", r.Name)
+			assert.Truef(t,
+				strings.HasPrefix(details["Route53 ARN"], "arn:aws:route53:::hostedzone/"),
+				"risk %q Route53 ARN %q should start with arn:aws:route53:::hostedzone/",
+				r.Name, details["Route53 ARN"])
 		}
 	})
 }


### PR DESCRIPTION
## What
Part of Phase 0 risk standardization (LAB-3740). Migrates the `subdomain-takeover` module from the freeform `output.AurelianRisk` to the platform `capmodel.Risk` + structured `capmodel.Proof`, mirroring the cloudfront-s3-takeover migration (#209).

Linear: https://linear.app/praetorianlabs/issue/LAB-3992/takeover-risk-aws-subdomain-takeover

> **Stacked on #209** (`fix/lab-3995-cloudfront-capmodel-risk`) — this PR's base is that branch, to inherit the `capability-sdk` dependency and the opened `AurelianModel` marker interface. **Retarget the base to `main` once #209 merges.**

## Changes (all package-local in `pkg/aws/dnstakeover/`)
- **`risk.go`** (new): one package-local proof builder for all three subdomain-takeover risk classes. Typed `takeoverFinding` input, a versioned (`v1.0.0`) takeover proof, local proof-element helpers, `severityToStatus`, and `NewTakeoverRisk(takeoverFinding) (capmodel.Risk, error)`. `Source=aurelian`, Chariot triage `Status` (EB→`TH`, EIP→`TM`, NS→`TH`), human-readable `Name`, `Target=nil` with a `TODO(LAB-3740)`. The legacy Route53 ARN (`arn:aws:route53:::hostedzone/{ZoneID}/recordset/{RecordName}/{Type}`) is preserved as a copyable key-value proof row.
- **`types.go`**: retire the old map-based `output.AurelianRisk` builder.
- **`check_eb.go` / `check_eip.go` / `check_ns.go`**: emit `capmodel.Risk` via the typed builder with skip-on-failure; detection logic unchanged.
- **`risk_test.go`** (new): unit tests for the three risk classes + the `severityToStatus` mapping.
- **`pkg/modules/aws/recon/subdomain_takeover_integration_test.go`**: rewritten to collect `capmodel.Risk` and assert the structured-proof contract (filters to the test zone via the Route53 ARN proof row).

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...`, `go vet -tags=integration ./pkg/modules/aws/recon/` — green.
- Live integration test (`AWS_PROFILE=bfr`, `-tags=integration`) — all 6 subtests pass across two runs (deploy + teardown/redeploy): EB→`TH`, EIP→`TM`, NS→`TH` (REFUSED), both safe records not flagged, `capmodel.Risk` contract held; fixtures torn down afterward.

## Out of scope / follow-ups
- Risk/proof builders are kept **package-local** (per-module `risk.go`), not a shared/centralized package — consistent with #209. A shared takeover-builder extraction (LAB-3992's "converge on a single builder" language) is a separate follow-up; some proof-helper duplication with the cloudfront package is the accepted trade-off.
- `Risk.Target` left `nil` (`TODO(LAB-3740)`) pending Aurelian's SDK `_type` envelope that Guard's ingest consumes.
