### PR TITLE
fix(aws/extraction): detect ECS task-def env-var credential pairs (LAB-4036)

### DIFF
--- a/pkg/aws/extraction/extract_ecs.go
+++ b/pkg/aws/extraction/extract_ecs.go
@@ -3,6 +3,7 @@ package extraction
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
@@ -23,5 +24,56 @@ func extractECS(_ extractContext, r output.AWSResource, out *pipeline.P[output.S
 	}
 
 	out.Send(output.ScanInputFromAWSResource(r, "ECS Task Definition", data))
+
+	// json.Marshal sorts map keys, so paired env vars (e.g. an access key and its
+	// secret) end up separated by structural JSON text that exceeds the proximity
+	// window of secret rules like np.aws.6. Emit the container environment variables
+	// as adjacent NAME=VALUE lines so paired credentials stay close enough to match.
+	if envLines := ecsEnvLines(r.Properties); envLines != "" {
+		out.Send(output.ScanInputFromAWSResource(r, "ECS Task Definition Env", []byte(envLines)))
+	}
+
 	return nil
+}
+
+// ecsEnvLines walks the (PascalCase, CloudControl-shaped) task definition properties
+// and returns each container environment variable as a NAME=VALUE line. Missing or
+// mistyped fields are skipped rather than treated as errors.
+func ecsEnvLines(props map[string]any) string {
+	containers, ok := props["ContainerDefinitions"].([]any)
+	if !ok {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, c := range containers {
+		container, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		env, ok := container["Environment"].([]any)
+		if !ok {
+			continue
+		}
+		for _, e := range env {
+			entry, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			name, ok := entry["Name"].(string)
+			if !ok {
+				continue
+			}
+			value, ok := entry["Value"].(string)
+			if !ok {
+				continue
+			}
+			b.WriteString(name)
+			b.WriteByte('=')
+			b.WriteString(value)
+			b.WriteByte('\n')
+		}
+	}
+
+	return b.String()
 }

--- a/pkg/aws/extraction/extract_ecs_test.go
+++ b/pkg/aws/extraction/extract_ecs_test.go
@@ -13,12 +13,14 @@ import (
 func runExtractECS(t *testing.T, r output.AWSResource) []output.ScanInput {
 	t.Helper()
 	out := pipeline.New[output.ScanInput]()
+	errCh := make(chan error, 1)
 	go func() {
 		defer out.Close()
-		require.NoError(t, extractECS(extractContext{}, r, out))
+		errCh <- extractECS(extractContext{}, r, out)
 	}()
 	items, err := out.Collect()
 	require.NoError(t, err)
+	require.NoError(t, <-errCh)
 	return items
 }
 

--- a/pkg/aws/extraction/extract_ecs_test.go
+++ b/pkg/aws/extraction/extract_ecs_test.go
@@ -1,0 +1,129 @@
+package extraction
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runExtractECS(t *testing.T, r output.AWSResource) []output.ScanInput {
+	t.Helper()
+	out := pipeline.New[output.ScanInput]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, extractECS(extractContext{}, r, out))
+	}()
+	items, err := out.Collect()
+	require.NoError(t, err)
+	return items
+}
+
+func TestExtractECS_EnvVarsEmittedAsAdjacentLines(t *testing.T) {
+	r := output.AWSResource{
+		ResourceType: "AWS::ECS::TaskDefinition",
+		ResourceID:   "arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:1",
+		Region:       "us-east-1",
+		AccountRef:   "123456789012",
+		Properties: map[string]any{
+			"Family": "my-task",
+			"ContainerDefinitions": []any{
+				map[string]any{
+					"Name": "app",
+					"Environment": []any{
+						map[string]any{"Name": "AWS_ACCESS_KEY_ID", "Value": "AKIAIOSFODNN7EXAMPLE"},
+						map[string]any{"Name": "AWS_SECRET_ACCESS_KEY", "Value": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+					},
+				},
+			},
+		},
+	}
+
+	items := runExtractECS(t, r)
+
+	var env *output.ScanInput
+	for i := range items {
+		if items[i].Label == "ECS Task Definition Env" {
+			env = &items[i]
+		}
+	}
+	require.NotNil(t, env, "expected an ECS Task Definition Env ScanInput")
+
+	content := string(env.Content)
+	assert.Contains(t, content, "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE")
+	assert.Contains(t, content, "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+	// Proximity is the whole point of the fix: the secret value must follow the
+	// access-key value on the next line so the gap stays inside np.aws.6's window.
+	expectedAdjacent := "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\nAWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"
+	assert.Contains(t, content, expectedAdjacent)
+	// np.aws.6 measures the gap between the END of the access key and the START of
+	// the secret value; that span must be under 40 chars.
+	const accessKey = "AKIAIOSFODNN7EXAMPLE"
+	endOfKey := strings.Index(content, accessKey) + len(accessKey)
+	gap := strings.Index(content, "wJalr") - endOfKey
+	assert.Less(t, gap, 40, "access-key and secret must be within np.aws.6's 40-char window")
+}
+
+func TestExtractECS_MultipleContainersEnvConcatenated(t *testing.T) {
+	r := output.AWSResource{
+		ResourceType: "AWS::ECS::TaskDefinition",
+		ResourceID:   "arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:1",
+		Properties: map[string]any{
+			"ContainerDefinitions": []any{
+				map[string]any{
+					"Name":        "a",
+					"Environment": []any{map[string]any{"Name": "FOO", "Value": "1"}},
+				},
+				map[string]any{
+					"Name":        "b",
+					"Environment": []any{map[string]any{"Name": "BAR", "Value": "2"}},
+				},
+				map[string]any{
+					"Name": "no-env",
+				},
+				"not-a-map",
+				map[string]any{
+					"Name":        "c",
+					"Environment": []any{map[string]any{"Name": "BAZ", "Value": 3}}, // non-string value skipped
+				},
+			},
+		},
+	}
+
+	items := runExtractECS(t, r)
+
+	var content string
+	for _, it := range items {
+		if it.Label == "ECS Task Definition Env" {
+			content = string(it.Content)
+		}
+	}
+	assert.Equal(t, "FOO=1\nBAR=2\n", content)
+}
+
+func TestExtractECS_NoEnvOnlyJSONScanInput(t *testing.T) {
+	r := output.AWSResource{
+		ResourceType: "AWS::ECS::TaskDefinition",
+		ResourceID:   "arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:1",
+		Properties: map[string]any{
+			"Family": "my-task",
+			"ContainerDefinitions": []any{
+				map[string]any{"Name": "app"},
+			},
+		},
+	}
+
+	items := runExtractECS(t, r)
+
+	require.Len(t, items, 1)
+	assert.Equal(t, "ECS Task Definition", items[0].Label)
+}
+
+func TestExtractECS_EmptyPropertiesEmitsNothing(t *testing.T) {
+	items := runExtractECS(t, output.AWSResource{ResourceType: "AWS::ECS::TaskDefinition"})
+	assert.Empty(t, items)
+}


### PR DESCRIPTION
## Summary

Fixes **LAB-4036**: paired AWS credentials stored across two ECS task-definition **environment variables** (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`) were not detected by `find-secrets`.

`extractECS` emitted the task definition only as `json.Marshal(r.Properties)`. Go sorts map keys alphabetically, so each env var serialized as `{"Name":…,"Value":…}` (Name before Value), leaving **~44 chars** of structural JSON between the access-key value and the secret value — wider than titus rule **np.aws.6**'s 40-char proximity window (the only rule that matches the AWS `…EXAMPLE` doc-cred pair). So the pair went undetected.

## Fix

`extractECS` now **also** walks `ContainerDefinitions[].Environment[]` and emits the variables as adjacent `NAME=VALUE` lines in an **additional** `ScanInput`, restoring proximity (gap ~23 chars) so np.aws.6 fires:

```
AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
```

- The original `json.Marshal` ScanInput (label "ECS Task Definition") is **unchanged**; the env ScanInput is additive and only sent when env vars exist. A no-env task def behaves exactly as before.
- Every nesting level uses comma-ok type assertions and skips malformed CloudControl payloads — no panics.
- This consolidates all env vars into one ScanInput (unlike `extract_lambda.go`'s per-var emission) deliberately: per-line emission would re-open the very proximity gap being closed.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — green. New `pkg/aws/extraction/extract_ecs_test.go` (4 cases: paired-creds gap <40, multi-container concat + malformed-skip paths, no-env single-ScanInput, empty-Properties-emits-nothing).
- Live AWS (`AWS_PROFILE=bfr go test -tags=integration -run TestAWSFindSecrets ./pkg/modules/aws/recon/`, acct 196766918487): `TestAWSFindSecrets` is now **fully green** — the previously-failing `detects_secret_in_ECS_Task_Def` subtest **passes**, all others remain green.

## Context

Independent pre-existing bug (failed on `main` since ≥May 13 2026), surfaced by the LAB-3988 capmodel.Risk migration's live gate (#215). Branched from `main`; not stacked.
