### PR TITLE
ci(ai-review): remove branch restriction and drop cancel-in-progress

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -2,14 +2,12 @@ name: AI Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
-    branches: [main]
+    types: [opened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
 
 concurrency:
   group: ai-review-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -2,7 +2,7 @@ name: AI Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize]
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -69,10 +69,6 @@ jobs:
             echo "::error::PR head is on a fork ($HEAD_REPO); refusing."
             exit 1
           fi
-          if [[ "$BASE" != "main" ]]; then
-            echo "::notice::PR #$NUM targets $BASE, not main; skipping review."
-            exit 0
-          fi
           if [[ "$STATE" != "OPEN" ]]; then
             echo "::notice::PR #$NUM is $STATE; skipping review."
             exit 0


### PR DESCRIPTION
## Summary
- Remove \`branches: [main]\` trigger restriction — reviews now fire on all PRs regardless of target branch
- Remove hard base-branch gate in \`Resolve PR head\` step that was skipping any PR not targeting \`main\` — this was nullifying the trigger change
- Drop \`cancel-in-progress: true\` — in-progress reviews run to completion; subsequent pushes queue rather than kill the current run

## Why
Two gates were blocking reviews on non-main-targeting PRs: the trigger filter and a redundant runtime check in the step script. Both are removed. Dropping cancel-in-progress ensures a review that starts when a PR is opened always completes.