### PR TITLE
feat(publicresource): migrate public-resources (AWS/Azure/GCP) to capmodel.Risk (LAB-3989/3990/3991)

### DIFF
--- a/pkg/gcp/publicaccess/evaluator.go
+++ b/pkg/gcp/publicaccess/evaluator.go
@@ -1,19 +1,22 @@
 package publicaccess
 
 import (
-	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
 
 	"github.com/praetorian-inc/aurelian/pkg/model"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/publicresource"
 )
 
 // AccessEvaluator evaluates a GCPResource for public/anonymous access indicators
-// and emits both the resource and an AurelianRisk if applicable.
+// and emits both the resource and a capmodel.Risk if applicable.
 type AccessEvaluator struct{}
 
-// Evaluate sends the resource to out and, if public or anonymous access is detected,
-// also emits an AurelianRisk.
+// Evaluate sends the resource to out and, if public or anonymous access is
+// detected, also emits a standardized public-resource capmodel.Risk.
 func (e *AccessEvaluator) Evaluate(r output.GCPResource, out *pipeline.P[model.AurelianModel]) error {
 	out.Send(r)
 
@@ -28,35 +31,45 @@ func (e *AccessEvaluator) Evaluate(r output.GCPResource, out *pipeline.P[model.A
 	}
 
 	var severity output.RiskSeverity
-	var name string
+	var name, summary string
 	switch {
 	case hasPublicNetwork && hasAnonymousAccess:
-		severity = output.RiskSeverityHigh
-		name = "public-anonymous-gcp-resource"
+		severity, name = output.RiskSeverityHigh, "public-anonymous-gcp-resource"
+		summary = fmt.Sprintf("GCP resource %s (%s) in project %s is reachable from the internet and allows anonymous access.", r.ResourceID, r.ResourceType, r.ProjectID)
 	case hasAnonymousAccess:
-		severity = output.RiskSeverityMedium
-		name = "anonymous-gcp-resource"
+		severity, name = output.RiskSeverityMedium, "anonymous-gcp-resource"
+		summary = fmt.Sprintf("GCP resource %s (%s) in project %s allows anonymous access.", r.ResourceID, r.ResourceType, r.ProjectID)
 	default:
-		severity = output.RiskSeverityMedium
-		name = "public-gcp-resource"
+		severity, name = output.RiskSeverityMedium, "public-gcp-resource"
+		summary = fmt.Sprintf("GCP resource %s (%s) in project %s has public network exposure.", r.ResourceID, r.ResourceType, r.ProjectID)
 	}
 
-	ctx, _ := json.Marshal(map[string]any{
-		"resourceType":    r.ResourceType,
-		"resourceID":      r.ResourceID,
-		"projectID":       r.ProjectID,
-		"publicNetwork":   hasPublicNetwork,
-		"anonymousAccess": hasAnonymousAccess,
-		"ips":             r.IPs,
-		"urls":            r.URLs,
+	risk, err := publicresource.NewRisk(publicresource.PublicResource{
+		Provider:     "GCP",
+		RiskName:     name,
+		ResourceType: r.ResourceType,
+		ResourceID:   r.ResourceID,
+		ResourceName: r.DisplayName,
+		Region:       r.Location,
+		Scope:        r.ProjectID,
+		ScopeLabel:   "GCP Project",
+		Severity:     severity,
+		Summary:      summary,
+		Exposure: []publicresource.Fact{
+			{Key: "Public Network", Value: strconv.FormatBool(hasPublicNetwork)},
+			{Key: "Anonymous Access", Value: strconv.FormatBool(hasAnonymousAccess)},
+		},
+		Lists: []publicresource.NamedList{
+			{Title: "Public IPs", Items: r.IPs},
+			{Title: "Public URLs", Items: r.URLs},
+		},
+		Properties: r.Properties,
 	})
+	if err != nil {
+		slog.Warn("failed to build public resource risk", "resource", r.ResourceID, "error", err)
+		return nil
+	}
 
-	out.Send(output.AurelianRisk{
-		Name:        name,
-		Severity:    severity,
-		ImpactedResourceID: r.ResourceID,
-		Context:     ctx,
-	})
-
+	out.Send(risk)
 	return nil
 }

--- a/pkg/gcp/publicaccess/evaluator_test.go
+++ b/pkg/gcp/publicaccess/evaluator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/model"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,7 +68,9 @@ func TestEvaluate_BothPublicAndAnonymous_HighSeverity(t *testing.T) {
 	items, err := out.Collect()
 	require.NoError(t, err)
 	require.Len(t, items, 2)
-	risk, ok := items[1].(output.AurelianRisk)
+	risk, ok := items[1].(capmodel.Risk)
 	require.True(t, ok)
-	assert.Equal(t, output.RiskSeverityHigh, risk.Severity)
+	assert.Equal(t, "TH", risk.Status)
+	assert.Equal(t, "public-anonymous-gcp-resource", risk.Name)
+	assert.Equal(t, "id", risk.TargetName)
 }

--- a/pkg/modules/aws/recon/public_resources.go
+++ b/pkg/modules/aws/recon/public_resources.go
@@ -1,9 +1,9 @@
 package recon
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/praetorian-inc/aurelian/pkg/aws/enrichment"
 	cclist "github.com/praetorian-inc/aurelian/pkg/aws/enumeration"
@@ -12,6 +12,7 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/pkg/publicresource"
 )
 
 func init() {
@@ -117,24 +118,50 @@ func riskFromResult(r publicaccess.PublicAccessResult, out *pipeline.P[model.Aur
 		return nil
 	}
 
-	resourceID := r.AWSResource.ResourceID
-	impactedARN := r.AWSResource.ARN
-	if impactedARN == "" {
-		impactedARN = resourceID
+	res := r.AWSResource
+	resourceID := res.ARN
+	if resourceID == "" {
+		resourceID = res.ResourceID
 	}
 
-	r.AWSResource = nil
-	ctx, err := json.Marshal(r)
+	risk, err := publicresource.NewRisk(publicresource.PublicResource{
+		Provider:     "AWS",
+		RiskName:     "public-aws-resource",
+		ResourceType: res.ResourceType,
+		ResourceID:   resourceID,
+		ResourceName: res.DisplayName,
+		Region:       res.Region,
+		Scope:        res.AccountRef,
+		ScopeLabel:   "AWS Account",
+		Severity:     severity,
+		Summary:      awsSummary(res, severity),
+		Exposure: []publicresource.Fact{
+			{Key: "Access Level", Value: string(res.AccessLevel)},
+			{Key: "Public", Value: strconv.FormatBool(r.IsPublic)},
+			{Key: "Needs Manual Triage", Value: strconv.FormatBool(r.NeedsManualTriage)},
+		},
+		Lists: []publicresource.NamedList{
+			{Title: "Allowed Actions", Items: r.AllowedActions},
+			{Title: "Evaluation Reasons", Items: r.EvaluationReasons},
+			{Title: "Public Endpoints", Items: append(append([]string{}, res.URLs...), res.IPs...)},
+		},
+		Properties: res.Properties,
+	})
 	if err != nil {
-		slog.Warn("failed to build risk context", "resource", resourceID, "error", err)
+		slog.Warn("failed to build public resource risk", "resource", resourceID, "error", err)
 		return nil
 	}
 
-	out.Send(output.AurelianRisk{
-		Name:        "public-aws-resource",
-		Severity:    severity,
-		ImpactedResourceID: impactedARN,
-		Context:     ctx,
-	})
+	out.Send(risk)
 	return nil
+}
+
+// awsSummary describes the exposure for the proof's Summary section.
+func awsSummary(res *output.AWSResource, severity output.RiskSeverity) string {
+	if severity == output.RiskSeverityMedium {
+		return fmt.Sprintf("AWS resource %s (%s) in account %s may be publicly accessible and requires manual triage.",
+			res.ResourceID, res.ResourceType, res.AccountRef)
+	}
+	return fmt.Sprintf("AWS resource %s (%s) in account %s is publicly accessible.",
+		res.ResourceID, res.ResourceType, res.AccountRef)
 }

--- a/pkg/modules/aws/recon/public_resources_integration_test.go
+++ b/pkg/modules/aws/recon/public_resources_integration_test.go
@@ -4,16 +4,15 @@ package recon
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/praetorian-inc/aurelian/pkg/model"
 	_ "github.com/praetorian-inc/aurelian/pkg/modules/aws/enrichers"
-	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,9 +49,9 @@ func TestAWSPublicResources(t *testing.T) {
 	p2 := pipeline.New[model.AurelianModel]()
 	pipeline.Pipe(p1, mod.Run, p2)
 
-	var risks []output.AurelianRisk
+	var risks []capmodel.Risk
 	for m := range p2.Range() {
-		if r, ok := m.(output.AurelianRisk); ok {
+		if r, ok := m.(capmodel.Risk); ok {
 			risks = append(risks, r)
 		}
 	}
@@ -61,9 +60,10 @@ func TestAWSPublicResources(t *testing.T) {
 
 	for _, risk := range risks {
 		assert.Equal(t, "public-aws-resource", risk.Name)
-		assert.Contains(t, []output.RiskSeverity{output.RiskSeverityHigh, output.RiskSeverityMedium}, risk.Severity)
-		assert.NotContains(t, string(risk.Context), "aws_resource")
-		assert.NotEmpty(t, risk.ImpactedResourceID)
+		assert.Equal(t, "aurelian", risk.Source)
+		assert.Contains(t, []string{"TH", "TM"}, risk.Status)
+		assert.NotEmpty(t, risk.TargetName)
+		assert.NotEmpty(t, risk.Proof)
 	}
 
 	expectedImpactedResources := []string{
@@ -90,18 +90,13 @@ func TestAWSPublicResources(t *testing.T) {
 	hasInvokeFunctionURL := false
 	hasAmplifyGetApp := false
 	for _, risk := range risks {
-		var ctx struct {
-			AllowedActions []string `json:"allowed_actions"`
-		}
-		require.NoError(t, json.Unmarshal(risk.Context, &ctx))
-		for _, action := range ctx.AllowedActions {
-			if action == "lambda:InvokeFunction" {
+		for _, action := range optionalSectionLabels(t, risk, "Allowed Actions") {
+			switch action {
+			case "lambda:InvokeFunction":
 				hasInvokeFunction = true
-			}
-			if action == "lambda:InvokeFunctionUrl" {
+			case "lambda:InvokeFunctionUrl":
 				hasInvokeFunctionURL = true
-			}
-			if action == "amplify:GetApp" {
+			case "amplify:GetApp":
 				hasAmplifyGetApp = true
 			}
 		}
@@ -114,52 +109,63 @@ func TestAWSPublicResources(t *testing.T) {
 	amplifyAppID := fixture.Output("public_amplify_app_id")
 	amplifyRisk := findRiskForResource(risks, amplifyAppID)
 	if assert.NotNilf(t, amplifyRisk, "expected risk for Amplify app %s", amplifyAppID) {
-		assert.Equal(t, output.RiskSeverityHigh, amplifyRisk.Severity)
-		var ctx struct {
-			AllowedActions    []string `json:"allowed_actions"`
-			EvaluationReasons []string `json:"evaluation_reasons"`
-		}
-		require.NoError(t, json.Unmarshal(amplifyRisk.Context, &ctx))
-		assert.Contains(t, ctx.AllowedActions, "amplify:GetApp")
-		assert.NotEmpty(t, ctx.EvaluationReasons)
-		assert.Contains(t, ctx.EvaluationReasons[0], "publicly accessible branch URL(s)")
+		assert.Equal(t, "TH", amplifyRisk.Status)
+		assert.Contains(t, optionalSectionLabels(t, *amplifyRisk, "Allowed Actions"), "amplify:GetApp")
+		reasons := optionalSectionLabels(t, *amplifyRisk, "Evaluation Reasons")
+		require.NotEmpty(t, reasons)
+		assert.Contains(t, reasons[0], "publicly accessible branch URL(s)")
 	}
 
 	publicAMIID := fixture.Output("public_ami_id")
 	amiRisk := findRiskForResource(risks, publicAMIID)
 	if assert.NotNilf(t, amiRisk, "expected risk for public AMI %s", publicAMIID) {
-		assert.Contains(t, []output.RiskSeverity{output.RiskSeverityHigh, output.RiskSeverityMedium}, amiRisk.Severity)
-		var ctx struct {
-			AllowedActions    []string `json:"allowed_actions"`
-			EvaluationReasons []string `json:"evaluation_reasons"`
-		}
-		require.NoError(t, json.Unmarshal(amiRisk.Context, &ctx))
-		assert.Contains(t, ctx.AllowedActions, "ec2:RunInstances")
-		assert.NotEmpty(t, ctx.EvaluationReasons)
+		assert.Contains(t, []string{"TH", "TM"}, amiRisk.Status)
+		assert.Contains(t, optionalSectionLabels(t, *amiRisk, "Allowed Actions"), "ec2:RunInstances")
+		assert.NotEmpty(t, optionalSectionLabels(t, *amiRisk, "Evaluation Reasons"))
 	}
+
+	t.Run("proof carries the standardized public-resource structure", func(t *testing.T) {
+		proof := decodeProof(t, risks[0])
+		assert.Equal(t, "v1.0.0", proof.Format)
+		assert.NotEmpty(t, paragraphText(sectionByTitle(t, proof, "Summary")))
+		resource := keyValueMap(sectionByTitle(t, proof, "Resource"))
+		assert.Equal(t, risks[0].TargetName, resource["Resource ID"])
+		assert.NotEmpty(t, keyValueMap(sectionByTitle(t, proof, "Exposure")))
+	})
 }
 
-func findRiskForResource(risks []output.AurelianRisk, expected string) *output.AurelianRisk {
-	for _, risk := range risks {
-		if risk.ImpactedResourceID == expected ||
-			strings.HasSuffix(risk.ImpactedResourceID, "/"+expected) ||
-			strings.HasSuffix(risk.ImpactedResourceID, ":"+expected) ||
-			strings.Contains(risk.ImpactedResourceID, expected) {
-			return &risk
+// optionalSectionLabels returns the list labels of a proof section when present,
+// or nil when the section is absent (sectionByTitle fails on missing sections).
+func optionalSectionLabels(t *testing.T, risk capmodel.Risk, title string) []string {
+	t.Helper()
+	proof := decodeProof(t, risk)
+	for _, s := range proof.Sections {
+		if s.Title == title {
+			return listLabels(s)
 		}
 	}
 	return nil
 }
 
-func hasRiskForResource(risks []output.AurelianRisk, expected string) bool {
+func findRiskForResource(risks []capmodel.Risk, expected string) *capmodel.Risk {
+	for i := range risks {
+		id := risks[i].TargetName
+		if id == expected ||
+			strings.HasSuffix(id, "/"+expected) ||
+			strings.HasSuffix(id, ":"+expected) ||
+			strings.Contains(id, expected) {
+			return &risks[i]
+		}
+	}
+	return nil
+}
+
+func hasRiskForResource(risks []capmodel.Risk, expected string) bool {
 	for _, risk := range risks {
-		if risk.ImpactedResourceID == expected {
-			return true
-		}
-		if strings.HasSuffix(risk.ImpactedResourceID, "/"+expected) {
-			return true
-		}
-		if strings.HasSuffix(risk.ImpactedResourceID, ":"+expected) {
+		id := risk.TargetName
+		if id == expected ||
+			strings.HasSuffix(id, "/"+expected) ||
+			strings.HasSuffix(id, ":"+expected) {
 			return true
 		}
 	}

--- a/pkg/modules/azure/recon/public_resources.go
+++ b/pkg/modules/azure/recon/public_resources.go
@@ -1,8 +1,9 @@
 package recon
 
 import (
-	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/praetorian-inc/aurelian/pkg/azure/resourcegraph"
 	"github.com/praetorian-inc/aurelian/pkg/azure/subscriptions"
@@ -11,6 +12,7 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/pkg/publicresource"
 	"github.com/praetorian-inc/aurelian/pkg/templates"
 	azuretemplates "github.com/praetorian-inc/aurelian/pkg/templates/azure/public-resources"
 )
@@ -122,17 +124,45 @@ func (m *AzurePublicResourcesModule) Run(_ plugin.Config, out *pipeline.P[model.
 }
 
 func resultToRisk(result templates.ARGQueryResult, out *pipeline.P[model.AurelianModel]) error {
-	ctx, err := json.Marshal(result)
+	tmpl := result.TemplateDetails
+	severity := output.RiskSeverityInfo
+	summary := fmt.Sprintf("Azure resource %s matched public-exposure query %s.", result.ResourceID, result.TemplateID)
+	exposure := []publicresource.Fact{{Key: "Template ID", Value: result.TemplateID}}
+	var references []string
+
+	if tmpl != nil {
+		severity = tmpl.Severity
+		if tmpl.Description != "" {
+			summary = tmpl.Description
+		}
+		references = tmpl.References
+		exposure = append(exposure,
+			publicresource.Fact{Key: "Template Name", Value: tmpl.Name},
+			publicresource.Fact{Key: "Category", Value: strings.Join(tmpl.Category, ", ")},
+			publicresource.Fact{Key: "Triage Notes", Value: tmpl.TriageNotes},
+		)
+	}
+
+	risk, err := publicresource.NewRisk(publicresource.PublicResource{
+		Provider:     "Azure",
+		RiskName:     "public-azure-resource",
+		ResourceType: result.ResourceType,
+		ResourceID:   result.ResourceID,
+		ResourceName: result.ResourceName,
+		Region:       result.Location,
+		Scope:        result.SubscriptionID,
+		ScopeLabel:   "Azure Subscription",
+		Severity:     severity,
+		Summary:      summary,
+		Exposure:     exposure,
+		References:   references,
+		Properties:   result.Properties,
+	})
 	if err != nil {
-		slog.Warn("failed to marshal risk context", "template", result.TemplateID, "error", err)
+		slog.Warn("failed to build public resource risk", "template", result.TemplateID, "error", err)
 		return nil
 	}
 
-	out.Send(output.AurelianRisk{
-		Name:        "public-azure-resource",
-		Severity:    result.TemplateDetails.Severity,
-		ImpactedResourceID: result.ResourceID,
-		Context:     ctx,
-	})
+	out.Send(risk)
 	return nil
 }

--- a/pkg/modules/azure/recon/public_resources_integration_test.go
+++ b/pkg/modules/azure/recon/public_resources_integration_test.go
@@ -8,12 +8,46 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// decodeProof unmarshals a Risk's proof bytes into a structured capmodel.Proof.
+func decodeProof(t *testing.T, risk capmodel.Risk) capmodel.Proof {
+	t.Helper()
+	var proof capmodel.Proof
+	require.NoError(t, json.Unmarshal(risk.Proof, &proof), "proof should decode into capmodel.Proof")
+	return proof
+}
+
+// sectionByTitle returns the named proof section, failing if it is absent.
+func sectionByTitle(t *testing.T, proof capmodel.Proof, title string) capmodel.ProofSection {
+	t.Helper()
+	for _, s := range proof.Sections {
+		if s.Title == title {
+			return s
+		}
+	}
+	require.Failf(t, "section not found", "proof has no %q section", title)
+	return capmodel.ProofSection{}
+}
+
+// keyValueMap flattens a section's key/value rows into a map for assertions.
+func keyValueMap(section capmodel.ProofSection) map[string]string {
+	out := make(map[string]string)
+	for _, el := range section.Elements {
+		if el.KeyValue == nil {
+			continue
+		}
+		for _, row := range el.KeyValue.Rows {
+			out[row.Key] = row.Value
+		}
+	}
+	return out
+}
 
 func TestAzurePublicResources(t *testing.T) {
 	fixture := testutil.NewAzureFixture(t, "azure/recon/public-resources")
@@ -39,28 +73,27 @@ func TestAzurePublicResources(t *testing.T) {
 	// Index risks by template ID for precise assertions.
 	// =====================================================================
 
-	type riskWithContext struct {
-		Risk       output.AurelianRisk
-		CtxMap     map[string]any
+	type riskWithProof struct {
+		Risk       capmodel.Risk
+		Proof      capmodel.Proof
 		Template   string
 		ResourceID string
 	}
 
-	var all []riskWithContext
-	byTemplate := make(map[string][]riskWithContext)
+	var all []riskWithProof
+	byTemplate := make(map[string][]riskWithProof)
 	for _, r := range results {
-		risk, ok := r.(output.AurelianRisk)
+		risk, ok := r.(capmodel.Risk)
 		if !ok {
 			continue
 		}
-		var ctx map[string]any
-		require.NoError(t, json.Unmarshal(risk.Context, &ctx))
-		tid, _ := ctx["templateId"].(string)
-		rc := riskWithContext{
+		proof := decodeProof(t, risk)
+		tid := keyValueMap(sectionByTitle(t, proof, "Exposure"))["Template ID"]
+		rc := riskWithProof{
 			Risk:       risk,
-			CtxMap:     ctx,
+			Proof:      proof,
 			Template:   tid,
-			ResourceID: risk.ImpactedResourceID,
+			ResourceID: risk.TargetName,
 		}
 		all = append(all, rc)
 		byTemplate[tid] = append(byTemplate[tid], rc)
@@ -74,7 +107,7 @@ func TestAzurePublicResources(t *testing.T) {
 	}
 
 	// Helper: find a risk for a specific fixture resource within a template.
-	findRisk := func(t *testing.T, templateID, fixtureResourceIDKey string) riskWithContext {
+	findRisk := func(t *testing.T, templateID, fixtureResourceIDKey string) riskWithProof {
 		t.Helper()
 		expectedID := strings.ToLower(fixture.Output(fixtureResourceIDKey))
 		require.NotEmpty(t, expectedID, "fixture output %q is empty", fixtureResourceIDKey)
@@ -87,23 +120,24 @@ func TestAzurePublicResources(t *testing.T) {
 		}
 		t.Fatalf("template %q has %d findings but none match fixture resource %q (%s)",
 			templateID, len(risks), expectedID, fixtureResourceIDKey)
-		return riskWithContext{} // unreachable
+		return riskWithProof{} // unreachable
 	}
 
 	// Helper: assert a specific risk's common fields.
 	// resourceNameSubstr is an environment-agnostic suffix (e.g., "-kv", "sa", "-aks")
-	// that must appear in the ImpactedResourceID to confirm the right resource was caught.
-	assertRisk := func(t *testing.T, rc riskWithContext, expectedTemplate string, expectedSeverity output.RiskSeverity, resourceNameSubstr string) {
+	// that must appear in the TargetName to confirm the right resource was caught.
+	assertRisk := func(t *testing.T, rc riskWithProof, expectedTemplate, expectedStatus, resourceNameSubstr string) {
 		t.Helper()
 		assert.Equal(t, "public-azure-resource", rc.Risk.Name)
-		assert.Equal(t, expectedSeverity, rc.Risk.Severity,
-			"template %s: expected severity %s, got %s", expectedTemplate, expectedSeverity, rc.Risk.Severity)
+		assert.Equal(t, "aurelian", rc.Risk.Source)
+		assert.Equal(t, expectedStatus, rc.Risk.Status,
+			"template %s: expected status %s, got %s", expectedTemplate, expectedStatus, rc.Risk.Status)
 		assert.Equal(t, expectedTemplate, rc.Template)
-		assert.NotEmpty(t, rc.Risk.ImpactedResourceID)
-		assert.NotEmpty(t, rc.Risk.Context)
-		assert.Contains(t, strings.ToLower(rc.Risk.ImpactedResourceID), strings.ToLower(resourceNameSubstr),
-			"template %s: ImpactedResourceID %q should contain resource name substring %q",
-			expectedTemplate, rc.Risk.ImpactedResourceID, resourceNameSubstr)
+		assert.NotEmpty(t, rc.Risk.TargetName)
+		assert.NotEmpty(t, rc.Risk.Proof)
+		assert.Contains(t, strings.ToLower(rc.Risk.TargetName), strings.ToLower(resourceNameSubstr),
+			"template %s: TargetName %q should contain resource name substring %q",
+			expectedTemplate, rc.Risk.TargetName, resourceNameSubstr)
 	}
 
 	// Per-template assertions: verify each template found the expected fixture resource
@@ -111,48 +145,52 @@ func TestAzurePublicResources(t *testing.T) {
 	templateTests := []struct {
 		templateID string
 		fixtureKey string
-		severity   output.RiskSeverity
+		status     string
 		substr     string
 		optional   bool // skip if fixture output is missing
 	}{
 		// Storage & Data
-		{"storage_accounts_public_access", "storage_account_id", output.RiskSeverityHigh, "sa", false},
-		{"key_vault_public_access", "key_vault_id", output.RiskSeverityHigh, "-kv", false},
-		{"cosmos_db_public_access", "cosmos_db_id", output.RiskSeverityHigh, "-cosmos", false},
-		{"redis_cache_public_access", "redis_cache_id", output.RiskSeverityLow, "-redis", false},
-		{"app_configuration_public_access", "app_configuration_id", output.RiskSeverityMedium, "-appconf", false},
+		{"storage_accounts_public_access", "storage_account_id", "TH", "sa", false},
+		{"key_vault_public_access", "key_vault_id", "TH", "-kv", false},
+		{"cosmos_db_public_access", "cosmos_db_id", "TH", "-cosmos", false},
+		{"app_configuration_public_access", "app_configuration_id", "TM", "-appconf", false},
+		// NOTE: redis_cache_public_access is intentionally NOT tested live. Classic
+		// Azure Cache for Redis (Microsoft.Cache/Redis) — the only type the
+		// redis_cache_public_access template matches — can no longer be created
+		// account-wide following the Azure Cache for Redis retirement (HTTP 400,
+		// reproduced in eastus2 and westus2). The fixture no longer provisions it.
 		// Databases
-		{"sql_servers_public_access", "sql_server_id", output.RiskSeverityHigh, "-w-sql", true},
-		{"postgresql_flexible_server_public_access", "postgresql_server_id", output.RiskSeverityMedium, "-pg", false},
+		{"sql_servers_public_access", "sql_server_id", "TH", "-w-sql", true},
+		{"postgresql_flexible_server_public_access", "postgresql_server_id", "TM", "-pg", false},
 		// Container & Registry
-		{"container_registries_public_access", "acr_id", output.RiskSeverityHigh, "acr", false},
-		{"acr_anonymous_pull_access", "acr_anon_pull_id", output.RiskSeverityHigh, "acranon", false},
-		{"container_apps_public_access", "container_app_id", output.RiskSeverityMedium, "-w-ca", true},
-		{"container_instances_public_access", "container_instance_id", output.RiskSeverityMedium, "-ci", false},
-		{"aks_public_access", "aks_id", output.RiskSeverityHigh, "-aks", false},
+		{"container_registries_public_access", "acr_id", "TH", "acr", false},
+		{"acr_anonymous_pull_access", "acr_anon_pull_id", "TH", "acranon", false},
+		{"container_apps_public_access", "container_app_id", "TM", "-w-ca", true},
+		{"container_instances_public_access", "container_instance_id", "TM", "-ci", false},
+		{"aks_public_access", "aks_id", "TH", "-aks", false},
 		// AI & Search
-		{"cognitive_services_public_access", "cognitive_account_id", output.RiskSeverityMedium, "-cog", false},
-		{"search_service_public_access", "search_service_id", output.RiskSeverityMedium, "-search", false},
+		{"cognitive_services_public_access", "cognitive_account_id", "TM", "-cog", false},
+		{"search_service_public_access", "search_service_id", "TM", "-search", false},
 		// Compute
-		{"virtual_machines_public_access", "virtual_machine_id", output.RiskSeverityHigh, "-vm", false},
-		{"databricks_public_access", "databricks_workspace_id", output.RiskSeverityMedium, "-dbw", false},
+		{"virtual_machines_public_access", "virtual_machine_id", "TH", "-vm", false},
+		{"databricks_public_access", "databricks_workspace_id", "TM", "-dbw", false},
 		// IoT & Messaging
-		{"iot_hub_public_access", "iot_hub_id", output.RiskSeverityMedium, "-iot", false},
-		{"event_grid_topics_public_access", "event_grid_topic_id", output.RiskSeverityMedium, "-egt", false},
-		{"notification_hubs_public_access", "notification_hub_namespace_id", output.RiskSeverityMedium, "-nhns", false},
-		{"service_bus_public_access", "service_bus_id", output.RiskSeverityLow, "-sbus", false},
-		{"event_hub_public_access", "event_hub_id", output.RiskSeverityHigh, "-eh", false},
+		{"iot_hub_public_access", "iot_hub_id", "TM", "-iot", false},
+		{"event_grid_topics_public_access", "event_grid_topic_id", "TM", "-egt", false},
+		{"notification_hubs_public_access", "notification_hub_namespace_id", "TM", "-nhns", false},
+		{"service_bus_public_access", "service_bus_id", "TL", "-sbus", false},
+		{"event_hub_public_access", "event_hub_id", "TH", "-eh", false},
 		// Analytics & Integration
-		{"synapse_public_access", "synapse_workspace_id", output.RiskSeverityMedium, "-w-syn", true},
-		{"ml_workspace_public_access", "ml_workspace_id", output.RiskSeverityMedium, "-w-mlw", true},
-		{"logic_apps_public_access", "logic_app_id", output.RiskSeverityMedium, "-la", false},
-		{"data_factory_public_access", "data_factory_id", output.RiskSeverityLow, "-adf", false},
-		{"log_analytics_public_access", "log_analytics_id", output.RiskSeverityLow, "-law", false},
-		{"data_explorer_public_access", "kusto_cluster_id", output.RiskSeverityMedium, "kusto", false},
+		{"synapse_public_access", "synapse_workspace_id", "TM", "-w-syn", true},
+		{"ml_workspace_public_access", "ml_workspace_id", "TM", "-w-mlw", true},
+		{"logic_apps_public_access", "logic_app_id", "TM", "-la", false},
+		{"data_factory_public_access", "data_factory_id", "TL", "-adf", false},
+		{"log_analytics_public_access", "log_analytics_id", "TL", "-law", false},
+		{"data_explorer_public_access", "kusto_cluster_id", "TM", "kusto", false},
 		// Networking
-		{"api_management_public_access", "api_management_id", output.RiskSeverityMedium, "-apim", false},
-		{"load_balancers_public", "load_balancer_id", output.RiskSeverityHigh, "-lb", false},
-		{"application_gateway_public_access", "application_gateway_id", output.RiskSeverityMedium, "-appgw", false},
+		{"api_management_public_access", "api_management_id", "TM", "-apim", false},
+		{"load_balancers_public", "load_balancer_id", "TH", "-lb", false},
+		{"application_gateway_public_access", "application_gateway_id", "TM", "-appgw", false},
 	}
 
 	for _, tt := range templateTests {
@@ -161,7 +199,7 @@ func TestAzurePublicResources(t *testing.T) {
 				t.Skipf("%s not provisioned in this environment", tt.fixtureKey)
 			}
 			rc := findRisk(t, tt.templateID, tt.fixtureKey)
-			assertRisk(t, rc, tt.templateID, tt.severity, tt.substr)
+			assertRisk(t, rc, tt.templateID, tt.status, tt.substr)
 		})
 	}
 
@@ -213,52 +251,46 @@ func TestAzurePublicResources(t *testing.T) {
 		}
 	})
 
-	t.Run("all risks have valid severity", func(t *testing.T) {
-		validSeverities := map[output.RiskSeverity]bool{
-			output.RiskSeverityInfo: true, output.RiskSeverityLow: true,
-			output.RiskSeverityMedium: true, output.RiskSeverityHigh: true,
-			output.RiskSeverityCritical: true,
-		}
+	t.Run("all risks have valid status", func(t *testing.T) {
+		validStatuses := map[string]bool{"TI": true, "TL": true, "TM": true, "TH": true, "TC": true}
 		for _, rc := range all {
-			assert.True(t, validSeverities[rc.Risk.Severity],
-				"template %q: invalid severity %q", rc.Template, rc.Risk.Severity)
+			assert.True(t, validStatuses[rc.Risk.Status],
+				"template %q: invalid status %q", rc.Template, rc.Risk.Status)
 		}
 	})
 
-	t.Run("all risks have non-empty resource ID", func(t *testing.T) {
+	t.Run("all risks have non-empty target name", func(t *testing.T) {
 		for _, rc := range all {
-			assert.NotEmpty(t, rc.Risk.ImpactedResourceID,
-				"template %q: ImpactedResourceID must not be empty", rc.Template)
+			assert.NotEmpty(t, rc.Risk.TargetName,
+				"template %q: TargetName must not be empty", rc.Template)
 		}
 	})
 
-	t.Run("all risks have valid JSON context with templateId", func(t *testing.T) {
+	t.Run("all risks have a Template ID in the Exposure section", func(t *testing.T) {
 		for _, rc := range all {
 			assert.NotEmpty(t, rc.Template,
-				"risk context must contain templateId")
+				"proof Exposure section must contain a Template ID")
 		}
 	})
 
-	t.Run("all risks have resourceId in context", func(t *testing.T) {
+	t.Run("all risks have Resource ID matching TargetName", func(t *testing.T) {
 		for _, rc := range all {
-			resID, _ := rc.CtxMap["resourceId"].(string)
-			assert.NotEmpty(t, resID,
-				"template %q: context should contain resourceId", rc.Template)
+			resource := keyValueMap(sectionByTitle(t, rc.Proof, "Resource"))
+			assert.Equal(t, rc.Risk.TargetName, resource["Resource ID"],
+				"template %q: Resource ID row should match TargetName", rc.Template)
 		}
 	})
 
-	t.Run("most risks have resourceType in context", func(t *testing.T) {
+	t.Run("most risks have resource type populated", func(t *testing.T) {
 		withType := 0
 		for _, rc := range all {
-			resType, _ := rc.CtxMap["resourceType"].(string)
-			if resType != "" {
+			if keyValueMap(sectionByTitle(t, rc.Proof, "Resource"))["Resource Type"] != "" {
 				withType++
 			}
 		}
-		// At least 80% of findings should have resourceType populated.
 		ratio := float64(withType) / float64(len(all))
 		assert.Greater(t, ratio, 0.8,
-			"only %d/%d findings have resourceType in context", withType, len(all))
+			"only %d/%d findings have Resource Type populated", withType, len(all))
 	})
 
 	t.Run("no duplicate findings per resource per template", func(t *testing.T) {
@@ -273,16 +305,13 @@ func TestAzurePublicResources(t *testing.T) {
 		}
 	})
 
-	t.Run("severity distribution has all expected levels", func(t *testing.T) {
-		sevCounts := make(map[output.RiskSeverity]int)
+	t.Run("status distribution has all expected levels", func(t *testing.T) {
+		counts := make(map[string]int)
 		for _, rc := range all {
-			sevCounts[rc.Risk.Severity]++
+			counts[rc.Risk.Status]++
 		}
-		assert.Greater(t, sevCounts[output.RiskSeverityHigh], 0,
-			"should have at least one high severity finding")
-		assert.Greater(t, sevCounts[output.RiskSeverityMedium], 0,
-			"should have at least one medium severity finding")
-		assert.Greater(t, sevCounts[output.RiskSeverityLow], 0,
-			"should have at least one low severity finding")
+		assert.Greater(t, counts["TH"], 0, "should have at least one high severity finding")
+		assert.Greater(t, counts["TM"], 0, "should have at least one medium severity finding")
+		assert.Greater(t, counts["TL"], 0, "should have at least one low severity finding")
 	})
 }

--- a/pkg/modules/azure/recon/public_resources_test.go
+++ b/pkg/modules/azure/recon/public_resources_test.go
@@ -9,11 +9,40 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/pkg/templates"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	publicresources "github.com/praetorian-inc/aurelian/pkg/templates/azure/public-resources"
 )
+
+// decodeRiskProof unmarshals a Risk's proof bytes into a capmodel.Proof.
+func decodeRiskProof(t *testing.T, risk capmodel.Risk) capmodel.Proof {
+	t.Helper()
+	var proof capmodel.Proof
+	require.NoError(t, json.Unmarshal(risk.Proof, &proof))
+	return proof
+}
+
+// riskKeyValues flattens the named section's key/value rows into a map.
+func riskKeyValues(t *testing.T, proof capmodel.Proof, title string) map[string]string {
+	t.Helper()
+	out := make(map[string]string)
+	for _, s := range proof.Sections {
+		if s.Title != title {
+			continue
+		}
+		for _, el := range s.Elements {
+			if el.KeyValue == nil {
+				continue
+			}
+			for _, row := range el.KeyValue.Rows {
+				out[row.Key] = row.Value
+			}
+		}
+	}
+	return out
+}
 
 func TestModuleMetadata(t *testing.T) {
 	m := &AzurePublicResourcesModule{}
@@ -64,7 +93,7 @@ func TestPublicResourcesTemplateLoader_LoadsAll36(t *testing.T) {
 		"app_configuration_public_access":          true,
 		"app_services_public_access":               true,
 		"application_gateway_public_access":        true,
-		"cognitive_services_public_access":          true,
+		"cognitive_services_public_access":         true,
 		"container_apps_public_access":             true,
 		"container_instances_public_access":        true,
 		"container_registries_public_access":       true,
@@ -126,7 +155,7 @@ func TestPublicResourcesTemplateLoader_SeveritiesMatchExpected(t *testing.T) {
 		"app_configuration_public_access":          output.RiskSeverityMedium,
 		"app_services_public_access":               output.RiskSeverityMedium,
 		"application_gateway_public_access":        output.RiskSeverityMedium,
-		"cognitive_services_public_access":          output.RiskSeverityMedium,
+		"cognitive_services_public_access":         output.RiskSeverityMedium,
 		"container_apps_public_access":             output.RiskSeverityMedium,
 		"container_instances_public_access":        output.RiskSeverityMedium,
 		"container_registries_public_access":       output.RiskSeverityHigh,
@@ -221,26 +250,56 @@ func TestResultToRisk(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
-	risk, ok := items[0].(output.AurelianRisk)
+	risk, ok := items[0].(capmodel.Risk)
 	require.True(t, ok)
 
 	assert.Equal(t, "public-azure-resource", risk.Name)
-	assert.Equal(t, output.RiskSeverityHigh, risk.Severity)
-	assert.Equal(t, "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage", risk.ImpactedResourceID)
-	assert.NotEmpty(t, risk.Context)
+	assert.Equal(t, "aurelian", risk.Source)
+	assert.Equal(t, "TH", risk.Status)
+	assert.Equal(t, "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/mystorage", risk.TargetName)
+	assert.NotEmpty(t, risk.Proof)
 
-	var ctx map[string]any
-	require.NoError(t, json.Unmarshal(risk.Context, &ctx))
-	assert.Equal(t, "storage_accounts_public_access", ctx["templateId"])
-	assert.Equal(t, "mystorage", ctx["resourceName"])
-	assert.Equal(t, "Microsoft.Storage/storageAccounts", ctx["resourceType"])
-	assert.Equal(t, "xxx", ctx["subscriptionId"])
+	proof := decodeRiskProof(t, risk)
+	exposure := riskKeyValues(t, proof, "Exposure")
+	assert.Equal(t, "storage_accounts_public_access", exposure["Template ID"])
+
+	resource := riskKeyValues(t, proof, "Resource")
+	assert.Equal(t, "mystorage", resource["Name"])
+	assert.Equal(t, "Microsoft.Storage/storageAccounts", resource["Resource Type"])
+	assert.Equal(t, "xxx", resource["Azure Subscription"])
+}
+
+func TestResultToRisk_NilTemplateDetails(t *testing.T) {
+	result := templates.ARGQueryResult{
+		TemplateID: "orphan_template",
+		ResourceID: "/subscriptions/s/resourceGroups/r/providers/T/n",
+	}
+
+	out := pipeline.New[model.AurelianModel]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, resultToRisk(result, out))
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	risk := items[0].(capmodel.Risk)
+	assert.Equal(t, "TI", risk.Status, "nil TemplateDetails defaults to Info severity")
+	assert.Equal(t, "public-azure-resource", risk.Name)
+	assert.Equal(t, "/subscriptions/s/resourceGroups/r/providers/T/n", risk.TargetName)
 }
 
 func TestResultToRisk_SeverityPreserved(t *testing.T) {
-	severities := []string{"low", "medium", "high", "critical"}
+	cases := map[string]string{
+		"low":      "TL",
+		"medium":   "TM",
+		"high":     "TH",
+		"critical": "TC",
+	}
 
-	for _, sev := range severities {
+	for sev, wantStatus := range cases {
 		t.Run(sev, func(t *testing.T) {
 			tmpl := &templates.ARGQueryTemplate{
 				ID:       "test_" + sev,
@@ -263,8 +322,8 @@ func TestResultToRisk_SeverityPreserved(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, items, 1)
 
-			risk := items[0].(output.AurelianRisk)
-			assert.Equal(t, output.RiskSeverity(sev), risk.Severity)
+			risk := items[0].(capmodel.Risk)
+			assert.Equal(t, wantStatus, risk.Status)
 			assert.Equal(t, "public-azure-resource", risk.Name)
 		})
 	}
@@ -294,14 +353,16 @@ func TestResultToRisk_ContextContainsAllFields(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 
-	risk := items[0].(output.AurelianRisk)
-	var ctx map[string]any
-	require.NoError(t, json.Unmarshal(risk.Context, &ctx))
+	risk := items[0].(capmodel.Risk)
+	proof := decodeRiskProof(t, risk)
 
-	// All expected context fields must be present.
-	assert.Equal(t, "key_vault_public_access", ctx["templateId"])
-	assert.Equal(t, "myvault", ctx["resourceName"])
-	assert.Equal(t, "Microsoft.KeyVault/vaults", ctx["resourceType"])
-	assert.Equal(t, "sub-1", ctx["subscriptionId"])
-	assert.Equal(t, "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault", ctx["resourceId"])
+	exposure := riskKeyValues(t, proof, "Exposure")
+	assert.Equal(t, "key_vault_public_access", exposure["Template ID"])
+
+	resource := riskKeyValues(t, proof, "Resource")
+	assert.Equal(t, "myvault", resource["Name"])
+	assert.Equal(t, "Microsoft.KeyVault/vaults", resource["Resource Type"])
+	assert.Equal(t, "sub-1", resource["Azure Subscription"])
+	assert.Equal(t, "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault", resource["Resource ID"])
+	assert.Equal(t, "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/myvault", risk.TargetName)
 }

--- a/pkg/modules/gcp/recon/list_all_resources_integration_test.go
+++ b/pkg/modules/gcp/recon/list_all_resources_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,12 +42,12 @@ func TestGCPListAllResources(t *testing.T) {
 	pipeline.Pipe(p1, mod.Run, p2)
 
 	var resources []output.GCPResource
-	var risks []output.AurelianRisk
+	var risks []capmodel.Risk
 	for m := range p2.Range() {
 		switch v := m.(type) {
 		case output.GCPResource:
 			resources = append(resources, v)
-		case output.AurelianRisk:
+		case capmodel.Risk:
 			risks = append(risks, v)
 		}
 	}

--- a/pkg/modules/gcp/recon/public_resources_integration_test.go
+++ b/pkg/modules/gcp/recon/public_resources_integration_test.go
@@ -13,9 +13,44 @@ import (
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// decodeProof unmarshals a Risk's proof bytes into a structured capmodel.Proof.
+func decodeProof(t *testing.T, risk capmodel.Risk) capmodel.Proof {
+	t.Helper()
+	var proof capmodel.Proof
+	require.NoError(t, json.Unmarshal(risk.Proof, &proof), "proof should decode into capmodel.Proof")
+	return proof
+}
+
+// sectionByTitle returns the named proof section, failing if it is absent.
+func sectionByTitle(t *testing.T, proof capmodel.Proof, title string) capmodel.ProofSection {
+	t.Helper()
+	for _, s := range proof.Sections {
+		if s.Title == title {
+			return s
+		}
+	}
+	require.Failf(t, "section not found", "proof has no %q section", title)
+	return capmodel.ProofSection{}
+}
+
+// keyValueMap flattens a section's key/value rows into a map for assertions.
+func keyValueMap(section capmodel.ProofSection) map[string]string {
+	out := make(map[string]string)
+	for _, el := range section.Elements {
+		if el.KeyValue == nil {
+			continue
+		}
+		for _, row := range el.KeyValue.Rows {
+			out[row.Key] = row.Value
+		}
+	}
+	return out
+}
 
 func TestGCPPublicResources(t *testing.T) {
 	fixture := testutil.NewGCPFixture(t, "gcp/recon/list")
@@ -50,12 +85,12 @@ func TestGCPPublicResources(t *testing.T) {
 	pipeline.Pipe(p1, mod.Run, p2)
 
 	var resources []output.GCPResource
-	var risks []output.AurelianRisk
+	var risks []capmodel.Risk
 	for m := range p2.Range() {
 		switch v := m.(type) {
 		case output.GCPResource:
 			resources = append(resources, v)
-		case output.AurelianRisk:
+		case capmodel.Risk:
 			risks = append(risks, v)
 		}
 	}
@@ -65,24 +100,25 @@ func TestGCPPublicResources(t *testing.T) {
 	t.Run("risk fields are populated", func(t *testing.T) {
 		for _, risk := range risks {
 			assert.NotEmpty(t, risk.Name, "risk Name must be set")
-			assert.Contains(t,
-				[]output.RiskSeverity{output.RiskSeverityHigh, output.RiskSeverityMedium},
-				risk.Severity,
-				"unexpected risk severity: %s", risk.Severity)
-			assert.NotEmpty(t, risk.ImpactedResourceID, "risk ImpactedResourceID must be set")
-			assert.NotEmpty(t, risk.Context, "risk Context must be set")
+			assert.Equal(t, "aurelian", risk.Source)
+			assert.Contains(t, []string{"TH", "TM"}, risk.Status,
+				"unexpected risk status: %s", risk.Status)
+			assert.NotEmpty(t, risk.TargetName, "risk TargetName must be set")
+			assert.NotEmpty(t, risk.Proof, "risk Proof must be set")
 		}
 	})
 
 	t.Run("risk context contains expected fields", func(t *testing.T) {
 		for _, risk := range risks {
-			var ctx map[string]any
-			require.NoError(t, json.Unmarshal(risk.Context, &ctx))
-			assert.Contains(t, ctx, "resourceType")
-			assert.Contains(t, ctx, "resourceID")
-			assert.Contains(t, ctx, "projectID")
-			assert.Contains(t, ctx, "publicNetwork")
-			assert.Contains(t, ctx, "anonymousAccess")
+			proof := decodeProof(t, risk)
+			assert.Equal(t, "v1.0.0", proof.Format)
+			resource := keyValueMap(sectionByTitle(t, proof, "Resource"))
+			assert.NotEmpty(t, resource["Resource Type"])
+			assert.NotEmpty(t, resource["Resource ID"])
+			assert.NotEmpty(t, resource["GCP Project"])
+			exposure := keyValueMap(sectionByTitle(t, proof, "Exposure"))
+			assert.Contains(t, exposure, "Public Network")
+			assert.Contains(t, exposure, "Anonymous Access")
 		}
 	})
 
@@ -119,18 +155,18 @@ func TestGCPPublicResources(t *testing.T) {
 		publicRunName := fixture.Output("cloud_run_public_name")
 		privateRunName := fixture.Output("cloud_run_private_name")
 
-		// Public Cloud Run (allUsers invoker) should have HIGH severity (public + anonymous).
+		// Public Cloud Run (allUsers invoker) should be HIGH severity (public + anonymous).
 		assert.Truef(t, hasRiskForNamedResource(resources, risks, publicRunName),
 			"expected risk for public cloud run service %q", publicRunName)
 
 		// Private Cloud Run still gets a public URL from GCP, so it's flagged as
-		// "public-gcp-resource" (MEDIUM). Both should have risks, but severity differs.
+		// "public-gcp-resource" (MEDIUM). Both should have risks, but status differs.
 		publicRisk := findRiskForNamedResource(resources, risks, publicRunName)
 		privateRisk := findRiskForNamedResource(resources, risks, privateRunName)
 		if publicRisk != nil && privateRisk != nil {
-			assert.Equal(t, output.RiskSeverityHigh, publicRisk.Severity,
+			assert.Equal(t, "TH", publicRisk.Status,
 				"public cloud run with allUsers should be HIGH")
-			assert.Equal(t, output.RiskSeverityMedium, privateRisk.Severity,
+			assert.Equal(t, "TM", privateRisk.Status,
 				"private cloud run (URL only) should be MEDIUM")
 		}
 	})
@@ -165,17 +201,17 @@ func TestGCPPublicResources(t *testing.T) {
 }
 
 // hasRiskForNamedResource finds a resource by display name, then checks if
-// there's a matching risk by ResourceID. This handles resources whose
+// there's a matching risk by TargetName. This handles resources whose
 // ResourceID is a numeric ID rather than a name.
-func hasRiskForNamedResource(resources []output.GCPResource, risks []output.AurelianRisk, name string) bool {
+func hasRiskForNamedResource(resources []output.GCPResource, risks []capmodel.Risk, name string) bool {
 	return findRiskForNamedResource(resources, risks, name) != nil
 }
 
-func findRiskForNamedResource(resources []output.GCPResource, risks []output.AurelianRisk, name string) *output.AurelianRisk {
+func findRiskForNamedResource(resources []output.GCPResource, risks []capmodel.Risk, name string) *capmodel.Risk {
 	for _, r := range resources {
 		if containsName(r, name) {
 			for i, risk := range risks {
-				if risk.ImpactedResourceID == r.ResourceID {
+				if risk.TargetName == r.ResourceID {
 					return &risks[i]
 				}
 			}
@@ -184,4 +220,3 @@ func findRiskForNamedResource(resources []output.GCPResource, risks []output.Aur
 	}
 	return nil
 }
-

--- a/pkg/publicresource/risk.go
+++ b/pkg/publicresource/risk.go
@@ -1,0 +1,206 @@
+// Package publicresource builds a standardized capmodel.Risk for a publicly
+// exposed cloud resource. It is CSP-agnostic: AWS, Azure, and GCP emission
+// sites map their native results into PublicResource and call NewRisk, which
+// renders a structured capmodel.Proof shared across all providers.
+package publicresource
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
+)
+
+// proofFormat is the proof schema version. Kept identical to the value emitted
+// by pkg/aws/cloudfront/risk.go (#209) so all Phase 0 (LAB-3740) migrations
+// share one format string; the per-risk shape is discriminated by Risk.Name.
+const proofFormat = "v1.0.0"
+
+// Fact is one exposure-evidence key/value row.
+type Fact struct {
+	Key      string
+	Value    string
+	Copyable bool
+}
+
+// NamedList is a titled list of strings rendered as its own proof section
+// (e.g. "Allowed Actions", "Evaluation Reasons", "Public URLs").
+type NamedList struct {
+	Title string
+	Items []string
+}
+
+// PublicResource is the CSP-agnostic description of a publicly exposed cloud
+// resource. Each provider's emission site maps its native result into this
+// struct; NewRisk renders the standardized proof.
+type PublicResource struct {
+	Provider     string // "AWS" | "Azure" | "GCP"
+	RiskName     string // per-CSP Guard rule key, e.g. "public-aws-resource"
+	ResourceType string // native type string
+	ResourceID   string // canonical identifier (ARN / Azure resource ID / GCP resource ID) -> Risk.TargetName
+	ResourceName string // optional display name
+	Region       string // AWS region / Azure location / GCP location (optional)
+	Scope        string // account ID / subscription ID / project ID
+	ScopeLabel   string // "AWS Account" / "Azure Subscription" / "GCP Project"
+	Severity     output.RiskSeverity
+	Summary      string         // one-paragraph description of the exposure
+	Exposure     []Fact         // what makes the resource public
+	Lists        []NamedList    // extra evidence lists, one section each
+	References   []string       // optional reference URLs
+	Properties   map[string]any // raw resource properties appendix (optional)
+}
+
+// NewRisk builds a platform capmodel.Risk with a standardized public-resource
+// proof. It returns an error only when required identity fields are missing or
+// the proof fails to marshal.
+func NewRisk(r PublicResource) (capmodel.Risk, error) {
+	if r.RiskName == "" {
+		return capmodel.Risk{}, fmt.Errorf("public resource risk requires a non-empty RiskName")
+	}
+	if r.ResourceID == "" {
+		return capmodel.Risk{}, fmt.Errorf("public resource risk requires a non-empty ResourceID")
+	}
+
+	proof, err := json.Marshal(buildProof(r))
+	if err != nil {
+		return capmodel.Risk{}, err
+	}
+
+	return capmodel.Risk{
+		TargetName: r.ResourceID,
+		Name:       r.RiskName,
+		Source:     "aurelian",
+		Status:     severityToStatus(r.Severity),
+		Proof:      proof,
+		// TODO(LAB-3740): populate a typed capmodel asset once Aurelian emits the
+		// SDK `_type` envelope and Guard's ingest consumes Risk.Target. Same TODO as
+		// pkg/aws/cloudfront/risk.go (LAB-3995) — inert until then.
+		Target: nil,
+	}, nil
+}
+
+// buildProof assembles the shared proof layout. Empty sections are omitted.
+func buildProof(r PublicResource) capmodel.Proof {
+	sections := []capmodel.ProofSection{
+		{Title: "Summary", Elements: []capmodel.ProofElement{paragraph(r.Summary)}},
+	}
+
+	if resourceRows := resourceRows(r); len(resourceRows) > 0 {
+		sections = append(sections, capmodel.ProofSection{
+			Title:    "Resource",
+			Elements: []capmodel.ProofElement{keyValue(resourceRows)},
+		})
+	}
+
+	if exposureRows := factRows(r.Exposure); len(exposureRows) > 0 {
+		sections = append(sections, capmodel.ProofSection{
+			Title:    "Exposure",
+			Elements: []capmodel.ProofElement{keyValue(exposureRows)},
+		})
+	}
+
+	for _, nl := range r.Lists {
+		if len(nl.Items) == 0 {
+			continue
+		}
+		sections = append(sections, capmodel.ProofSection{
+			Title:    nl.Title,
+			Elements: []capmodel.ProofElement{list(nl.Items)},
+		})
+	}
+
+	if len(r.References) > 0 {
+		sections = append(sections, capmodel.ProofSection{
+			Title:    "References",
+			Elements: []capmodel.ProofElement{referenceList(r.References)},
+		})
+	}
+
+	if len(r.Properties) > 0 {
+		if content, err := json.MarshalIndent(r.Properties, "", "  "); err == nil {
+			sections = append(sections, capmodel.ProofSection{
+				Title:    "Resource Properties",
+				Elements: []capmodel.ProofElement{codeBlock("json", string(content))},
+			})
+		}
+	}
+
+	return capmodel.Proof{Format: proofFormat, Sections: sections}
+}
+
+// resourceRows builds the identity key/value rows, skipping empty values.
+func resourceRows(r PublicResource) []capmodel.ProofKeyValueRow {
+	candidates := []capmodel.ProofKeyValueRow{
+		{Key: "Provider", Value: r.Provider},
+		{Key: "Resource Type", Value: r.ResourceType},
+		{Key: "Resource ID", Value: r.ResourceID, Copyable: true},
+		{Key: "Name", Value: r.ResourceName},
+		{Key: "Region", Value: r.Region},
+		{Key: r.ScopeLabel, Value: r.Scope, Copyable: true},
+	}
+	rows := make([]capmodel.ProofKeyValueRow, 0, len(candidates))
+	for _, row := range candidates {
+		if row.Key == "" || row.Value == "" {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// factRows converts exposure facts into key/value rows, skipping empty values.
+func factRows(facts []Fact) []capmodel.ProofKeyValueRow {
+	rows := make([]capmodel.ProofKeyValueRow, 0, len(facts))
+	for _, f := range facts {
+		if f.Key == "" || f.Value == "" {
+			continue
+		}
+		rows = append(rows, capmodel.ProofKeyValueRow{Key: f.Key, Value: f.Value, Copyable: f.Copyable})
+	}
+	return rows
+}
+
+// severityToStatus maps a risk severity to a Chariot triage status code.
+func severityToStatus(sev output.RiskSeverity) string {
+	switch output.NormalizeSeverity(sev) {
+	case output.RiskSeverityCritical:
+		return "TC"
+	case output.RiskSeverityHigh:
+		return "TH"
+	case output.RiskSeverityMedium:
+		return "TM"
+	case output.RiskSeverityLow:
+		return "TL"
+	default:
+		return "TI"
+	}
+}
+
+func paragraph(text string) capmodel.ProofElement {
+	return capmodel.ProofElement{Type: "paragraph", Paragraph: &capmodel.ProofParagraph{Text: text}}
+}
+
+func keyValue(rows []capmodel.ProofKeyValueRow) capmodel.ProofElement {
+	return capmodel.ProofElement{Type: "key_value", KeyValue: &capmodel.ProofKeyValue{Rows: rows}}
+}
+
+func list(items []string) capmodel.ProofElement {
+	listItems := make([]capmodel.ProofListItem, 0, len(items))
+	for _, item := range items {
+		listItems = append(listItems, capmodel.ProofListItem{Label: item})
+	}
+	return capmodel.ProofElement{Type: "list", List: &capmodel.ProofList{Items: listItems}}
+}
+
+func referenceList(urls []string) capmodel.ProofElement {
+	items := make([]capmodel.ProofListItem, 0, len(urls))
+	for _, u := range urls {
+		items = append(items, capmodel.ProofListItem{Label: u, Href: u})
+	}
+	return capmodel.ProofElement{Type: "list", List: &capmodel.ProofList{Items: items}}
+}
+
+func codeBlock(language, content string) capmodel.ProofElement {
+	return capmodel.ProofElement{Type: "code_block", CodeBlock: &capmodel.ProofCodeBlock{Language: language, Content: content}}
+}

--- a/pkg/publicresource/risk_test.go
+++ b/pkg/publicresource/risk_test.go
@@ -1,0 +1,281 @@
+package publicresource
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/capability-sdk/pkg/capmodel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// decodeProof unmarshals a Risk's Proof bytes into a structured capmodel.Proof.
+func decodeProof(t *testing.T, risk capmodel.Risk) capmodel.Proof {
+	t.Helper()
+	var proof capmodel.Proof
+	require.NoError(t, json.Unmarshal(risk.Proof, &proof))
+	return proof
+}
+
+// findSection returns the named section and whether it exists.
+func findSection(proof capmodel.Proof, title string) (capmodel.ProofSection, bool) {
+	for _, s := range proof.Sections {
+		if s.Title == title {
+			return s, true
+		}
+	}
+	return capmodel.ProofSection{}, false
+}
+
+// sectionByTitle returns the named proof section, requiring it to exist.
+func sectionByTitle(t *testing.T, proof capmodel.Proof, title string) capmodel.ProofSection {
+	t.Helper()
+	s, ok := findSection(proof, title)
+	require.Truef(t, ok, "proof has no %q section", title)
+	return s
+}
+
+// keyValueMap flattens a section's key/value rows into a map for assertions.
+func keyValueMap(section capmodel.ProofSection) map[string]string {
+	out := make(map[string]string)
+	for _, el := range section.Elements {
+		if el.KeyValue == nil {
+			continue
+		}
+		for _, row := range el.KeyValue.Rows {
+			out[row.Key] = row.Value
+		}
+	}
+	return out
+}
+
+// listLabels collects the labels of every list item across a section.
+func listLabels(section capmodel.ProofSection) []string {
+	var labels []string
+	for _, el := range section.Elements {
+		if el.List == nil {
+			continue
+		}
+		for _, item := range el.List.Items {
+			labels = append(labels, item.Label)
+		}
+	}
+	return labels
+}
+
+// paragraphText concatenates the text of every paragraph element in a section.
+func paragraphText(section capmodel.ProofSection) string {
+	var text string
+	for _, el := range section.Elements {
+		if el.Paragraph != nil {
+			text += el.Paragraph.Text
+		}
+	}
+	return text
+}
+
+func sampleResource() PublicResource {
+	return PublicResource{
+		Provider:     "AWS",
+		RiskName:     "public-aws-resource",
+		ResourceType: "AWS::S3::Bucket",
+		ResourceID:   "arn:aws:s3:::public-bucket",
+		ResourceName: "public-bucket",
+		Region:       "us-east-1",
+		Scope:        "123456789012",
+		ScopeLabel:   "AWS Account",
+		Severity:     output.RiskSeverityHigh,
+		Summary:      "AWS resource is publicly accessible.",
+		Exposure: []Fact{
+			{Key: "Access Level", Value: "public"},
+			{Key: "Public", Value: "true"},
+		},
+		Lists: []NamedList{
+			{Title: "Allowed Actions", Items: []string{"s3:GetObject"}},
+		},
+		References: []string{"https://example.com/ref"},
+		Properties: map[string]any{"PublicAccessBlock": false},
+	}
+}
+
+func TestNewRisk_Identity(t *testing.T) {
+	risk, err := NewRisk(sampleResource())
+	require.NoError(t, err)
+
+	assert.Equal(t, "arn:aws:s3:::public-bucket", risk.TargetName)
+	assert.Equal(t, "public-aws-resource", risk.Name)
+	assert.Equal(t, "aurelian", risk.Source)
+	assert.Equal(t, "TH", risk.Status)
+	assert.Empty(t, risk.Title)
+	assert.Nil(t, risk.Target)
+}
+
+func TestNewRisk_ProofSections(t *testing.T) {
+	risk, err := NewRisk(sampleResource())
+	require.NoError(t, err)
+	proof := decodeProof(t, risk)
+
+	assert.Equal(t, "v1.0.0", proof.Format)
+
+	assert.NotEmpty(t, paragraphText(sectionByTitle(t, proof, "Summary")))
+
+	resource := keyValueMap(sectionByTitle(t, proof, "Resource"))
+	assert.Equal(t, "AWS", resource["Provider"])
+	assert.Equal(t, "AWS::S3::Bucket", resource["Resource Type"])
+	assert.Equal(t, "arn:aws:s3:::public-bucket", resource["Resource ID"])
+	assert.Equal(t, "public-bucket", resource["Name"])
+	assert.Equal(t, "us-east-1", resource["Region"])
+	assert.Equal(t, "123456789012", resource["AWS Account"])
+
+	exposure := keyValueMap(sectionByTitle(t, proof, "Exposure"))
+	assert.Equal(t, "public", exposure["Access Level"])
+	assert.Equal(t, "true", exposure["Public"])
+
+	assert.Equal(t, []string{"s3:GetObject"}, listLabels(sectionByTitle(t, proof, "Allowed Actions")))
+
+	refs := sectionByTitle(t, proof, "References")
+	require.NotEmpty(t, refs.Elements)
+	require.NotNil(t, refs.Elements[0].List)
+	require.Len(t, refs.Elements[0].List.Items, 1)
+	assert.Equal(t, "https://example.com/ref", refs.Elements[0].List.Items[0].Href)
+
+	props := sectionByTitle(t, proof, "Resource Properties")
+	require.NotEmpty(t, props.Elements)
+	require.NotNil(t, props.Elements[0].CodeBlock)
+	assert.Equal(t, "json", props.Elements[0].CodeBlock.Language)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(props.Elements[0].CodeBlock.Content), &decoded))
+	assert.Equal(t, false, decoded["PublicAccessBlock"])
+}
+
+func TestNewRisk_OptionalSectionsOmitted(t *testing.T) {
+	r := PublicResource{
+		Provider:     "GCP",
+		RiskName:     "public-gcp-resource",
+		ResourceType: "compute.googleapis.com/Address",
+		ResourceID:   "addr-1",
+		ScopeLabel:   "GCP Project",
+		Scope:        "proj",
+		Severity:     output.RiskSeverityMedium,
+		Summary:      "GCP resource has public network exposure.",
+		Exposure:     nil,
+		Lists:        []NamedList{{Title: "Public IPs", Items: nil}},
+		References:   nil,
+		Properties:   nil,
+	}
+
+	risk, err := NewRisk(r)
+	require.NoError(t, err)
+	proof := decodeProof(t, risk)
+
+	_, hasSummary := findSection(proof, "Summary")
+	_, hasResource := findSection(proof, "Resource")
+	assert.True(t, hasSummary)
+	assert.True(t, hasResource)
+
+	for _, absent := range []string{"Exposure", "Public IPs", "References", "Resource Properties"} {
+		_, ok := findSection(proof, absent)
+		assert.Falsef(t, ok, "section %q should be omitted", absent)
+	}
+}
+
+func TestNewRisk_EmptyFactValuesSkipped(t *testing.T) {
+	r := sampleResource()
+	r.Exposure = []Fact{
+		{Key: "Access Level", Value: "public"},
+		{Key: "Empty", Value: ""},
+	}
+
+	risk, err := NewRisk(r)
+	require.NoError(t, err)
+	proof := decodeProof(t, risk)
+
+	exposure := keyValueMap(sectionByTitle(t, proof, "Exposure"))
+	assert.Contains(t, exposure, "Access Level")
+	assert.NotContains(t, exposure, "Empty")
+}
+
+func TestNewRisk_Validation(t *testing.T) {
+	t.Run("missing RiskName", func(t *testing.T) {
+		r := sampleResource()
+		r.RiskName = ""
+		_, err := NewRisk(r)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing ResourceID", func(t *testing.T) {
+		r := sampleResource()
+		r.ResourceID = ""
+		_, err := NewRisk(r)
+		assert.Error(t, err)
+	})
+}
+
+func TestSeverityToStatus(t *testing.T) {
+	cases := map[string]string{
+		"critical": "TC",
+		"high":     "TH",
+		"medium":   "TM",
+		"low":      "TL",
+		"info":     "TI",
+		"":         "TI",
+		"bogus":    "TI",
+	}
+	for sev, want := range cases {
+		assert.Equalf(t, want, severityToStatus(output.RiskSeverity(sev)), "severity %q", sev)
+	}
+}
+
+func TestNewRisk_AzureShape(t *testing.T) {
+	risk, err := NewRisk(PublicResource{
+		Provider:     "Azure",
+		RiskName:     "public-azure-resource",
+		ResourceType: "Microsoft.Storage/storageAccounts",
+		ResourceID:   "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa",
+		ResourceName: "sa",
+		Region:       "eastus",
+		Scope:        "s",
+		ScopeLabel:   "Azure Subscription",
+		Severity:     output.RiskSeverityHigh,
+		Summary:      "Azure storage account is public.",
+		Exposure:     []Fact{{Key: "Template ID", Value: "storage_accounts_public_access"}},
+		References:   []string{"https://learn.microsoft.com"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "public-azure-resource", risk.Name)
+	assert.Equal(t, "TH", risk.Status)
+	proof := decodeProof(t, risk)
+	exposure := keyValueMap(sectionByTitle(t, proof, "Exposure"))
+	assert.Equal(t, "storage_accounts_public_access", exposure["Template ID"])
+	resource := keyValueMap(sectionByTitle(t, proof, "Resource"))
+	assert.Equal(t, "s", resource["Azure Subscription"])
+}
+
+func TestNewRisk_GCPShape(t *testing.T) {
+	risk, err := NewRisk(PublicResource{
+		Provider:     "GCP",
+		RiskName:     "public-anonymous-gcp-resource",
+		ResourceType: "run.googleapis.com/Service",
+		ResourceID:   "svc-1",
+		Scope:        "proj",
+		ScopeLabel:   "GCP Project",
+		Severity:     output.RiskSeverityHigh,
+		Summary:      "GCP resource is reachable and anonymous.",
+		Exposure: []Fact{
+			{Key: "Public Network", Value: "true"},
+			{Key: "Anonymous Access", Value: "true"},
+		},
+		Lists: []NamedList{{Title: "Public URLs", Items: []string{"https://svc.run.app"}}},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "public-anonymous-gcp-resource", risk.Name)
+	assert.Equal(t, "TH", risk.Status)
+	proof := decodeProof(t, risk)
+	exposure := keyValueMap(sectionByTitle(t, proof, "Exposure"))
+	assert.Equal(t, "true", exposure["Public Network"])
+	assert.Equal(t, "true", exposure["Anonymous Access"])
+	assert.Equal(t, []string{"https://svc.run.app"}, listLabels(sectionByTitle(t, proof, "Public URLs")))
+}

--- a/test/terraform/azure/recon/public-resources/main.tf
+++ b/test/terraform/azure/recon/public-resources/main.tf
@@ -38,7 +38,7 @@
 // | 23 | Cosmos DB                    | cosmos_db_public                           | DETECTED |
 // | 24 | Service Bus                  | service_bus_public                         | DETECTED |
 // | 25 | Event Hub                    | event_hub_public                           | DETECTED |
-// | 26 | Redis Cache                  | redis_cache_public                         | DETECTED |
+// | 26 | Redis Cache                  | redis_cache_public                         | REMOVED (classic Redis creation retired by Azure) |
 // | 27 | ACR Anonymous Pull           | acr_anonymous_pull                         | DETECTED |
 // | 28 | AKS                          | aks_public_access                          | DETECTED |
 // | 29 | API Management               | api_management_public_access               | DETECTED |
@@ -260,12 +260,15 @@ resource "azurerm_cognitive_account" "public" {
 
 # ============================================================================
 # 8. Search Service — publicly accessible
+# Deployed to the secondary region: the primary region (eastus2) intermittently
+# returns InsufficientResourcesAvailable for new Search services. ARG queries are
+# subscription-wide, so the cross-region placement does not affect detection.
 # ============================================================================
 
 resource "azurerm_search_service" "public" {
   name                          = "${local.prefix}-search"
   resource_group_name           = azurerm_resource_group.test.name
-  location                      = local.location
+  location                      = var.location_secondary
   sku                           = "free"
   public_network_access_enabled = true
   tags                          = local.tags
@@ -593,22 +596,18 @@ resource "azurerm_eventhub_namespace" "public" {
 
 # ============================================================================
 # 26. Redis Cache — publicly accessible
+#
+# REMOVED: Classic Azure Cache for Redis (Microsoft.Cache/Redis) can no longer be
+# created. As of the Azure Cache for Redis retirement, the control plane rejects
+# new classic-Redis creation account-wide (HTTP 400 "Azure Cache for Redis is
+# retiring, create Azure Managed Redis instance instead"; reproduced in both
+# eastus2 and westus2). The replacement, Azure Managed Redis, is a different
+# resource type (Microsoft.Cache/redisEnterprise) that the
+# redis_cache_public_access ARG template (type =~ 'Microsoft.Cache/Redis') does
+# NOT match, so it cannot stand in for this fixture. The redis_cache_public_access
+# integration case is therefore omitted from the live test.
+# See https://aka.ms/AzureCacheForRedisRetirement
 # ============================================================================
-
-resource "azurerm_redis_cache" "public" {
-  name                          = "${local.prefix}-redis"
-  resource_group_name           = azurerm_resource_group.test.name
-  location                      = local.location
-  capacity                      = 0
-  family                        = "C"
-  sku_name                      = "Basic"
-  minimum_tls_version           = "1.2"
-  public_network_access_enabled = true
-
-  redis_configuration {}
-
-  tags = local.tags
-}
 
 # ============================================================================
 # 27. ACR with Anonymous Pull — publicly accessible
@@ -634,6 +633,12 @@ resource "azurerm_kubernetes_cluster" "public" {
   resource_group_name = azurerm_resource_group.test.name
   location            = local.location
   dns_prefix          = "${local.prefix}-aks"
+
+  # Azure enables the OIDC issuer on the managed cluster and refuses to disable
+  # it once enabled (HTTP 400 OIDCIssuerFeatureCannotBeDisabled). Declaring it
+  # here keeps the config in sync with the cluster's actual state so re-applies
+  # against a reused fixture do not plan a rejected update.
+  oidc_issuer_enabled = true
 
   default_node_pool {
     name       = "default"

--- a/test/terraform/azure/recon/public-resources/outputs.tf
+++ b/test/terraform/azure/recon/public-resources/outputs.tf
@@ -90,9 +90,10 @@ output "event_hub_id" {
   value = azurerm_eventhub_namespace.public.id
 }
 
-output "redis_cache_id" {
-  value = azurerm_redis_cache.public.id
-}
+# redis_cache_id output removed: classic azurerm_redis_cache
+# (Microsoft.Cache/Redis) can no longer be created account-wide following the
+# Azure Cache for Redis retirement. The redis_cache_public_access test case is
+# omitted from the live test accordingly.
 
 output "acr_anon_pull_id" {
   value = azurerm_container_registry.anon_pull.id
@@ -118,24 +119,8 @@ output "application_gateway_id" {
   value = azurerm_application_gateway.public.id
 }
 
-# output "kusto_cluster_id" {
-#   value = azurerm_kusto_cluster.public.id
-# }
-
-output "app_service_id" {
-  value = azurerm_linux_web_app.public.id
-}
-
-output "function_app_id" {
-  value = azurerm_linux_function_app.public.id
-}
-
-output "mysql_server_id" {
-  value = azurerm_mysql_flexible_server.public.id
-}
-
-output "event_grid_domain_id" {
-  value = azurerm_eventgrid_domain.public.id
+output "kusto_cluster_id" {
+  value = azurerm_kusto_cluster.public.id
 }
 
 # Negative test outputs — secure resources that must NOT appear in findings


### PR DESCRIPTION
## What

Part of **Phase 0: Risk Standardization** ([LAB-3740](https://linear.app/praetorianlabs/issue/LAB-3740)). Migrates the **public-resource** risk emission for all three CSPs from the freeform `output.AurelianRisk` to the platform `capmodel.Risk` + structured `capmodel.Proof`, via a **single versioned CSP-agnostic proof builder** in the new `pkg/publicresource` package.

Closes:
- [LAB-3989](https://linear.app/praetorianlabs/issue/LAB-3989/public-resource-risk-aws-public-resources) — AWS `recon public-resources`
- [LAB-3990](https://linear.app/praetorianlabs/issue/LAB-3990/public-resource-risk-azure-public-resources) — Azure `recon public-resources`
- [LAB-3991](https://linear.app/praetorianlabs/issue/LAB-3991/public-resource-risk-gcp-public-resources-list-all) — GCP `recon public-resources` + `list-all`

> Originally stacked on #209 (same pattern as #213/#214/#215); #209 merged on 2026-06-11, so this branch is rebased onto `main` and targets `main` directly.

## Changes

- **`pkg/publicresource` (new)** — the shared builder mandated by the tickets ("do not define a CSP-specific shape"): `NewRisk(PublicResource) (capmodel.Risk, error)`. Proof `Format: "v1.0.0"` (consistent with #209), `Source: "aurelian"`, `Status` T-codes via `severityToStatus`, `Target: nil` (TODO LAB-3740, same as #209). Standard sections: Summary → Resource (key/values) → Exposure (key/values) → per-evidence lists (e.g. Allowed Actions / Evaluation Reasons / Public IPs) → References → Resource Properties (JSON `code_block` appendix, best-effort).
- **AWS** `pkg/modules/aws/recon/public_resources.go` — `riskFromResult` maps `publicaccess.PublicAccessResult` into the builder. `TargetName` keeps the ARN-falling-back-to-ResourceID semantics of the old `ImpactedResourceID`.
- **Azure** `pkg/modules/azure/recon/public_resources.go` — `resultToRisk` maps `templates.ARGQueryResult`; template description/severity/references feed Summary/Status/References. A `TemplateDetails == nil` guard now defaults to Info/`TI` (previously nil-panicked).
- **GCP** `pkg/gcp/publicaccess/evaluator.go` — evaluator emission migrated; **signature unchanged**, so both `gcp recon public-resources` and `gcp recon list-all` keep emitting (per LAB-3991 confirmation: list-all keeps emitting, standardized). All three existing GCP risk names preserved (`public-anonymous-gcp-resource`, `anonymous-gcp-resource`, `public-gcp-resource`). Marshal failures are now logged-and-skipped instead of silently ignored.
- **Risk identity preserved**: all `Risk.Name` values unchanged (Guard rules key on them); severity decisions unchanged.
- **Tests**: new `pkg/publicresource/risk_test.go`; Azure/GCP unit tests retyped to `capmodel.Risk`; all four integration tests (AWS/Azure/GCP public-resources + GCP list-all) updated to assert the capmodel contract (AWS reuses #209's proof helpers).
- **Azure fixture repair** (pre-existing decay, not caused by this PR): removed retired classic Redis (`Microsoft.Cache/Redis` creation is rejected account-wide) + its templateTests entry, dropped 4 dangling outputs, uncommented `kusto_cluster_id`, relocated the search service to the secondary region, aligned AKS `oidc_issuer_enabled`.

## Verification

- `go build ./...`, `go vet ./...`, `go vet -tags=integration`, full `go test ./...` — all pass (re-verified after the rebase onto main); zero residual `AurelianRisk` references in the migrated paths (other unmigrated modules still use it intentionally).
- **AWS integration** `TestAWSPublicResources` — PASS live (account 196766918487, fresh fixture, all 12 expected resources, proof structure verified).
- **Azure integration** `TestAzurePublicResources` — PASS live, 42/42 subtests (verified on fresh deploy, reuse, and final re-apply).
- **Live binary runs** — `aws recon public-resources` (2 risks) and `azure recon public-resources` (40 risks, 29 distinct templates): every risk carries `name`/`source=aurelian`/T-code `status`/`target_name` and a decodable proof with `Format v1.0.0` + Summary/Resource/Exposure sections.
- GCP: vet/unit only (no GCP creds in scope).

## Notes for reviewers

- LAB-3991 mentions only `public-gcp-resource`, but the evaluator has always emitted three names — all three are preserved and integration-asserted.
- Known follow-up (out of scope): the Azure integration test's `fixtureHasOutput` helper can't actually catch `t.Fatalf` (recover vs `runtime.Goexit`), so optional fixture outputs that are *missing* fail the parent test; current fixture state avoids this.