### PR TITLE
fix(azure/recon): per-template risk names + severity recalibration for configuration-scan

### DIFF
--- a/pkg/modules/azure/recon/configuration_scan.go
+++ b/pkg/modules/azure/recon/configuration_scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/praetorian-inc/aurelian/pkg/azure/enrichment"
@@ -146,8 +147,12 @@ func configScanToRisk(result templates.ARGQueryResult, out *pipeline.P[model.Aur
 		return nil
 	}
 
+	// Emit a distinct risk type per template (e.g. "azure-key-vault-access-policy-privilege-escalation")
+	// rather than collapsing every configuration finding into one generic "azure-configuration-scan"
+	// risk. Each template is a distinct vulnerability class, so it should carry its own risk identity
+	// and definition downstream.
 	out.Send(output.AurelianRisk{
-		Name:               "azure-configuration-scan",
+		Name:               "azure-" + strings.ReplaceAll(result.TemplateID, "_", "-"),
 		Severity:           result.TemplateDetails.Severity,
 		ImpactedResourceID: result.ResourceID,
 		Context:            ctx,

--- a/pkg/modules/azure/recon/configuration_scan_integration_test.go
+++ b/pkg/modules/azure/recon/configuration_scan_integration_test.go
@@ -86,7 +86,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("aks_local_accounts_enabled", func(t *testing.T) {
 		rc := findRisk(t, "aks_local_accounts_enabled", "aks_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-aks-local-accounts-enabled", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("low"), rc.Risk.Severity)
 		assert.Equal(t, "aks_local_accounts_enabled", rc.Template)
 		assert.NotEmpty(t, rc.Risk.Context)
@@ -97,7 +97,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("app_service_auth_disabled", func(t *testing.T) {
 		rc := findRisk(t, "app_service_auth_disabled", "webapp_no_auth_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-app-service-auth-disabled", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "app_service_auth_disabled", rc.Template)
 
@@ -111,7 +111,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("app_service_remote_debugging_enabled", func(t *testing.T) {
 		rc := findRisk(t, "app_service_remote_debugging_enabled", "webapp_debug_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-app-service-remote-debugging-enabled", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "app_service_remote_debugging_enabled", rc.Template)
 
@@ -129,7 +129,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("databases_allow_azure_services", func(t *testing.T) {
 		rc := findRisk(t, "databases_allow_azure_services", "sql_server_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-databases-allow-azure-services", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "databases_allow_azure_services", rc.Template)
 	})
@@ -141,7 +141,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("function_app_http_anonymous_access", func(t *testing.T) {
 		rc := findRisk(t, "function_app_http_anonymous_access", "func_anon_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-function-app-http-anonymous-access", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "function_app_http_anonymous_access", rc.Template)
 	})
@@ -151,7 +151,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("function_apps_admin_managed_identity", func(t *testing.T) {
 		rc := findRisk(t, "function_apps_admin_managed_identity", "func_admin_mi_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-function-apps-admin-managed-identity", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("low"), rc.Risk.Severity)
 		assert.Equal(t, "function_apps_admin_managed_identity", rc.Template)
 	})
@@ -161,7 +161,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("key_vault_access_policy_privilege_escalation", func(t *testing.T) {
 		rc := findRisk(t, "key_vault_access_policy_privilege_escalation", "key_vault_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-key-vault-access-policy-privilege-escalation", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "key_vault_access_policy_privilege_escalation", rc.Template)
 	})
@@ -171,7 +171,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("kusto_wildcard_trusted_tenants", func(t *testing.T) {
 		rc := findRisk(t, "kusto_wildcard_trusted_tenants", "kusto_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-kusto-wildcard-trusted-tenants", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "kusto_wildcard_trusted_tenants", rc.Template)
 	})
@@ -181,7 +181,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("nsg_unrestricted_port_ranges", func(t *testing.T) {
 		rc := findRisk(t, "nsg_unrestricted_port_ranges", "nsg_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-nsg-unrestricted-port-ranges", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "nsg_unrestricted_port_ranges", rc.Template)
 	})
@@ -191,7 +191,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("overprivileged_custom_roles", func(t *testing.T) {
 		rc := findRisk(t, "overprivileged_custom_roles", "custom_role_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-overprivileged-custom-roles", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "overprivileged_custom_roles", rc.Template)
 	})
@@ -201,7 +201,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("vm_privileged_managed_identity", func(t *testing.T) {
 		rc := findRisk(t, "vm_privileged_managed_identity", "vm_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-vm-privileged-managed-identity", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("low"), rc.Risk.Severity)
 		assert.Equal(t, "vm_privileged_managed_identity", rc.Template)
 	})
@@ -211,7 +211,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("vm_ssh_password_authentication", func(t *testing.T) {
 		rc := findRisk(t, "vm_ssh_password_authentication", "vm_id")
-		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
+		assert.Equal(t, "azure-vm-ssh-password-authentication", rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "vm_ssh_password_authentication", rc.Template)
 	})
@@ -219,13 +219,6 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	// Cross-finding invariants
 	// =====================================================================
-
-	t.Run("all risks have name azure-configuration-scan", func(t *testing.T) {
-		for _, rc := range all {
-			assert.Equal(t, "azure-configuration-scan", rc.Risk.Name,
-				"template %q: risk name should be azure-configuration-scan", rc.Template)
-		}
-	})
 
 	t.Run("all risks have valid severity", func(t *testing.T) {
 		validSeverities := map[output.RiskSeverity]bool{

--- a/pkg/modules/azure/recon/configuration_scan_integration_test.go
+++ b/pkg/modules/azure/recon/configuration_scan_integration_test.go
@@ -112,7 +112,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	t.Run("app_service_remote_debugging_enabled", func(t *testing.T) {
 		rc := findRisk(t, "app_service_remote_debugging_enabled", "webapp_debug_id")
 		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
-		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
+		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "app_service_remote_debugging_enabled", rc.Template)
 
 		// The no-auth web app should NOT appear in remote debugging findings
@@ -130,7 +130,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	t.Run("databases_allow_azure_services", func(t *testing.T) {
 		rc := findRisk(t, "databases_allow_azure_services", "sql_server_id")
 		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
-		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
+		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "databases_allow_azure_services", rc.Template)
 	})
 
@@ -142,7 +142,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	t.Run("function_app_http_anonymous_access", func(t *testing.T) {
 		rc := findRisk(t, "function_app_http_anonymous_access", "func_anon_id")
 		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
-		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
+		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "function_app_http_anonymous_access", rc.Template)
 	})
 
@@ -162,7 +162,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	t.Run("key_vault_access_policy_privilege_escalation", func(t *testing.T) {
 		rc := findRisk(t, "key_vault_access_policy_privilege_escalation", "key_vault_id")
 		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
-		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
+		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "key_vault_access_policy_privilege_escalation", rc.Template)
 	})
 
@@ -172,7 +172,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	t.Run("kusto_wildcard_trusted_tenants", func(t *testing.T) {
 		rc := findRisk(t, "kusto_wildcard_trusted_tenants", "kusto_id")
 		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
-		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
+		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "kusto_wildcard_trusted_tenants", rc.Template)
 	})
 
@@ -192,7 +192,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	t.Run("overprivileged_custom_roles", func(t *testing.T) {
 		rc := findRisk(t, "overprivileged_custom_roles", "custom_role_id")
 		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
-		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
+		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "overprivileged_custom_roles", rc.Template)
 	})
 
@@ -212,7 +212,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	t.Run("vm_ssh_password_authentication", func(t *testing.T) {
 		rc := findRisk(t, "vm_ssh_password_authentication", "vm_id")
 		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
-		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
+		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "vm_ssh_password_authentication", rc.Template)
 	})
 

--- a/pkg/modules/azure/recon/configuration_scan_integration_test.go
+++ b/pkg/modules/azure/recon/configuration_scan_integration_test.go
@@ -86,7 +86,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("aks_local_accounts_enabled", func(t *testing.T) {
 		rc := findRisk(t, "aks_local_accounts_enabled", "aks_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("low"), rc.Risk.Severity)
 		assert.Equal(t, "aks_local_accounts_enabled", rc.Template)
 		assert.NotEmpty(t, rc.Risk.Context)
@@ -97,7 +97,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("app_service_auth_disabled", func(t *testing.T) {
 		rc := findRisk(t, "app_service_auth_disabled", "webapp_no_auth_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "app_service_auth_disabled", rc.Template)
 
@@ -111,7 +111,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("app_service_remote_debugging_enabled", func(t *testing.T) {
 		rc := findRisk(t, "app_service_remote_debugging_enabled", "webapp_debug_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
 		assert.Equal(t, "app_service_remote_debugging_enabled", rc.Template)
 
@@ -129,7 +129,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("databases_allow_azure_services", func(t *testing.T) {
 		rc := findRisk(t, "databases_allow_azure_services", "sql_server_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
 		assert.Equal(t, "databases_allow_azure_services", rc.Template)
 	})
@@ -141,7 +141,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("function_app_http_anonymous_access", func(t *testing.T) {
 		rc := findRisk(t, "function_app_http_anonymous_access", "func_anon_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
 		assert.Equal(t, "function_app_http_anonymous_access", rc.Template)
 	})
@@ -151,7 +151,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("function_apps_admin_managed_identity", func(t *testing.T) {
 		rc := findRisk(t, "function_apps_admin_managed_identity", "func_admin_mi_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("low"), rc.Risk.Severity)
 		assert.Equal(t, "function_apps_admin_managed_identity", rc.Template)
 	})
@@ -161,7 +161,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("key_vault_access_policy_privilege_escalation", func(t *testing.T) {
 		rc := findRisk(t, "key_vault_access_policy_privilege_escalation", "key_vault_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
 		assert.Equal(t, "key_vault_access_policy_privilege_escalation", rc.Template)
 	})
@@ -171,7 +171,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("kusto_wildcard_trusted_tenants", func(t *testing.T) {
 		rc := findRisk(t, "kusto_wildcard_trusted_tenants", "kusto_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
 		assert.Equal(t, "kusto_wildcard_trusted_tenants", rc.Template)
 	})
@@ -181,7 +181,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("nsg_unrestricted_port_ranges", func(t *testing.T) {
 		rc := findRisk(t, "nsg_unrestricted_port_ranges", "nsg_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("medium"), rc.Risk.Severity)
 		assert.Equal(t, "nsg_unrestricted_port_ranges", rc.Template)
 	})
@@ -191,7 +191,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("overprivileged_custom_roles", func(t *testing.T) {
 		rc := findRisk(t, "overprivileged_custom_roles", "custom_role_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
 		assert.Equal(t, "overprivileged_custom_roles", rc.Template)
 	})
@@ -201,7 +201,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("vm_privileged_managed_identity", func(t *testing.T) {
 		rc := findRisk(t, "vm_privileged_managed_identity", "vm_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("low"), rc.Risk.Severity)
 		assert.Equal(t, "vm_privileged_managed_identity", rc.Template)
 	})
@@ -211,7 +211,7 @@ func TestAzureConfigurationScan(t *testing.T) {
 	// =====================================================================
 	t.Run("vm_ssh_password_authentication", func(t *testing.T) {
 		rc := findRisk(t, "vm_ssh_password_authentication", "vm_id")
-		assert.Equal(t, "azure-configuration-scan", rc.Risk.Name)
+		assert.Equal(t, "azure-"+strings.ReplaceAll(rc.Template, "_", "-"), rc.Risk.Name)
 		assert.Equal(t, output.RiskSeverity("high"), rc.Risk.Severity)
 		assert.Equal(t, "vm_ssh_password_authentication", rc.Template)
 	})

--- a/pkg/modules/azure/recon/configuration_scan_test.go
+++ b/pkg/modules/azure/recon/configuration_scan_test.go
@@ -130,7 +130,7 @@ func TestConfigScanToRisk(t *testing.T) {
 	risk, ok := items[0].(output.AurelianRisk)
 	require.True(t, ok)
 
-	assert.Equal(t, "azure-configuration-scan", risk.Name)
+	assert.Equal(t, "azure-test-misconfig", risk.Name)
 	assert.Equal(t, output.RiskSeverity("high"), risk.Severity)
 	assert.Equal(t, "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm-1", risk.ImpactedResourceID)
 	assert.NotEmpty(t, risk.Context)

--- a/pkg/templates/azure/configuration-scan/aks_rbac_disabled.yaml
+++ b/pkg/templates/azure/configuration-scan/aks_rbac_disabled.yaml
@@ -2,7 +2,7 @@ id: aks_rbac_disabled
 name: AKS Clusters with RBAC Disabled
 description: Detects AKS clusters without Kubernetes RBAC enabled, allowing any authenticated user cluster-wide permissions
 category: ["Privilege Escalation", "arg-scan"]
-severity: High
+severity: Medium
 reportability: Automatic
 triageNotes: |
   This finding identifies AKS clusters that have Kubernetes RBAC disabled, which creates significant security risks:

--- a/pkg/templates/azure/configuration-scan/app_service_remote_debugging.yaml
+++ b/pkg/templates/azure/configuration-scan/app_service_remote_debugging.yaml
@@ -1,7 +1,7 @@
 id: app_service_remote_debugging_enabled
 name: App Service Remote Debugging Enabled
 description: Detects Azure App Services with remote debugging enabled, which provides RCE-equivalent access to application code, environment variables, and memory. Remote debugging should be disabled in production environments to minimize attack surface.
-severity: High
+severity: Medium
 category: ["Access Control", "arg-scan"]
 reportability: Automatic
 triageNotes: |

--- a/pkg/templates/azure/configuration-scan/databases_allow_azure_services.yaml
+++ b/pkg/templates/azure/configuration-scan/databases_allow_azure_services.yaml
@@ -2,7 +2,7 @@ id: databases_allow_azure_services
 name: Database Azure Services Access Detection
 category: ["Access Control", "arg-scan"]
 description: Detects database servers with "Allow Azure services" firewall rules enabled using enrichment analysis
-severity: High
+severity: Medium
 reportability: Automatic
 triageNotes: |
   This template identifies database resources that may have "Allow Azure services" firewall rules enabled.

--- a/pkg/templates/azure/configuration-scan/function_app_http_anonymous_access.yaml
+++ b/pkg/templates/azure/configuration-scan/function_app_http_anonymous_access.yaml
@@ -1,7 +1,7 @@
 id: function_app_http_anonymous_access
 name: Function App HTTP Triggers Without Access Keys
 description: Detects Azure Function Apps with HTTP triggers configured for anonymous access (authLevel=anonymous), allowing unauthenticated public execution. HTTP-triggered functions without authentication requirements can be invoked by anyone with knowledge of the function URL, potentially exposing sensitive business logic and data.
-severity: High
+severity: Medium
 category: ["Access Control", "arg-scan"]
 reportability: Automatic
 triageNotes: |

--- a/pkg/templates/azure/configuration-scan/key_vault_access_policy_privilege_escalation.yaml
+++ b/pkg/templates/azure/configuration-scan/key_vault_access_policy_privilege_escalation.yaml
@@ -2,7 +2,7 @@ id: key_vault_access_policy_privilege_escalation
 name: Key Vault Access Policy Privilege Escalation
 description: Detects Key Vault instances using legacy access policies that allow privilege escalation by users with Contributor roles
 category: ["Privilege Escalation", "arg-scan"]
-severity: High
+severity: Medium
 reportability: Automatic
 triageNotes: |
  Key Vaults using access policies (enableRbacAuthorization=false) allow users with Key Vault Contributor, Contributor, or Owner roles to modify access policies and grant themselves data access. This bypasses intended RBAC boundaries and violates the principle of least privilege.

--- a/pkg/templates/azure/configuration-scan/kusto_wildcard_trusted_tenants.yaml
+++ b/pkg/templates/azure/configuration-scan/kusto_wildcard_trusted_tenants.yaml
@@ -2,7 +2,7 @@ id: kusto_wildcard_trusted_tenants
 name: Kusto Clusters with Wildcard Trusted External Tenants
 category: ["Access Control", "arg-scan"]
 description: Detects Azure Data Explorer (Kusto) clusters configured with wildcard trusted external tenants, allowing authentication from any Azure AD tenant
-severity: High
+severity: Medium
 reportability: Automatic
 triageNotes: |
   1. **Immediate Threat**: Wildcard trustedExternalTenants ("*") allows authentication attempts from ANY Azure AD tenant globally

--- a/pkg/templates/azure/configuration-scan/overprivileged_custom_roles.yaml
+++ b/pkg/templates/azure/configuration-scan/overprivileged_custom_roles.yaml
@@ -1,7 +1,7 @@
 id: overprivileged_custom_roles
 name: Custom Roles with Privilege Escalation Permissions
 description: Detects custom role definitions that contain permissions allowing privilege escalation through role assignments, classic administrator changes, or role definition modifications
-severity: High
+severity: Medium
 category: ["Privilege Escalation", "arg-scan"]
 triageNotes: |
   Potential Risk:

--- a/pkg/templates/azure/configuration-scan/vm_ssh_password_authentication.yaml
+++ b/pkg/templates/azure/configuration-scan/vm_ssh_password_authentication.yaml
@@ -1,7 +1,7 @@
 id: vm_ssh_password_authentication
 name: VM SSH Password Authentication Enabled
 description: Detects Azure Linux virtual machines configured with SSH password authentication enabled (disablePasswordAuthentication=false). Password-based SSH authentication exposes VMs to credential-based attacks including brute-forcing, password spraying, and compromise via weak or default credentials. SSH key-based authentication provides stronger security by eliminating password vulnerabilities.
-severity: High
+severity: Medium
 category: ["Access Control", "arg-scan"]
 reportability: Automatic
 triageNotes: |


### PR DESCRIPTION
## Summary

Two related fixes to the Azure configuration-scan module's risk output.

### 1. Per-template risk names (was: one generic slug)

`configScanToRisk` hardcoded `Name: "azure-configuration-scan"` for every finding, collapsing distinct vulnerability classes (key-vault privilege escalation, DB firewall exposure, kusto wildcard tenants, overprivileged roles, etc.) into a single risk type. This loses signal downstream: findings can't be distinguished by name, group/dedupe together, and can't carry per-class definitions.

Now derives the name from `result.TemplateID`:
```go
Name: "azure-" + strings.ReplaceAll(result.TemplateID, "_", "-"),
```
So each template produces a distinct risk identity, e.g. `azure-key-vault-access-policy-privilege-escalation`, `azure-databases-allow-azure-services`.

### 2. Severity recalibration: High → Medium

The 8 config-scan templates that declared `severity: High` are misconfigurations / hardening gaps (DB "allow Azure services", Key Vault access-policy privesc, overprivileged custom roles, anonymous function triggers, app-service remote debugging, SSH password auth, AKS RBAC disabled / local accounts) rather than directly-exploitable High findings. Downgraded all 8 to Medium so the triage rating reflects a config-review finding. Severity flows straight from the template YAML → emitted risk, so this is a YAML-only change (+ matching integration-test assertions).

Affected templates: `aks_rbac_disabled`, `app_service_remote_debugging`, `databases_allow_azure_services`, `function_app_http_anonymous_access`, `key_vault_access_policy_privilege_escalation`, `kusto_wildcard_trusted_tenants`, `overprivileged_custom_roles`, `vm_ssh_password_authentication`.

## Scope

Intentionally **configuration-scan only**. `public-resources` uses a single-slug pattern too but that's defensible (every finding means "this resource is public", differentiated by resource); config-scan templates are distinct vulnerability classes.

## Compatibility note

The per-template naming changes the risk `Name` (identity) for configuration-scan findings. Downstream consumers keyed on the literal `"azure-configuration-scan"` will see new slugs and may need migration. The single-slug collapse was the bug.

## Tests

- Unit `TestConfigScanToRisk` asserts the derived name (`azure-test-misconfig`).
- Integration assertions derive the expected name from each block's `rc.Template`, and severity assertions updated to Medium for the 8 downgraded templates.
- `go build` / `go vet` (incl. `-tags integration`) / unit tests pass.

## End-to-end validation

Deployed to a dev Guard stack and ran `aurelian-azure-configuration-scan` against a live Azure subscription with seeded misconfigurations. Findings landed in Guard as **distinct per-template risk records** (`azure-databases-allow-azure-services`, `azure-key-vault-access-policy-privilege-escalation`, `azure-overprivileged-custom-roles`, `azure-nsg-unrestricted-port-ranges`, `azure-aks-local-accounts-enabled`, etc.) with correct titles, replacing the single generic risk. (Severity downgrade verified at the template/unit level; the live run predated that commit.)
