### PR TITLE
fix(aws/iam): remove IsValidActionForResource pre-filter from Evaluate

### DIFF
--- a/pkg/aws/iam/evaluator.go
+++ b/pkg/aws/iam/evaluator.go
@@ -181,14 +181,11 @@ func policyToStatementList(policy *types.Policy) *types.PolicyStatementList {
 
 // Evaluate performs the full policy evaluation
 func (e *PolicyEvaluator) Evaluate(req *EvaluationRequest) (*EvaluationResult, error) {
-	// First validate that the action is valid for the resource type
-	if !IsValidActionForResource(req.Action, req.Resource) {
-		return &EvaluationResult{
-			Allowed:           false,
-			PolicyResult:      NewPolicyResult(),
-			EvaluationDetails: fmt.Sprintf("Action %s is not valid for resource %s", req.Action, req.Resource),
-		}, nil
-	}
+	// NOTE: IsValidActionForResource was previously used here as a pre-filter
+	// but it incorrectly rejected valid evaluations (e.g., lambda:CreateFunction
+	// on a concrete Lambda ARN when the policy grants Resource:"*"). The
+	// statement-level evaluation already handles resource matching correctly.
+	// See: 2026-06-15-AURELIAN-BUG-check-specific-service-arn.md
 
 	result := &EvaluationResult{
 		PolicyResult: NewPolicyResult(),

--- a/pkg/aws/iam/evaluator_test.go
+++ b/pkg/aws/iam/evaluator_test.go
@@ -1104,8 +1104,10 @@ func TestPolicyEvaluator_CreateWithServiceAsResource(t *testing.T) {
 	result, err = evaluator.Evaluate(req)
 	t.Log(result)
 	assert.NoError(t, err)
-	// CreateFunction is NOT valid for an existing function ARN resource - it maps to service type
-	assert.False(t, result.Allowed)
+	// A principal with Allow *:* on * is allowed on any concrete resource,
+	// including a specific function ARN. AWS evaluates the policy, not the
+	// action-resource-type map.
+	assert.True(t, result.Allowed)
 }
 
 func TestPolicyEvaluator_SCPServiceLinkedRole(t *testing.T) {
@@ -1761,7 +1763,7 @@ func TestPolicyToStatementList(t *testing.T) {
 	})
 }
 
-func TestPolicyEvaluator_InvalidActionForResource(t *testing.T) {
+func TestPolicyEvaluator_ActionOnConcreteResourceARN(t *testing.T) {
 	evaluator := NewPolicyEvaluator(&PolicyData{})
 
 	identityStatements := &types.PolicyStatementList{
@@ -1779,10 +1781,11 @@ func TestPolicyEvaluator_InvalidActionForResource(t *testing.T) {
 		IdentityStatements: identityStatements,
 	}
 
+	// A principal with Allow *:* on * must be allowed on any concrete resource.
+	// Previously this was incorrectly denied by IsValidActionForResource pre-filter.
 	result, err := evaluator.Evaluate(req)
 	assert.NoError(t, err)
-	assert.False(t, result.Allowed)
-	assert.Contains(t, result.EvaluationDetails, "is not valid for resource")
+	assert.True(t, result.Allowed)
 }
 
 func TestPolicyEvaluator_CrossAccountAssumeRole(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove `IsValidActionForResource` gate from `PolicyEvaluator.Evaluate()` — it incorrectly denied actions on concrete resource ARNs when the action's resource-type map didn't include a matching pattern, even when the principal's policy grants `Resource:"*"`.
- This caused **false negatives** for `lambda:CreateFunction`, `sts:AssumeRole`, `ec2:RunInstances`, and any action whose resource-type map only included `"service"`.
- The statement-level evaluation already handles resource matching correctly (`Resource:"*"` matches any ARN). The pre-filter was a misguided optimization.

**Impact:** On the 137-principal sandbox, Aurelian fired only 10/44 escalation rules (297 paths) vs IAMSpy's 44 rules (2099 paths). The entire gap was this erroneous pre-filter denying legitimate permissions.

**Found by:** Three-backend cross-validation harness (policy_summary vs IAMSpy vs Aurelian) on `hengrui-sandbox-read` (352505431836). See `docs/specs/2026-06-15-AURELIAN-BUG-check-specific-service-arn.md` in `aws-iam-pe`.

**Supersedes:** #228 (`CreateRole`/`CreateUser`/`CreateGroup` resource-type map fix) — that fix addressed individual mappings; this fix removes the flawed gate entirely, covering all actions.

## Test plan

- [x] Updated test that asserted buggy behavior (`TestPolicyEvaluator_InvalidActionForResource` → `TestPolicyEvaluator_ActionOnConcreteResourceARN`)
- [x] Updated test asserting `CreateFunction` on function ARN is denied → now asserts allowed
- [x] All 2190 existing tests pass
- [x] golangci-lint clean