### PR TITLE
Constantine: CWE-476: NULL Pointer Dereference

### DIFF
--- a/internal/helpers/aws/cloudcontrol.go
+++ b/internal/helpers/aws/cloudcontrol.go
@@ -15,6 +15,9 @@ func CloudControlToAWSResource(desc cctypes.ResourceDescription, resourceType, a
 		region = ""
 	}
 
+	if desc.Identifier == nil {
+		return output.AWSResource{}
+	}
 	identifier := *desc.Identifier
 	a := types.BuildResourceARN(identifier, resourceType, region, accountID)
 
@@ -31,6 +34,10 @@ func CloudControlToAWSResource(desc cctypes.ResourceDescription, resourceType, a
 		Region:       region,
 	}
 
+	if desc.Properties == nil {
+		resource.Properties = map[string]any{}
+		return resource
+	}
 	var props map[string]any
 	if err := json.Unmarshal([]byte(*desc.Properties), &props); err == nil {
 		resource.Properties = props

--- a/internal/helpers/aws/cloudcontrol.go
+++ b/internal/helpers/aws/cloudcontrol.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"encoding/json"
+	"log/slog"
 
 	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/praetorian-inc/aurelian/pkg/output"
@@ -10,13 +11,21 @@ import (
 
 // CloudControlToAWSResource converts a CloudControl ResourceDescription
 // directly to an AWSResource without an intermediate ERD.
-func CloudControlToAWSResource(desc cctypes.ResourceDescription, resourceType, accountID, region string) output.AWSResource {
+//
+// It returns ok=false when the description cannot yield a valid resource. The
+// only such case is a nil Identifier: the Cloud Control API contract guarantees
+// every ResourceDescription carries a primary identifier, so a nil one is a
+// malformed response. Callers must skip emitting the resource when ok is false
+// rather than forwarding a phantom zero-value resource into the pipeline.
+func CloudControlToAWSResource(desc cctypes.ResourceDescription, resourceType, accountID, region string) (output.AWSResource, bool) {
 	if IsGlobalService(resourceType) {
 		region = ""
 	}
 
 	if desc.Identifier == nil {
-		return output.AWSResource{}
+		slog.Warn("cloudcontrol: ResourceDescription has nil Identifier, skipping",
+			"resourceType", resourceType, "accountID", accountID, "region", region)
+		return output.AWSResource{}, false
 	}
 	identifier := *desc.Identifier
 	a := types.BuildResourceARN(identifier, resourceType, region, accountID)
@@ -36,7 +45,7 @@ func CloudControlToAWSResource(desc cctypes.ResourceDescription, resourceType, a
 
 	if desc.Properties == nil {
 		resource.Properties = map[string]any{}
-		return resource
+		return resource, true
 	}
 	var props map[string]any
 	if err := json.Unmarshal([]byte(*desc.Properties), &props); err == nil {
@@ -45,5 +54,5 @@ func CloudControlToAWSResource(desc cctypes.ResourceDescription, resourceType, a
 		resource.Properties = map[string]any{"raw_properties": *desc.Properties}
 	}
 
-	return resource
+	return resource, true
 }

--- a/internal/helpers/aws/cloudcontrol_test.go
+++ b/internal/helpers/aws/cloudcontrol_test.go
@@ -1,0 +1,80 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloudControlToAWSResource_NilIdentifier verifies that a ResourceDescription
+// with a nil Identifier — an AWS Cloud Control API contract violation — is
+// reported as invalid (ok == false) so callers can skip emitting it, rather than
+// producing a phantom zero-value resource that flows to output.
+func TestCloudControlToAWSResource_NilIdentifier(t *testing.T) {
+	desc := cctypes.ResourceDescription{
+		Identifier: nil,
+		Properties: aws.String(`{"Name":"ignored"}`),
+	}
+
+	resource, ok := CloudControlToAWSResource(desc, "AWS::Lambda::Function", "123456789012", "us-east-1")
+
+	assert.False(t, ok, "nil Identifier must report ok=false so the caller skips the send")
+	assert.Equal(t, "", resource.ResourceID, "no resource should be constructed for a nil Identifier")
+	assert.Equal(t, "", resource.ResourceType, "no resource should be constructed for a nil Identifier")
+}
+
+// TestCloudControlToAWSResource_NilProperties verifies that a nil Properties —
+// a normal, expected condition for resource types that return no property blob —
+// produces a valid resource (ok == true) with an empty Properties map and does
+// not panic.
+func TestCloudControlToAWSResource_NilProperties(t *testing.T) {
+	desc := cctypes.ResourceDescription{
+		Identifier: aws.String("my-func"),
+		Properties: nil,
+	}
+
+	resource, ok := CloudControlToAWSResource(desc, "AWS::Lambda::Function", "123456789012", "us-east-1")
+
+	require.True(t, ok, "nil Properties is normal data; the resource must still be valid")
+	assert.Equal(t, "my-func", resource.ResourceID)
+	assert.Equal(t, "AWS::Lambda::Function", resource.ResourceType)
+	assert.NotNil(t, resource.Properties, "Properties should be a non-nil empty map, not nil")
+	assert.Empty(t, resource.Properties, "Properties should be empty when the source is nil")
+}
+
+// TestCloudControlToAWSResource_ValidJSONProperties verifies the happy path:
+// a populated Identifier and valid JSON Properties yield a fully-formed resource.
+func TestCloudControlToAWSResource_ValidJSONProperties(t *testing.T) {
+	desc := cctypes.ResourceDescription{
+		Identifier: aws.String("my-func"),
+		Properties: aws.String(`{"FunctionName":"my-func","Runtime":"go1.x"}`),
+	}
+
+	resource, ok := CloudControlToAWSResource(desc, "AWS::Lambda::Function", "123456789012", "us-east-1")
+
+	require.True(t, ok)
+	assert.Equal(t, "my-func", resource.ResourceID)
+	assert.Equal(t, "AWS::Lambda::Function", resource.ResourceType)
+	assert.Equal(t, "123456789012", resource.AccountRef)
+	assert.Equal(t, "us-east-1", resource.Region)
+	assert.Equal(t, "my-func", resource.Properties["FunctionName"])
+	assert.Equal(t, "go1.x", resource.Properties["Runtime"])
+}
+
+// TestCloudControlToAWSResource_InvalidJSONProperties verifies that
+// non-JSON Properties are preserved under the raw_properties key rather than
+// being dropped, and the resource is still valid.
+func TestCloudControlToAWSResource_InvalidJSONProperties(t *testing.T) {
+	desc := cctypes.ResourceDescription{
+		Identifier: aws.String("my-func"),
+		Properties: aws.String("not-json"),
+	}
+
+	resource, ok := CloudControlToAWSResource(desc, "AWS::Lambda::Function", "123456789012", "us-east-1")
+
+	require.True(t, ok)
+	assert.Equal(t, "not-json", resource.Properties["raw_properties"])
+}

--- a/pkg/aws/enumeration/cloud_control_enumerator.go
+++ b/pkg/aws/enumeration/cloud_control_enumerator.go
@@ -3,6 +3,8 @@ package enumeration
 import (
 	"context"
 	"fmt"
+	"log/slog"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsaarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
@@ -51,7 +53,7 @@ func (cc *CloudControlEnumerator) List(identifier string, out *pipeline.P[output
 }
 
 func (cc *CloudControlEnumerator) EnumerateByARN(resourceARN string, out *pipeline.P[output.AWSResource]) error {
-	resource, err := cc.getResourceByARN(resourceARN)
+	resource, ok, err := cc.getResourceByARN(resourceARN)
 	if err != nil {
 		// Design note: we re-parse the ARN here rather than reusing the
 		// resolved region from getResourceByARN, because getResourceByARN
@@ -72,24 +74,35 @@ func (cc *CloudControlEnumerator) EnumerateByARN(resourceARN string, out *pipeli
 		return err
 	}
 
+	// ok is false when GetResource returned a malformed description (e.g. a nil
+	// Identifier). The helper has already logged the anomaly; skip the send
+	// rather than forwarding a phantom zero-value resource.
+	if !ok {
+		return nil
+	}
+
 	out.Send(resource)
 	return nil
 }
 
-func (cc *CloudControlEnumerator) getResourceByARN(arn string) (output.AWSResource, error) {
+// getResourceByARN fetches a single resource via GetResource. The returned bool
+// is false when the response cannot yield a valid resource — either a nil
+// ResourceDescription or a description with a nil Identifier — in which case the
+// caller must skip emitting it. err is reserved for genuine fetch failures.
+func (cc *CloudControlEnumerator) getResourceByARN(arn string) (output.AWSResource, bool, error) {
 	region, resourceType, identifier, err := cc.resolveARNTarget(arn)
 	if err != nil {
-		return output.AWSResource{}, err
+		return output.AWSResource{}, false, err
 	}
 
 	client, err := cc.newCloudControlClient(region)
 	if err != nil {
-		return output.AWSResource{}, fmt.Errorf("create client: %w", err)
+		return output.AWSResource{}, false, fmt.Errorf("create client: %w", err)
 	}
 
 	accountID, err := cc.provider.GetAccountID(region)
 	if err != nil {
-		return output.AWSResource{}, err
+		return output.AWSResource{}, false, err
 	}
 
 	result, err := client.GetResource(context.Background(), &cloudcontrol.GetResourceInput{
@@ -97,11 +110,17 @@ func (cc *CloudControlEnumerator) getResourceByARN(arn string) (output.AWSResour
 		Identifier: aws.String(identifier),
 	})
 	if err != nil {
-		return output.AWSResource{}, fmt.Errorf("get %s %s: %w", resourceType, identifier, err)
+		return output.AWSResource{}, false, fmt.Errorf("get %s %s: %w", resourceType, identifier, err)
 	}
 
-	cr := awshelpers.CloudControlToAWSResource(*result.ResourceDescription, resourceType, accountID, region)
-	return cr, nil
+	if result.ResourceDescription == nil {
+		slog.Warn("cloudcontrol: GetResource returned nil ResourceDescription, skipping",
+			"resourceType", resourceType, "identifier", identifier, "region", region)
+		return output.AWSResource{}, false, nil
+	}
+
+	cr, ok := awshelpers.CloudControlToAWSResource(*result.ResourceDescription, resourceType, accountID, region)
+	return cr, ok, nil
 }
 
 func (cc *CloudControlEnumerator) resolveARNTarget(resourceARN string) (string, string, string, error) {
@@ -286,7 +305,10 @@ func (cc *CloudControlEnumerator) listByType(
 		}
 
 		for _, desc := range result.ResourceDescriptions {
-			cr := awshelpers.CloudControlToAWSResource(desc, resourceType, accountID, region)
+			cr, ok := awshelpers.CloudControlToAWSResource(desc, resourceType, accountID, region)
+			if !ok {
+				continue
+			}
 			out.Send(cr)
 		}
 


### PR DESCRIPTION
## Root cause: nil checks before pointer dereference with early returns

Add explicit nil guards for desc.Identifier and desc.Properties before each dereference. When Identifier is nil, return a zero-value AWSResource (matching the error-path convention already used in the callers). When Properties is nil, leave resource.Properties as an empty/nil map rather than panicking.

### Defense Layers

- **primary:** Guard desc.Identifier with a nil check; return empty AWSResource if nil. Guard desc.Properties with a nil check; set empty properties map and return if nil.

### Finding Details

- **Risk:** CWE-476: NULL Pointer Dereference
- **File:** `https://github.com/praetorian-inc/aurelian:cwe476:internal/helpers/aws/cloudcontrol.go`

[View finding details in Guard](https://guard.praetorian.com/Imd1YXJkK2FjbWUtaGp5QHByYWV0b3JpYW4uY29tIg==/vulnerabilities?vulnerabilityDrawerKey=%23risk%23https%3A%2F%2Fgithub.com%2Fpraetorian-inc%2Faurelian%3Acwe476%3Ainternal%2Fhelpers%2Faws%2Fcloudcontrol.go%23constantine-cwe476&drawerOrder=%5B%22vulnerability%22%5D&vulnerabilityDrawerTab=evidence)

---
*Generated by [Constantine](https://github.com/praetorian-inc/constantine) via [Guard](https://guard.praetorian.com)*
