### PR TITLE
fix(fixture): teardown-budget + prefix-purge review fixes, plus CI drain backstop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/neo4j v0.40.0
 	golang.org/x/sync v0.19.0
+	golang.org/x/tools v0.41.0
 	google.golang.org/api v0.269.0
 	modernc.org/sqlite v1.46.1
 )
@@ -196,6 +197,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
+	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/scripts/destroy-integration-fixtures.sh
+++ b/scripts/destroy-integration-fixtures.sh
@@ -125,7 +125,7 @@ fi
 # Derive moduleDir (everything between STATE_PREFIX and /terraform.tfstate).
 declare -a MODULES=()
 for key in "${STATE_KEYS[@]}"; do
-  module="${key#${STATE_PREFIX}}"
+  module="${key#"${STATE_PREFIX}"}"
   module="${module%/terraform.tfstate}"
   MODULES+=("$module")
 done

--- a/test/conventions_test.go
+++ b/test/conventions_test.go
@@ -69,8 +69,15 @@ func TestIntegrationFixturePackagesDrainViaRunTests(t *testing.T) {
 	}
 	facts := map[string]*pkgFacts{}
 	keyOf := func(p *packages.Package) string {
-		// Collapse "pkg.test", "pkg [pkg.test]", "pkg_test [pkg.test]" to "pkg".
+		// Collapse every go/packages variant of one directory to a single key.
+		// We key off PkgPath, where the test-variant marker is only ever the
+		// ".test"/"_test" suffix — the bracketed " [pkg.test]" form appears in
+		// p.ID, NOT p.PkgPath. We still defensively strip a trailing bracket so
+		// the skip stays correct even if a caller ever passes an ID-shaped value.
 		k := p.PkgPath
+		if i := strings.IndexByte(k, ' '); i >= 0 { // "pkg [pkg.test]" -> "pkg"
+			k = k[:i]
+		}
 		k = strings.TrimSuffix(k, ".test")
 		k = strings.TrimSuffix(k, "_test")
 		return k

--- a/test/conventions_test.go
+++ b/test/conventions_test.go
@@ -10,6 +10,7 @@ package conventions_test
 
 import (
 	"go/ast"
+	"go/token"
 	"go/types"
 	"sort"
 	"strings"
@@ -101,11 +102,13 @@ func TestIntegrationFixturePackagesDrainViaRunTests(t *testing.T) {
 		if p.TypesInfo == nil || len(p.Syntax) == 0 {
 			continue
 		}
-		// Skip the fixture package itself and the testutil helpers: the former
-		// owns the lifecycle (and its own TestMain), the latter only defines the
-		// constructors (it deploys nothing at test time).
+		// Skip the fixture package itself: it legitimately calls NewBase from
+		// its own in-package tests and owns the canonical TestMain. Helper
+		// packages like test/testutil need no special-casing — the _test.go
+		// gate below means we only count fixtures actually deployed by a test,
+		// not constructors merely defined in a non-test helper file.
 		base := keyOf(p)
-		if base == fixturePkgPath || base == modulePath+"/test/testutil" {
+		if base == fixturePkgPath {
 			continue
 		}
 
@@ -116,6 +119,13 @@ func TestIntegrationFixturePackagesDrainViaRunTests(t *testing.T) {
 		}
 
 		for _, file := range p.Syntax {
+			// Only test files deploy fixtures at run time. A constructor wrapper
+			// defined in a non-test .go file does not run during `go test`, so it
+			// must not count as a deploy (it would force a needless TestMain and
+			// surprise contributors who factor helpers out of a test package).
+			if !isTestFile(p.Fset, file) {
+				continue
+			}
 			ast.Inspect(file, func(n ast.Node) bool {
 				call, ok := n.(*ast.CallExpr)
 				if !ok {
@@ -167,6 +177,16 @@ func TestIntegrationFixturePackagesDrainViaRunTests(t *testing.T) {
 			"Without it, the package's fixtures are never destroyed after a successful run (idle cloud cost).",
 			strings.Join(offenders, "\n  - "), fixturePkgPath)
 	}
+}
+
+// isTestFile reports whether the syntax file is a Go test file (its name ends
+// in _test.go). Resolved via the FileSet because *ast.File carries no path.
+func isTestFile(fset *token.FileSet, file *ast.File) bool {
+	if fset == nil {
+		return false
+	}
+	name := fset.File(file.Pos()).Name()
+	return strings.HasSuffix(name, "_test.go")
 }
 
 // isFixtureObj reports whether obj is the named object `name` declared in the

--- a/test/conventions_test.go
+++ b/test/conventions_test.go
@@ -1,0 +1,248 @@
+// Package conventions holds repo-wide convention checks that run under the
+// normal (non-integration) `go test` pass so they gate every PR in CI.
+//
+// The integration build tag is deliberately NOT set on this file: it loads and
+// type-checks OTHER packages (under the integration tag) via go/packages rather
+// than being compiled with them, so it must run in the default build that CI
+// exercises. It needs no cloud credentials — nothing here executes a test, it
+// only inspects type information.
+package conventions_test
+
+import (
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	modulePath      = "github.com/praetorian-inc/aurelian"
+	fixturePkgPath  = modulePath + "/test/testutil/fixture"
+	fixtureIface    = "Fixture" // fixture.Fixture — implemented by every deployed fixture
+	baseFixtureType = "BaseFixture"
+	runTestsFunc    = "RunTests" // fixture.RunTests — the end-of-package drain
+)
+
+// TestIntegrationFixturePackagesDrainViaRunTests enforces the fixture-cleanup
+// contract introduced in the "destroy fixtures on package success" change:
+// every package whose tests deploy fixtures MUST own a TestMain that calls
+// fixture.RunTests, otherwise its fixtures leak (idle cloud cost) because the
+// end-of-package destroy never fires.
+//
+// This is a TYPE-AWARE backstop. Rather than matching constructor names, it
+// loads every package under the integration build tag with full type info and:
+//
+//   - flags a package as fixture-deploying if any of its test files call a
+//     function whose result implements fixture.Fixture (or is *fixture.BaseFixture).
+//     This catches existing constructors (testutil.New{,AWS,Azure,GCP}Fixture)
+//     AND any future one, by type — no name list to keep in sync.
+//   - confirms drainage by resolving each call's callee to a function and
+//     checking it is RunTests declared in the fixture package, so a same-named
+//     helper in any other package can never spoof it.
+//
+// Adding a new integration-test package that deploys fixtures but forgets the
+// TestMain compiles and passes today; this test turns that omission into a CI
+// failure with a copy-pasteable fix.
+func TestIntegrationFixturePackagesDrainViaRunTests(t *testing.T) {
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports,
+		BuildFlags: []string{"-tags=integration"},
+		Tests:      true, // load *_test.go and the synthesized test variants
+	}
+
+	pkgs, err := packages.Load(cfg, modulePath+"/...")
+	if err != nil {
+		t.Fatalf("loading packages: %v", err)
+	}
+
+	// Aggregate per logical package (group the [X], [X.test], X_test variants
+	// that go/packages emits for one directory under one key).
+	type pkgFacts struct {
+		name           string // import path of the underlying package, for messages
+		deploys        bool
+		drains         bool
+		sampleDeployer string // a function whose call deploys a fixture, for the message
+	}
+	facts := map[string]*pkgFacts{}
+	keyOf := func(p *packages.Package) string {
+		// Collapse "pkg.test", "pkg [pkg.test]", "pkg_test [pkg.test]" to "pkg".
+		k := p.PkgPath
+		k = strings.TrimSuffix(k, ".test")
+		k = strings.TrimSuffix(k, "_test")
+		return k
+	}
+
+	var loadErr bool
+	packages.Visit(pkgs, nil, func(p *packages.Package) {
+		for _, e := range p.Errors {
+			// A type-check error in an unrelated package shouldn't silently
+			// weaken the check — surface it and fail.
+			t.Errorf("package %s: %v", p.PkgPath, e)
+			loadErr = true
+		}
+	})
+	if loadErr {
+		t.FailNow()
+	}
+
+	for _, p := range pkgs {
+		// Only consider packages that actually carry test syntax + type info.
+		if p.TypesInfo == nil || len(p.Syntax) == 0 {
+			continue
+		}
+		// Skip the fixture package itself and the testutil helpers: the former
+		// owns the lifecycle (and its own TestMain), the latter only defines the
+		// constructors (it deploys nothing at test time).
+		base := keyOf(p)
+		if base == fixturePkgPath || base == modulePath+"/test/testutil" {
+			continue
+		}
+
+		f := facts[base]
+		if f == nil {
+			f = &pkgFacts{name: base}
+			facts[base] = f
+		}
+
+		for _, file := range p.Syntax {
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				// Drain detection: does this call resolve to fixture.RunTests?
+				// Matched by (package path, name) rather than pointer identity,
+				// because go/packages type-checks the fixture package once per
+				// importing variant — pointer identity does not survive that.
+				if obj := calleeObject(p.TypesInfo, call); isFixtureObj(obj, runTestsFunc) {
+					f.drains = true
+				}
+				// Deploy detection: does this call return a fixture.Fixture
+				// (or *fixture.BaseFixture)?
+				if resultDeploysFixture(p.TypesInfo, call) {
+					f.deploys = true
+					if f.sampleDeployer == "" {
+						f.sampleDeployer = callDescription(p.TypesInfo, call)
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	var offenders []string
+	for _, f := range facts {
+		if f.deploys && !f.drains {
+			line := strings.TrimPrefix(f.name, modulePath+"/")
+			if f.sampleDeployer != "" {
+				line += " (deploys via " + f.sampleDeployer + ")"
+			}
+			offenders = append(offenders, line)
+		}
+	}
+	sort.Strings(offenders)
+
+	if len(offenders) > 0 {
+		t.Errorf("integration-test packages deploy fixtures but lack a TestMain that drains them:\n  - %s\n\n"+
+			"Each listed package must add a file (e.g. testmain_test.go) containing:\n\n"+
+			"\t//go:build integration\n\n"+
+			"\tpackage <pkg>\n\n"+
+			"\timport (\n"+
+			"\t\t\"os\"\n"+
+			"\t\t\"testing\"\n\n"+
+			"\t\t\"%s\"\n"+
+			"\t)\n\n"+
+			"\tfunc TestMain(m *testing.M) { os.Exit(fixture.RunTests(m)) }\n\n"+
+			"Without it, the package's fixtures are never destroyed after a successful run (idle cloud cost).",
+			strings.Join(offenders, "\n  - "), fixturePkgPath)
+	}
+}
+
+// isFixtureObj reports whether obj is the named object `name` declared in the
+// fixture package. Matching by (package path, name) is deliberate: go/packages
+// type-checks the fixture package once per importing variant, so the same
+// logical object appears as distinct *types.Object pointers across packages —
+// pointer identity would miss most matches.
+func isFixtureObj(obj types.Object, name string) bool {
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == fixturePkgPath && obj.Name() == name
+}
+
+// calleeObject returns the function/var object a call expression resolves to,
+// or nil if it can't be determined.
+func calleeObject(info *types.Info, call *ast.CallExpr) types.Object {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return info.Uses[fun]
+	case *ast.SelectorExpr:
+		return info.Uses[fun.Sel]
+	}
+	return nil
+}
+
+// resultDeploysFixture reports whether the call's result type is the
+// fixture.Fixture interface or *fixture.BaseFixture — i.e. the call hands back
+// a deployable fixture. It walks the result type to its underlying named type
+// and matches on (package path, type name), so it is purely type-driven (any
+// constructor, any name) and stable across go/packages test variants.
+func resultDeploysFixture(info *types.Info, call *ast.CallExpr) bool {
+	tv, ok := info.Types[call]
+	if !ok || tv.Type == nil {
+		return false
+	}
+	return typeIsFixture(tv.Type)
+}
+
+func typeIsFixture(typ types.Type) bool {
+	// A *types.Tuple is never aliased; handle it before unaliasing.
+	if tup, ok := typ.(*types.Tuple); ok { // multi-return constructor: check each result
+		for i := 0; i < tup.Len(); i++ {
+			if typeIsFixture(tup.At(i).Type()) {
+				return true
+			}
+		}
+		return false
+	}
+	// Unalias first: constructors that return the testutil.Fixture alias
+	// (type Fixture = fixture.Fixture) surface here as *types.Alias.
+	switch t := types.Unalias(typ).(type) {
+	case *types.Pointer: // *fixture.BaseFixture
+		return isFixtureNamed(t.Elem(), baseFixtureType)
+	case *types.Named: // fixture.Fixture (interface)
+		return isFixtureNamed(t, fixtureIface)
+	}
+	return false
+}
+
+// isFixtureNamed reports whether typ is the named type `name` from the fixture
+// package. types.Alias (Go 1.22+, e.g. testutil.Fixture = fixture.Fixture) is
+// unwrapped to its target first so the alias matches too.
+func isFixtureNamed(typ types.Type, name string) bool {
+	named, ok := types.Unalias(typ).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == fixturePkgPath && obj.Name() == name
+}
+
+// callDescription renders a human-readable callee name for the failure message,
+// e.g. "testutil.NewAzureFixture".
+func callDescription(info *types.Info, call *ast.CallExpr) string {
+	if obj := calleeObject(info, call); obj != nil {
+		if pkg := obj.Pkg(); pkg != nil {
+			return pkg.Name() + "." + obj.Name()
+		}
+		return obj.Name()
+	}
+	return "a fixture constructor"
+}

--- a/test/testutil/fixture/fixture.go
+++ b/test/testutil/fixture/fixture.go
@@ -25,15 +25,15 @@ const (
 
 // Config holds the parameters needed to set up a Terraform fixture.
 type Config struct {
-	Provider    Provider
-	ModuleDir   string
-	FixtureDir  string
-	ExecPath    string
-	ContainerID string
-	StateKey    string
-	StateURI    string
+	Provider     Provider
+	ModuleDir    string
+	FixtureDir   string
+	ExecPath     string
+	ContainerID  string
+	StateKey     string
+	StateURI     string
 	ArtifactsURI string
-	InitOpts    []tfexec.InitOption
+	InitOpts     []tfexec.InitOption
 }
 
 // Fixture is the public interface for integration test fixtures.

--- a/test/testutil/fixture/registry.go
+++ b/test/testutil/fixture/registry.go
@@ -75,17 +75,42 @@ func (r *registry) DestroyAll(ctx context.Context) error {
 
 	var errs []error
 	for _, f := range fixtures {
-		fixtureCtx, cancel := context.WithTimeout(ctx, perFixtureDestroyTimeout)
-		if err := fn(fixtureCtx, f); err != nil {
+		// Stop early if the caller's context is already done, but otherwise
+		// give each fixture its own full per-fixture budget. The per-fixture
+		// deadline is rooted independently (not derived from ctx) so a slow
+		// first fixture cannot starve later ones of their teardown time and
+		// leak cloud resources mid-`terraform destroy`. Caller cancellation is
+		// still honored — see destroyOne.
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, fmt.Errorf("destroy %s: %w", f.cfg.StateKey, err))
+			continue
+		}
+		if err := destroyOne(ctx, fn, f); err != nil {
 			errs = append(errs, fmt.Errorf("destroy %s: %w", f.cfg.StateKey, err))
 		}
-		cancel()
 	}
 
 	if len(errs) == 0 {
 		return nil
 	}
 	return errors.Join(errs...)
+}
+
+// destroyOne runs a single fixture's teardown with an independent
+// perFixtureDestroyTimeout budget that does not borrow from the caller's
+// remaining time, while still aborting if the caller's context is canceled.
+func destroyOne(parent context.Context, fn func(context.Context, *BaseFixture) error, f *BaseFixture) error {
+	// Independent deadline: rooted at Background so each fixture gets the full
+	// timeout regardless of how long earlier fixtures took.
+	fixtureCtx, cancel := context.WithTimeout(context.Background(), perFixtureDestroyTimeout)
+	defer cancel()
+
+	// Propagate caller cancellation (e.g. an outer bound or SIGINT) into the
+	// independent context without importing the caller's deadline.
+	stop := context.AfterFunc(parent, cancel)
+	defer stop()
+
+	return fn(fixtureCtx, f)
 }
 
 // defaultTeardown is the production teardown path: destroy terraform

--- a/test/testutil/fixture/registry_test.go
+++ b/test/testutil/fixture/registry_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 )
@@ -99,6 +100,79 @@ func TestRegistry_DestroyAll_CallsTeardownForEach(t *testing.T) {
 	}
 }
 
+// TestRegistry_DestroyAll_PerFixtureBudgetIsIndependent guards the fix for the
+// context-starvation bug: each fixture must receive (close to) the full
+// perFixtureDestroyTimeout, not a slice of one shared budget that shrinks as
+// earlier fixtures consume it. We simulate a slow first teardown and assert the
+// second fixture's deadline is still ~perFixtureDestroyTimeout away.
+func TestRegistry_DestroyAll_PerFixtureBudgetIsIndependent(t *testing.T) {
+	r := &registry{}
+
+	var mu sync.Mutex
+	remaining := map[string]time.Duration{}
+	r.teardownFn = func(ctx context.Context, f *BaseFixture) error {
+		dl, ok := ctx.Deadline()
+		if !ok {
+			t.Errorf("fixture %s: expected a deadline on the teardown context", f.cfg.StateKey)
+			return nil
+		}
+		mu.Lock()
+		remaining[f.cfg.StateKey] = time.Until(dl)
+		mu.Unlock()
+		// Simulate a slow first teardown burning wall-clock that, under the old
+		// shared-context scheme, would have eaten into the second fixture's budget.
+		if f.cfg.StateKey == "slow" {
+			time.Sleep(75 * time.Millisecond)
+		}
+		return nil
+	}
+
+	r.register(&BaseFixture{cfg: Config{StateKey: "slow"}})
+	r.register(&BaseFixture{cfg: Config{StateKey: "fast"}})
+
+	if err := r.DestroyAll(context.Background()); err != nil {
+		t.Fatalf("DestroyAll: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Every fixture should see nearly the full budget. Allow generous slack for
+	// scheduling, but far less than the ~75ms the slow fixture consumed — proving
+	// the budgets are not derived from one shrinking parent deadline.
+	const minExpected = perFixtureDestroyTimeout - time.Second
+	for key, rem := range remaining {
+		if rem < minExpected {
+			t.Errorf("fixture %s got only %v of its %v budget (deadline borrowed from a shared parent?)",
+				key, rem, perFixtureDestroyTimeout)
+		}
+	}
+}
+
+// TestRegistry_DestroyAll_HonorsCallerCancellation verifies that a canceled
+// caller context still aborts the pass: fixtures not yet started are skipped
+// (and recorded as errors) rather than torn down past the caller's intent.
+func TestRegistry_DestroyAll_HonorsCallerCancellation(t *testing.T) {
+	r := &registry{}
+	var teardowns int
+	r.teardownFn = func(ctx context.Context, f *BaseFixture) error {
+		teardowns++
+		return nil
+	}
+	r.register(&BaseFixture{cfg: Config{StateKey: "a"}})
+	r.register(&BaseFixture{cfg: Config{StateKey: "b"}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled before DestroyAll runs
+
+	err := r.DestroyAll(ctx)
+	if err == nil {
+		t.Fatal("want error when caller context is canceled, got nil")
+	}
+	if teardowns != 0 {
+		t.Fatalf("want 0 teardowns under canceled context, got %d", teardowns)
+	}
+}
+
 func TestRegistry_DestroyAll_AggregatesErrors(t *testing.T) {
 	r := &registry{}
 	r.teardownFn = func(ctx context.Context, f *BaseFixture) error {
@@ -142,4 +216,3 @@ func (baseOpsZero) Output(context.Context, ...tfexec.OutputOption) (map[string]t
 func (baseOpsZero) UploadArtifacts(context.Context) error   { return nil }
 func (baseOpsZero) DeleteArtifacts(context.Context) error   { return nil }
 func (baseOpsZero) PurgeModulePrefix(context.Context) error { return nil }
-

--- a/test/testutil/fixture/registry_test.go
+++ b/test/testutil/fixture/registry_test.go
@@ -101,12 +101,21 @@ func TestRegistry_DestroyAll_CallsTeardownForEach(t *testing.T) {
 }
 
 // TestRegistry_DestroyAll_PerFixtureBudgetIsIndependent guards the fix for the
-// context-starvation bug: each fixture must receive (close to) the full
-// perFixtureDestroyTimeout, not a slice of one shared budget that shrinks as
-// earlier fixtures consume it. We simulate a slow first teardown and assert the
-// second fixture's deadline is still ~perFixtureDestroyTimeout away.
+// context-starvation bug: each fixture's teardown deadline must be its own full
+// perFixtureDestroyTimeout, NOT derived from (and thus capped by) the caller's
+// remaining time.
+//
+// The test is constructed so it distinguishes the fix from the bug. The caller
+// context is given a deadline far SHORTER than perFixtureDestroyTimeout. Under
+// the old code (context.WithTimeout(ctx, perFixtureDestroyTimeout)) the child
+// deadline would be capped at the caller's ~2s remaining; under the fix
+// (rooted at context.Background via destroyOne) each fixture sees ~10m. We
+// assert the observed deadline is well beyond the caller's, which fails on the
+// old implementation and passes on the new one.
 func TestRegistry_DestroyAll_PerFixtureBudgetIsIndependent(t *testing.T) {
 	r := &registry{}
+
+	const callerBudget = 2 * time.Second
 
 	var mu sync.Mutex
 	remaining := map[string]time.Duration{}
@@ -119,31 +128,34 @@ func TestRegistry_DestroyAll_PerFixtureBudgetIsIndependent(t *testing.T) {
 		mu.Lock()
 		remaining[f.cfg.StateKey] = time.Until(dl)
 		mu.Unlock()
-		// Simulate a slow first teardown burning wall-clock that, under the old
-		// shared-context scheme, would have eaten into the second fixture's budget.
-		if f.cfg.StateKey == "slow" {
-			time.Sleep(75 * time.Millisecond)
-		}
 		return nil
 	}
 
-	r.register(&BaseFixture{cfg: Config{StateKey: "slow"}})
-	r.register(&BaseFixture{cfg: Config{StateKey: "fast"}})
+	r.register(&BaseFixture{cfg: Config{StateKey: "a"}})
+	r.register(&BaseFixture{cfg: Config{StateKey: "b"}})
 
-	if err := r.DestroyAll(context.Background()); err != nil {
+	// Caller deadline deliberately << perFixtureDestroyTimeout.
+	ctx, cancel := context.WithTimeout(context.Background(), callerBudget)
+	defer cancel()
+
+	if err := r.DestroyAll(ctx); err != nil {
 		t.Fatalf("DestroyAll: %v", err)
 	}
 
 	mu.Lock()
 	defer mu.Unlock()
-	// Every fixture should see nearly the full budget. Allow generous slack for
-	// scheduling, but far less than the ~75ms the slow fixture consumed — proving
-	// the budgets are not derived from one shrinking parent deadline.
-	const minExpected = perFixtureDestroyTimeout - time.Second
+	if len(remaining) != 2 {
+		t.Fatalf("want 2 fixtures torn down, got %d", len(remaining))
+	}
+	// Each fixture must see far more than the caller's tiny budget — i.e. its
+	// own independent perFixtureDestroyTimeout, not a slice of the caller's.
+	// Generous lower bound to tolerate scheduling jitter while still being well
+	// above callerBudget.
+	minExpected := callerBudget * 10
 	for key, rem := range remaining {
-		if rem < minExpected {
-			t.Errorf("fixture %s got only %v of its %v budget (deadline borrowed from a shared parent?)",
-				key, rem, perFixtureDestroyTimeout)
+		if rem <= minExpected {
+			t.Errorf("fixture %s teardown deadline only %v away (<= %v); budget appears derived from the caller context, not rooted independently",
+				key, rem, minExpected)
 		}
 	}
 }

--- a/test/testutil/fixture/run_tests.go
+++ b/test/testutil/fixture/run_tests.go
@@ -10,11 +10,13 @@ import (
 	"time"
 )
 
-// destroyTimeout bounds a single DestroyAll pass. Sized generously to
-// accommodate slow cloud teardowns (EKS, CloudFront) without running up
-// against typical `go test -timeout 30m` ceilings. This is an outer
-// bound — DestroyAll additionally enforces a per-fixture timeout.
-const destroyTimeout = 15 * time.Minute
+// destroyTimeout is a coarse backstop on the whole DestroyAll pass, sized so a
+// pathological hang is still interrupted before `go test`'s own -timeout (30m
+// by default) SIGKILLs the process and skips cleanup entirely. It is NOT the
+// effective per-fixture budget: DestroyAll gives each fixture an independent
+// perFixtureDestroyTimeout, so this bound only needs to exceed the realistic
+// sum of sequential teardowns, not a single one.
+const destroyTimeout = 25 * time.Minute
 
 // runner is the interface satisfied by *testing.M; declared here so
 // runTestsWith can be unit-tested with a stub.

--- a/test/testutil/fixture/s3.go
+++ b/test/testutil/fixture/s3.go
@@ -363,6 +363,7 @@ func (f *BaseFixture) purgeModulePrefix(ctx context.Context) error {
 	bucket := stateBucket
 	prefix := filepath.ToSlash(filepath.Dir(f.cfg.StateKey)) + "/"
 
+	var partialErrs []error
 	var continuationToken *string
 	for {
 		listOutput, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
@@ -391,17 +392,20 @@ func (f *BaseFixture) purgeModulePrefix(ctx context.Context) error {
 				if err != nil {
 					return fmt.Errorf("delete module prefix objects: %w", err)
 				}
+				// Record per-object failures but keep paginating: returning here
+				// would leave objects on pages 2+ undeleted, breaking the
+				// "prefix empty after destroy" contract on large fixtures.
 				if len(deleteOutput.Errors) > 0 {
 					e := deleteOutput.Errors[0]
-					return fmt.Errorf("delete module prefix objects: partial failure: key=%q code=%q message=%q (and %d more)",
-						aws.ToString(e.Key), aws.ToString(e.Code), aws.ToString(e.Message), len(deleteOutput.Errors)-1)
+					partialErrs = append(partialErrs, fmt.Errorf("delete module prefix objects: partial failure: key=%q code=%q message=%q (and %d more)",
+						aws.ToString(e.Key), aws.ToString(e.Code), aws.ToString(e.Message), len(deleteOutput.Errors)-1))
 				}
 			}
 		}
 
 		isTruncated := listOutput.IsTruncated != nil && *listOutput.IsTruncated
 		if !isTruncated {
-			return nil
+			return errors.Join(partialErrs...)
 		}
 
 		continuationToken = listOutput.NextContinuationToken


### PR DESCRIPTION
Stacks on top of #177 (`ztg/integration`). Addresses the bot review findings on that PR and adds a CI backstop so the cleanup contract can't silently regress.

## Commit 1 — review fixes (`fix(fixture): ...`)
Resolves the two Critical findings from the automated review plus two minor cleanups:

- **Per-fixture teardown budget was shared, not independent** (Claude Review, Critical). `DestroyAll` derived each fixture's 10-min context from the 15-min outer bound via `context.WithTimeout(ctx, …)`, which caps at the parent's *remaining* time. A slow first fixture (EKS/CloudFront ~15-min teardowns, per #177's own description) could leave the next one only a sliver and get SIGKILLed mid-`terraform destroy` → **leaked cloud resources**. Now each fixture's deadline is rooted independently (`destroyOne`), while caller cancellation is still honored via `context.AfterFunc`. Outer `RunTests` bound relaxed 15m→25m and re-documented as a coarse backstop.
- **`purgeModulePrefix` aborted pagination on first partial failure** (Claude Review, Critical). Returning on page 1's `DeleteObjects.Errors` left pages 2+ of a >1000-object prefix undeleted, breaking the "prefix empty after destroy" contract. Now accumulates partial-failure errors and keeps paginating (`errors.Join`).
- **SC2295** (CodeRabbit, minor): quote the prefix in `${key#"$STATE_PREFIX"}` in `destroy-integration-fixtures.sh`.
- **gofmt**: `Config` struct field alignment in `fixture.go` (was already dirty at #177 HEAD).

Adds regression tests: per-fixture budget independence, and caller-cancel aborts the pass.

## Commit 2 — CI drain backstop (`test(fixture): ...`)
New type-aware meta-test (`test/conventions_test.go`) that runs in the **default** (non-integration) `go test` pass, so it gates every PR. It loads all packages under `-tags=integration` with full type info and fails if any package **deploys a fixture** (a call whose result is `fixture.Fixture` / `*fixture.BaseFixture`) but lacks a `TestMain` calling `fixture.RunTests` — the exact omission that silently leaks fixtures.

Matching is by type and `(package path, name)`, **not** a constructor-name allowlist, so it catches future constructors automatically and survives `go/packages` test-variant duplication. Promotes `golang.org/x/tools` to a direct dependency.

## Verification
- `go build ./...` ✅ · `go vet -tags=integration ./test/testutil/fixture/...` ✅
- Fixture unit suite: all logic tests pass (the real-AWS `TestDestroyAll_RemovesModulePrefix` canary requires credentials)
- Meta-test passes on the current tree; verified it **fails** when a `TestMain` is removed and when a differently-named fixture constructor is introduced without one
- `go mod tidy` stable, `gofmt` clean, both shell scripts `bash -n` clean