### PR TITLE
chore(deps): add Dependabot config scoped to titus

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Only watch the internal Praetorian dependency (github.com/praetorian-inc/titus).
+    # The AWS/Azure SDK surface is large and churns constantly, so it is intentionally
+    # excluded here to avoid PR noise.
+    allow:
+      - dependency-name: "github.com/praetorian-inc/titus"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      # titus ships faster than weekly (historically several tags/week, recently
-      # every ~4-5 days), so poll daily to stay current. Scoped to one dep, so
-      # Dependabot keeps a single rolling PR rather than stacking many.
-      interval: "daily"
+      interval: "weekly"
     # Only watch the internal Praetorian dependency (github.com/praetorian-inc/titus).
     # The AWS/Azure SDK surface is large and churns constantly, so it is intentionally
     # excluded here to avoid PR noise.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # Only watch the internal Praetorian dependency (github.com/praetorian-inc/titus).
-    # The AWS/Azure SDK surface is large and churns constantly, so it is intentionally
-    # excluded here to avoid PR noise.
     allow:
       - dependency-name: "github.com/praetorian-inc/titus"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      # titus ships faster than weekly (historically several tags/week, recently
+      # every ~4-5 days), so poll daily to stay current. Scoped to one dep, so
+      # Dependabot keeps a single rolling PR rather than stacking many.
+      interval: "daily"
     # Only watch the internal Praetorian dependency (github.com/praetorian-inc/titus).
     # The AWS/Azure SDK surface is large and churns constantly, so it is intentionally
     # excluded here to avoid PR noise.


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to automatically open PRs when our one internal Praetorian dependency, `github.com/praetorian-inc/titus`, cuts a new release.

## Why

`titus` is currently pinned to a commit-based pseudo-version (`v1.1.10-0.20260324...`) and is behind the latest tagged release (`v1.2.5`). It's the only `praetorian-inc/*` module in our dependency graph (imported across ~35 files under `pkg/secrets/`). A scoped Dependabot config keeps it current with minimal maintenance.

## Scope

- `gomod` ecosystem, weekly schedule
- `allow` list restricts updates to **titus only** — the large AWS/Azure SDK surface is intentionally excluded to avoid PR noise
- Bump PRs are validated by existing CI (`go-ci.yml`)

## Verification

- YAML validated locally (parses, correct schema)
- Dependabot activates its scan loop once this lands on `main`; the first titus bump PR (likely → v1.2.5) confirms it works end to end