### PR TITLE
fix(secrets): drain Titus timed-out retry matches

### DIFF
--- a/pkg/modules/aws/recon/find_secrets.go
+++ b/pkg/modules/aws/recon/find_secrets.go
@@ -110,7 +110,7 @@ func (m *AWSFindSecretsModule) Run(cfg plugin.Config, out *pipeline.P[model.Aure
 	})
 
 	scanned := pipeline.New[secrets.SecretScanResult]()
-	pipeline.Pipe(extracted, s.Scan, scanned, &pipeline.PipeOpts{
+	s.ScanAndFlush(extracted, scanned, &pipeline.PipeOpts{
 		Progress: cfg.Log.ProgressFunc("scanning for secrets"),
 	})
 	pipeline.Pipe(scanned, secrets.RiskFromScanResult, out)

--- a/pkg/modules/azure/recon/find_secrets.go
+++ b/pkg/modules/azure/recon/find_secrets.go
@@ -107,7 +107,7 @@ func (m *AzureFindSecretsModule) Run(_ plugin.Config, out *pipeline.P[model.Aure
 
 	// Scan extracted content and convert results to risks.
 	scanned := pipeline.New[secrets.SecretScanResult]()
-	pipeline.Pipe(extracted, s.Scan, scanned)
+	s.ScanAndFlush(extracted, scanned)
 	pipeline.Pipe(scanned, secrets.RiskFromScanResult, out)
 
 	return out.Wait()

--- a/pkg/modules/gcp/recon/find_secrets.go
+++ b/pkg/modules/gcp/recon/find_secrets.go
@@ -109,7 +109,7 @@ func (m *GCPFindSecretsModule) Run(_ plugin.Config, out *pipeline.P[model.Aureli
 
 	// Scan for secrets.
 	scanned := pipeline.New[secrets.SecretScanResult]()
-	pipeline.Pipe(extracted, s.Scan, scanned)
+	s.ScanAndFlush(extracted, scanned)
 	pipeline.Pipe(scanned, secrets.RiskFromScanResult, out)
 
 	return out.Wait()

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -64,6 +64,19 @@ func (e *P[T]) Close() {
 	})
 }
 
+// CloseWithError records err as the pipeline's error and then closes it, so a
+// downstream Wait() observes the failure. Use it when a producer needs to
+// propagate an error from a stage it consumed (e.g. a wrapped sub-pipeline)
+// onto the pipeline it owns. A nil err is equivalent to Close. Like Close it is
+// safe to call multiple times; only the first call takes effect.
+func (e *P[T]) CloseWithError(err error) {
+	e.closeOnce.Do(func() {
+		e.err = err
+		close(e.ch)
+		close(e.done)
+	})
+}
+
 // Wait blocks until the producer signals completion and returns its error.
 func (e *P[T]) Wait() error {
 	<-e.done

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -39,6 +39,31 @@ func TestEmitter_ErrorPropagation(t *testing.T) {
 	require.Error(t, e.Wait())
 }
 
+func TestEmitter_CloseWithError(t *testing.T) {
+	e := New[int]()
+	sentinel := errors.New("boom")
+	go func() {
+		e.Send(1)
+		e.CloseWithError(sentinel)
+	}()
+
+	for range e.Range() {
+	}
+
+	assert.ErrorIs(t, e.Wait(), sentinel, "CloseWithError must surface the error via Wait")
+}
+
+func TestEmitter_CloseWithError_NilIsCleanClose(t *testing.T) {
+	e := New[int]()
+	go func() {
+		e.Send(1)
+		e.CloseWithError(nil)
+	}()
+	for range e.Range() {
+	}
+	assert.NoError(t, e.Wait(), "CloseWithError(nil) behaves like a normal Close")
+}
+
 func TestPipe(t *testing.T) {
 	in := From(1, 2, 3)
 	out := New[string]()

--- a/pkg/secrets/scanner.go
+++ b/pkg/secrets/scanner.go
@@ -152,7 +152,7 @@ func (s *SecretScanner) Flush(out *pipeline.P[SecretScanResult]) error {
 
 	matches, err := s.ps.drainTimedOut()
 	if err != nil {
-		return fmt.Errorf("failed to drain timed-out matches: %w", err)
+		return fmt.Errorf("flush: %w", err)
 	}
 
 	for _, match := range matches {
@@ -179,6 +179,7 @@ func (s *SecretScanner) scanInputFor(blobID types.BlobID) output.ScanInput {
 	}
 	ext, ok := prov.(types.ExtendedProvenance)
 	if !ok {
+		slog.Warn("unexpected provenance type for recovered match", "blob", blobID.Hex(), "type", fmt.Sprintf("%T", prov))
 		return output.ScanInput{}
 	}
 	return scanInputFromProvenance(ext)

--- a/pkg/secrets/scanner.go
+++ b/pkg/secrets/scanner.go
@@ -90,18 +90,7 @@ func (s *SecretScanner) Scan(input output.ScanInput, out *pipeline.P[SecretScanR
 	}
 
 	blobID := types.ComputeBlobID(input.Content)
-	provenance := types.ExtendedProvenance{
-		Payload: map[string]any{
-			"platform":      input.Platform,
-			"resource_id":   input.ResourceID,
-			"resource_type": input.ResourceType,
-			"region":        input.Region,
-			"account_id":    input.AccountID,
-			"subresource":   input.Label,
-		},
-	}
-
-	matches, err := s.ps.scanContent(input.Content, blobID, provenance)
+	matches, err := s.ps.scanContent(input.Content, blobID, provenanceFromScanInput(input))
 	if err != nil {
 		slog.Warn("failed to scan content for secrets", "resource", input.ResourceID, "label", input.Label, "error", err)
 		return nil
@@ -167,44 +156,32 @@ func (s *SecretScanner) Flush(out *pipeline.P[SecretScanResult]) error {
 	}
 
 	for _, match := range matches {
+		// Recovered matches do not carry the original ScanInput; reconstruct it
+		// from the provenance stored at scan time so validation and the emitted
+		// result get the same resource metadata as the immediate-match path.
+		input := s.scanInputFor(match.BlobID)
 		if s.validate && s.engine != nil {
-			s.validateMatch(match, match.RuleID)
+			s.validateMatch(match, input.ResourceID)
 		}
-		out.Send(s.drainedToScanResult(match))
+		out.Send(toScanResult(input, match))
 	}
 	return nil
 }
 
-// drainedToScanResult builds a SecretScanResult for a recovered match.
-// Recovered matches do not carry the original ScanInput, so the resource
-// metadata is reconstructed from the ExtendedProvenance stored at scan time and
-// fed through the same toScanResult constructor as immediate matches — keeping a
-// single place that maps metadata onto SecretScanResult.
-func (s *SecretScanner) drainedToScanResult(match *types.Match) SecretScanResult {
-	input := output.ScanInput{}
-
-	prov, err := s.ps.store.GetProvenance(match.BlobID)
+// scanInputFor reconstructs the ScanInput for a recovered match from the
+// ExtendedProvenance stored when the blob was first scanned. Returns a zero
+// ScanInput (and logs) if provenance is unavailable.
+func (s *SecretScanner) scanInputFor(blobID types.BlobID) output.ScanInput {
+	prov, err := s.ps.store.GetProvenance(blobID)
 	if err != nil {
-		slog.Warn("failed to load provenance for recovered match", "blob", match.BlobID.Hex(), "error", err)
-		return toScanResult(input, match)
+		slog.Warn("failed to load provenance for recovered match", "blob", blobID.Hex(), "error", err)
+		return output.ScanInput{}
 	}
-
-	if ext, ok := prov.(types.ExtendedProvenance); ok {
-		str := func(key string) string {
-			if v, ok := ext.Payload[key].(string); ok {
-				return v
-			}
-			return ""
-		}
-		input.Platform = str("platform")
-		input.ResourceID = str("resource_id")
-		input.ResourceType = str("resource_type")
-		input.Region = str("region")
-		input.AccountID = str("account_id")
-		input.Label = str("subresource")
+	ext, ok := prov.(types.ExtendedProvenance)
+	if !ok {
+		return output.ScanInput{}
 	}
-
-	return toScanResult(input, match)
+	return scanInputFromProvenance(ext)
 }
 
 // validateMatch runs the validation engine against a match, populating its ValidationResult.
@@ -226,5 +203,39 @@ func toScanResult(input output.ScanInput, match *types.Match) SecretScanResult {
 		Platform:     input.Platform,
 		Label:        input.Label,
 		Match:        match,
+	}
+}
+
+// provenanceFromScanInput and scanInputFromProvenance are inverses: they map a
+// ScanInput's resource metadata to/from the ExtendedProvenance payload stored
+// with each blob. Keeping the payload key set in this one pair prevents the
+// scan-time and drain-time sides from drifting and silently losing metadata.
+func provenanceFromScanInput(input output.ScanInput) types.ExtendedProvenance {
+	return types.ExtendedProvenance{
+		Payload: map[string]any{
+			"platform":      input.Platform,
+			"resource_id":   input.ResourceID,
+			"resource_type": input.ResourceType,
+			"region":        input.Region,
+			"account_id":    input.AccountID,
+			"subresource":   input.Label,
+		},
+	}
+}
+
+func scanInputFromProvenance(prov types.ExtendedProvenance) output.ScanInput {
+	str := func(key string) string {
+		if v, ok := prov.Payload[key].(string); ok {
+			return v
+		}
+		return ""
+	}
+	return output.ScanInput{
+		Platform:     str("platform"),
+		ResourceID:   str("resource_id"),
+		ResourceType: str("resource_type"),
+		Region:       str("region"),
+		AccountID:    str("account_id"),
+		Label:        str("subresource"),
 	}
 }

--- a/pkg/secrets/scanner.go
+++ b/pkg/secrets/scanner.go
@@ -129,13 +129,22 @@ func (s *SecretScanner) ScanAndFlush(in *pipeline.P[output.ScanInput], out *pipe
 	pipeline.Pipe(in, s.Scan, scanned, opts...)
 
 	go func() {
+		// Safety net: guarantees out is closed even if a stage below panics.
+		// No-op once CloseWithError/Close has already run (guarded by closeOnce).
 		defer out.Close()
+
 		for item := range scanned.Range() {
 			out.Send(item)
 		}
-		// Scan never returns an error (it logs and continues), so the scan
-		// stage cannot fail; drain the queue once all inputs are scanned.
-		_ = scanned.Wait()
+		// s.Scan itself never errors, but pipeline.Pipe records any upstream
+		// stage failure (e.g. a cloud lister/extractor) on the scanned stream
+		// via in.Wait(). Propagate it to out so the module reports failure
+		// instead of silent partial success.
+		if err := scanned.Wait(); err != nil {
+			out.CloseWithError(err)
+			return
+		}
+		// Drain the timed-out retry queue once all inputs are scanned.
 		if err := s.Flush(out); err != nil {
 			slog.Warn("failed to flush timed-out secret matches", "error", err)
 		}
@@ -166,35 +175,36 @@ func (s *SecretScanner) Flush(out *pipeline.P[SecretScanResult]) error {
 	return nil
 }
 
-// drainedToScanResult builds a SecretScanResult for a recovered match,
-// reconstructing the resource metadata from the provenance stored at scan time.
+// drainedToScanResult builds a SecretScanResult for a recovered match.
+// Recovered matches do not carry the original ScanInput, so the resource
+// metadata is reconstructed from the ExtendedProvenance stored at scan time and
+// fed through the same toScanResult constructor as immediate matches — keeping a
+// single place that maps metadata onto SecretScanResult.
 func (s *SecretScanner) drainedToScanResult(match *types.Match) SecretScanResult {
-	result := SecretScanResult{Match: match}
+	input := output.ScanInput{}
 
 	prov, err := s.ps.store.GetProvenance(match.BlobID)
 	if err != nil {
 		slog.Warn("failed to load provenance for recovered match", "blob", match.BlobID.Hex(), "error", err)
-		return result
+		return toScanResult(input, match)
 	}
 
-	ext, ok := prov.(types.ExtendedProvenance)
-	if !ok {
-		return result
-	}
-
-	str := func(key string) string {
-		if v, ok := ext.Payload[key].(string); ok {
-			return v
+	if ext, ok := prov.(types.ExtendedProvenance); ok {
+		str := func(key string) string {
+			if v, ok := ext.Payload[key].(string); ok {
+				return v
+			}
+			return ""
 		}
-		return ""
+		input.Platform = str("platform")
+		input.ResourceID = str("resource_id")
+		input.ResourceType = str("resource_type")
+		input.Region = str("region")
+		input.AccountID = str("account_id")
+		input.Label = str("subresource")
 	}
-	result.ResourceRef = str("resource_id")
-	result.ResourceType = str("resource_type")
-	result.Region = str("region")
-	result.AccountID = str("account_id")
-	result.Platform = str("platform")
-	result.Label = str("subresource")
-	return result
+
+	return toScanResult(input, match)
 }
 
 // validateMatch runs the validation engine against a match, populating its ValidationResult.

--- a/pkg/secrets/scanner.go
+++ b/pkg/secrets/scanner.go
@@ -116,6 +116,87 @@ func (s *SecretScanner) Scan(input output.ScanInput, out *pipeline.P[SecretScanR
 	return nil
 }
 
+// ScanAndFlush runs Scan over every input and then flushes any timed-out retry
+// matches into the same output pipeline, closing out when complete. It is a
+// drop-in replacement for `pipeline.Pipe(in, s.Scan, out, opts...)` that also
+// drains Titus' deferred-retry queue, so secrets that hit the regexp timeout
+// path are not silently dropped. Like pipeline.Pipe it returns immediately and
+// runs asynchronously, closing out when done. The drain runs only after every
+// Scan has completed, since the matcher's queue is shared across all scanned
+// blobs.
+func (s *SecretScanner) ScanAndFlush(in *pipeline.P[output.ScanInput], out *pipeline.P[SecretScanResult], opts ...*pipeline.PipeOpts) {
+	scanned := pipeline.New[SecretScanResult]()
+	pipeline.Pipe(in, s.Scan, scanned, opts...)
+
+	go func() {
+		defer out.Close()
+		for item := range scanned.Range() {
+			out.Send(item)
+		}
+		// Scan never returns an error (it logs and continues), so the scan
+		// stage cannot fail; drain the queue once all inputs are scanned.
+		_ = scanned.Wait()
+		if err := s.Flush(out); err != nil {
+			slog.Warn("failed to flush timed-out secret matches", "error", err)
+		}
+	}()
+}
+
+// Flush recovers matches that hit Titus' regexp timeout retry path and emits
+// them to the output pipeline. Titus withholds such matches from the per-blob
+// Scan results and queues them behind the matcher's drain; without Flush they
+// are silently dropped. Call once after all Scan calls have completed and
+// before the output pipeline is closed.
+func (s *SecretScanner) Flush(out *pipeline.P[SecretScanResult]) error {
+	if s.ps == nil {
+		return nil
+	}
+
+	matches, err := s.ps.drainTimedOut()
+	if err != nil {
+		return fmt.Errorf("failed to drain timed-out matches: %w", err)
+	}
+
+	for _, match := range matches {
+		if s.validate && s.engine != nil {
+			s.validateMatch(match, match.RuleID)
+		}
+		out.Send(s.drainedToScanResult(match))
+	}
+	return nil
+}
+
+// drainedToScanResult builds a SecretScanResult for a recovered match,
+// reconstructing the resource metadata from the provenance stored at scan time.
+func (s *SecretScanner) drainedToScanResult(match *types.Match) SecretScanResult {
+	result := SecretScanResult{Match: match}
+
+	prov, err := s.ps.store.GetProvenance(match.BlobID)
+	if err != nil {
+		slog.Warn("failed to load provenance for recovered match", "blob", match.BlobID.Hex(), "error", err)
+		return result
+	}
+
+	ext, ok := prov.(types.ExtendedProvenance)
+	if !ok {
+		return result
+	}
+
+	str := func(key string) string {
+		if v, ok := ext.Payload[key].(string); ok {
+			return v
+		}
+		return ""
+	}
+	result.ResourceRef = str("resource_id")
+	result.ResourceType = str("resource_type")
+	result.Region = str("region")
+	result.AccountID = str("account_id")
+	result.Platform = str("platform")
+	result.Label = str("subresource")
+	return result
+}
+
 // validateMatch runs the validation engine against a match, populating its ValidationResult.
 func (s *SecretScanner) validateMatch(match *types.Match, resourceID string) {
 	result, err := s.engine.ValidateMatch(context.Background(), match)

--- a/pkg/secrets/scanner_test.go
+++ b/pkg/secrets/scanner_test.go
@@ -577,3 +577,247 @@ func TestSecretScanner_ScanSkipsMultipleIgnoredPaths(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Timed-out retry drain tests
+//
+// Titus v1.2+ defers matches that hit the regexp timeout retry path: they are
+// withheld from MatchWithBlobID and only recoverable via Matcher.DrainTimedOut.
+// These tests guarantee Aurelian drains that queue so those secrets are not
+// silently dropped.
+// ---------------------------------------------------------------------------
+
+// fakeMatcher implements matcher.Matcher and lets a test control exactly which
+// matches surface from MatchWithBlobID vs. the deferred DrainTimedOut queue.
+type fakeMatcher struct {
+	immediate    []*types.Match
+	queued       []*types.Match // surfaced once, via DrainTimedOut
+	drainErr     error
+	drainedCalls int
+}
+
+func (f *fakeMatcher) Match(content []byte) ([]*types.Match, error) {
+	return f.immediate, nil
+}
+
+func (f *fakeMatcher) MatchWithBlobID(content []byte, blobID types.BlobID) ([]*types.Match, error) {
+	return f.immediate, nil
+}
+
+// DrainTimedOut returns the queued matches once, mirroring the real matcher
+// which empties its retry queue on drain.
+func (f *fakeMatcher) DrainTimedOut() ([]*types.Match, error) {
+	f.drainedCalls++
+	q := f.queued
+	f.queued = nil
+	return q, f.drainErr
+}
+
+func (f *fakeMatcher) Close() error { return nil }
+
+func TestPersistentScanner_DrainTimedOut_StoresAndReturnsRecoveredMatches(t *testing.T) {
+	s := startScanner(t)
+
+	// Scan real content so a blob and a real rule match are registered in the
+	// store; the drained match must reference an existing blob + known rule.
+	content := []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF")
+	blobID := types.ComputeBlobID(content)
+	provenance := types.FileProvenance{FilePath: "creds.txt"}
+
+	real, err := s.ps.scanContent(content, blobID, provenance)
+	require.NoError(t, err)
+	require.NotEmpty(t, real, "fixture scan should produce at least one real match to borrow a RuleID from")
+	ruleID := real[0].RuleID
+
+	// Build a recovered match that the matcher only surfaces via DrainTimedOut.
+	recovered := &types.Match{
+		BlobID:   blobID,
+		RuleID:   ruleID,
+		RuleName: real[0].RuleName,
+		Groups:   [][]byte{[]byte("AKIADEADBEEFDEADBEEF_retry")},
+		Snippet: types.Snippet{
+			Matching: []byte("AKIADEADBEEFDEADBEEF"),
+		},
+	}
+
+	fake := &fakeMatcher{queued: []*types.Match{recovered}}
+	s.ps.matcher = fake
+
+	drained, err := s.ps.drainTimedOut()
+	require.NoError(t, err, "drainTimedOut should succeed")
+	require.Equal(t, 1, fake.drainedCalls, "drainTimedOut must call the matcher's DrainTimedOut")
+	require.Len(t, drained, 1, "recovered match should be returned, not dropped")
+
+	// The recovered match must be persisted (with a finding), exactly like an
+	// immediate match would be.
+	stored, err := s.ps.store.GetMatches(blobID)
+	require.NoError(t, err)
+	var found bool
+	for _, m := range stored {
+		for _, g := range m.Groups {
+			if string(g) == "AKIADEADBEEFDEADBEEF_retry" {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "recovered match should be persisted to the store")
+}
+
+func TestPersistentScanner_DrainTimedOut_PropagatesMatcherError(t *testing.T) {
+	s := startScanner(t)
+
+	s.ps.matcher = &fakeMatcher{drainErr: assert.AnError}
+
+	_, err := s.ps.drainTimedOut()
+	require.Error(t, err, "drain error from the matcher must surface, not be swallowed")
+}
+
+func TestSecretScanner_Flush_EmitsRecoveredMatches(t *testing.T) {
+	s := startScanner(t)
+
+	// Register a blob and borrow a real RuleID, as above.
+	content := []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF")
+	blobID := types.ComputeBlobID(content)
+	real, err := s.ps.scanContent(content, blobID, types.FileProvenance{FilePath: "creds.txt"})
+	require.NoError(t, err)
+	require.NotEmpty(t, real)
+
+	recovered := &types.Match{
+		BlobID:   blobID,
+		RuleID:   real[0].RuleID,
+		RuleName: real[0].RuleName,
+		Groups:   [][]byte{[]byte("AKIADEADBEEFDEADBEEF_retry")},
+		Snippet:  types.Snippet{Matching: []byte("AKIADEADBEEFDEADBEEF")},
+	}
+	s.ps.matcher = &fakeMatcher{queued: []*types.Match{recovered}}
+
+	out := pipeline.New[SecretScanResult]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, s.Flush(out))
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	require.Len(t, items, 1, "Flush must emit recovered matches to the output pipeline")
+	assert.Same(t, recovered, items[0].Match, "emitted result should carry the recovered match")
+}
+
+func TestSecretScanner_Flush_NoScannerIsNoOp(t *testing.T) {
+	var s SecretScanner
+	out := pipeline.New[SecretScanResult]()
+	go func() {
+		defer out.Close()
+		assert.NoError(t, s.Flush(out), "Flush before Start should be a safe no-op")
+	}()
+	items, err := out.Collect()
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+// TestSecretScanner_Flush_EmptyDrainEmitsNothing covers the common case: a scan
+// with zero timeouts. Flush must drain an empty queue, emit nothing, and close
+// cleanly. This path runs on virtually every real scan.
+func TestSecretScanner_Flush_EmptyDrainEmitsNothing(t *testing.T) {
+	s := startScanner(t)
+	s.ps.matcher = &fakeMatcher{} // no queued matches
+
+	out := pipeline.New[SecretScanResult]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, s.Flush(out))
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	assert.Empty(t, items, "Flush with no timed-out matches must emit nothing")
+}
+
+// TestSecretScanner_Flush_EmitsRecoveredMatchEvenWhenProvenanceMissing pins the
+// fix's core guarantee: a recovered match is never dropped. Even when provenance
+// lookup yields no usable metadata, the match must still be emitted (just
+// without resource attribution) rather than silently discarded.
+func TestSecretScanner_Flush_EmitsRecoveredMatchEvenWhenProvenanceMissing(t *testing.T) {
+	s := startScanner(t)
+
+	// A recovered match for a blob that was never scanned, so the store has no
+	// provenance for it.
+	unknownBlob := types.ComputeBlobID([]byte("never-scanned-content"))
+	content := []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF")
+	real, err := s.ps.scanContent(content, types.ComputeBlobID(content), types.FileProvenance{FilePath: "x.txt"})
+	require.NoError(t, err)
+	require.NotEmpty(t, real)
+
+	recovered := &types.Match{
+		BlobID:   unknownBlob,
+		RuleID:   real[0].RuleID,
+		RuleName: real[0].RuleName,
+		Groups:   [][]byte{[]byte("AKIADEADBEEFDEADBEEF_orphan")},
+		Snippet:  types.Snippet{Matching: []byte("AKIADEADBEEFDEADBEEF")},
+	}
+	// AddBlob so storeMatchAndFinding's FK is satisfied, but add NO provenance.
+	require.NoError(t, s.ps.store.AddBlob(unknownBlob, int64(len(content))))
+	s.ps.matcher = &fakeMatcher{queued: []*types.Match{recovered}}
+
+	out := pipeline.New[SecretScanResult]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, s.Flush(out))
+	}()
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+	require.Len(t, items, 1, "recovered match must still be emitted when provenance is missing")
+	assert.Same(t, recovered, items[0].Match, "the recovered match itself must survive")
+	assert.Empty(t, items[0].ResourceRef, "metadata is absent without provenance, but the match is not dropped")
+}
+
+func TestSecretScanner_ScanAndFlush_EmitsBothImmediateAndRecovered(t *testing.T) {
+	s := startScanner(t)
+
+	// Register the blob so the recovered match references an existing blob, and
+	// borrow a real RuleID. Scan via the public path so provenance is stored.
+	content := []byte("aws_access_key_id=AKIADEADBEEFDEADBEEF")
+	blobID := types.ComputeBlobID(content)
+	input := output.ScanInput{
+		Content:      content,
+		ResourceID:   "arn:aws:lambda:us-east-1:123456789012:function:demo",
+		ResourceType: "AWS::Lambda::Function",
+		Region:       "us-east-1",
+		AccountID:    "123456789012",
+		Label:        "handler.py",
+	}
+
+	// Prime the store + capture a real RuleID by scanning once directly.
+	real, err := s.ps.scanContent(content, blobID, types.ExtendedProvenance{Payload: map[string]any{
+		"resource_id": input.ResourceID, "subresource": input.Label,
+	}})
+	require.NoError(t, err)
+	require.NotEmpty(t, real)
+
+	recovered := &types.Match{
+		BlobID:   blobID,
+		RuleID:   real[0].RuleID,
+		RuleName: real[0].RuleName,
+		Groups:   [][]byte{[]byte("AKIADEADBEEFDEADBEEF_retry")},
+		Snippet:  types.Snippet{Matching: []byte("AKIADEADBEEFDEADBEEF")},
+	}
+	s.ps.matcher = &fakeMatcher{immediate: real, queued: []*types.Match{recovered}}
+
+	in := pipeline.From(input)
+	out := pipeline.New[SecretScanResult]()
+	s.ScanAndFlush(in, out)
+
+	items, err := out.Collect()
+	require.NoError(t, err)
+
+	var sawRecovered bool
+	for _, it := range items {
+		if it.Match == recovered {
+			sawRecovered = true
+			assert.Equal(t, input.ResourceID, it.ResourceRef, "recovered result should carry resource metadata from stored provenance")
+		}
+	}
+	assert.True(t, sawRecovered, "ScanAndFlush must emit the recovered (timed-out) match")
+	assert.GreaterOrEqual(t, len(items), 2, "should emit both the immediate match(es) and the recovered match")
+}

--- a/pkg/secrets/scanner_test.go
+++ b/pkg/secrets/scanner_test.go
@@ -851,3 +851,27 @@ func TestSecretScanner_ScanAndFlush_PropagatesUpstreamError(t *testing.T) {
 	_, err := out.Collect()
 	require.ErrorIs(t, err, upstreamErr, "upstream pipeline error must propagate to out, not be discarded")
 }
+
+// TestProvenanceScanInputRoundTrip pins the invariant that the provenance
+// payload key set lives in exactly one place: a ScanInput written to provenance
+// at scan time must reconstruct identically on the drain path. If the two sides
+// ever drift, recovered matches silently lose resource metadata.
+func TestProvenanceScanInputRoundTrip(t *testing.T) {
+	input := output.ScanInput{
+		Platform:     "aws",
+		ResourceID:   "arn:aws:lambda:us-east-1:123456789012:function:demo",
+		ResourceType: "AWS::Lambda::Function",
+		Region:       "us-east-1",
+		AccountID:    "123456789012",
+		Label:        "handler.py",
+	}
+
+	got := scanInputFromProvenance(provenanceFromScanInput(input))
+
+	assert.Equal(t, input.Platform, got.Platform)
+	assert.Equal(t, input.ResourceID, got.ResourceID)
+	assert.Equal(t, input.ResourceType, got.ResourceType)
+	assert.Equal(t, input.Region, got.Region)
+	assert.Equal(t, input.AccountID, got.AccountID)
+	assert.Equal(t, input.Label, got.Label)
+}

--- a/pkg/secrets/scanner_test.go
+++ b/pkg/secrets/scanner_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -820,4 +821,33 @@ func TestSecretScanner_ScanAndFlush_EmitsBothImmediateAndRecovered(t *testing.T)
 	}
 	assert.True(t, sawRecovered, "ScanAndFlush must emit the recovered (timed-out) match")
 	assert.GreaterOrEqual(t, len(items), 2, "should emit both the immediate match(es) and the recovered match")
+}
+
+// TestSecretScanner_ScanAndFlush_PropagatesUpstreamError guards against the P1
+// regression: when an upstream stage feeding ScanAndFlush fails (e.g. a cloud
+// lister or extractor errors), that failure must reach the output pipeline so
+// the module reports failure rather than silent partial success.
+func TestSecretScanner_ScanAndFlush_PropagatesUpstreamError(t *testing.T) {
+	s := startScanner(t)
+	s.ps.matcher = &fakeMatcher{}
+
+	upstreamErr := errors.New("extractor blew up")
+
+	// An input pipeline that emits one item then fails, mimicking pipeline.Pipe
+	// recording an upstream error on the stream feeding ScanAndFlush.
+	in := pipeline.New[output.ScanInput]()
+	go func() {
+		in.Send(output.ScanInput{
+			Content:    []byte("nothing sensitive"),
+			ResourceID: "arn:aws:s3:::demo",
+			Label:      "a.txt",
+		})
+		in.CloseWithError(upstreamErr)
+	}()
+
+	out := pipeline.New[SecretScanResult]()
+	s.ScanAndFlush(in, out)
+
+	_, err := out.Collect()
+	require.ErrorIs(t, err, upstreamErr, "upstream pipeline error must propagate to out, not be discarded")
 }

--- a/pkg/secrets/titus.go
+++ b/pkg/secrets/titus.go
@@ -136,6 +136,30 @@ func (ps *persistentScanner) scanContent(content []byte, blobID types.BlobID, pr
 	return matches, nil
 }
 
+// drainTimedOut recovers matches that hit Titus' regexp timeout retry path.
+// Such matches are withheld from MatchWithBlobID and queued behind the
+// matcher's DrainTimedOut; without draining they are silently dropped. Each
+// recovered match is persisted (with its finding) exactly like an immediate
+// match and returned to the caller.
+//
+// Must be called after all scanContent calls have completed, since the matcher
+// drains a queue shared across every blob scanned.
+func (ps *persistentScanner) drainTimedOut() ([]*types.Match, error) {
+	matches, err := ps.matcher.DrainTimedOut()
+	if err != nil {
+		return nil, fmt.Errorf("failed to drain timed-out matches: %w", err)
+	}
+
+	for _, match := range matches {
+		if err := ps.storeMatchAndFinding(match); err != nil {
+			return nil, err
+		}
+	}
+	ps.populateFindingIDs(matches)
+
+	return matches, nil
+}
+
 func (ps *persistentScanner) storeMatchAndFinding(match *types.Match) error {
 	if err := ps.store.AddMatch(match); err != nil {
 		return fmt.Errorf("failed to store match: %w", err)


### PR DESCRIPTION
## Summary

Addresses the Codex P2 review finding on #239: after the Titus v1.2.6 bump, matches that hit the regexp timeout retry path are withheld from `MatchWithBlobID` and queued behind `Matcher.DrainTimedOut`. The persistent scanner only stored immediate results and closed the matcher without draining, so those recovered secrets were **silently dropped** — secrets in large or regex-heavy blobs could be missed.

This branch targets #239 directly so the bump and the fix land together (the `DrainTimedOut` API does not exist in the pre-bump Titus version).

## Changes

- `persistentScanner.drainTimedOut()` — recovers queued matches, persists each (with its finding) via the existing store path, returns them.
- `SecretScanner.Flush(out)` — emits recovered matches to the pipeline, reconstructing resource metadata from the provenance stored at scan time. Safe no-op before `Start`.
- `SecretScanner.ScanAndFlush(in, out, opts)` — drop-in replacement for `pipeline.Pipe(in, s.Scan, out)` that drains **once** after all blobs are scanned (the matcher's retry queue is shared across blobs).
- Wired `ScanAndFlush` into the AWS/Azure/GCP `find_secrets` modules.

## Verification

- **Unit:** 261 tests pass across impacted packages (59 in `pkg/secrets`, race-clean). New tests cover drain/store/return, error propagation, empty-drain no-op, provenance-missing fallback, and the full scan+flush pipeline — each verified to fail against a deliberately-broken implementation before passing.
- **Live E2E:** `TestAWSFindSecrets` (8 AWS resource types with planted secrets) passes 13/13 under both `sandbox-admin` (fixture provisioning) and `sandbox-read-only` (least-privilege module run), against the real S3 backend.
- **Correctness chain:** Titus's withhold-on-timeout + 30s retry pass verified directly against the real matcher; recovery behavior is covered upstream by Titus's own `TestPortableRegexp_TimedOutBlobsAreRetried`. Our change is the adapter that forwards drained matches through the existing store/validate/emit pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)