### PR TITLE
Enumerate AWS RAM resource shares via list-all

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse v0.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
-	github.com/aws/aws-sdk-go-v2 v1.42.0
+	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/account v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/amplify v1.38.13
@@ -65,6 +65,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/opensearch v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.50.2
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoice v1.29.13
+	github.com/aws/aws-sdk-go-v2/service/ram v1.38.1
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.236.1
@@ -74,7 +75,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.13
-	github.com/aws/smithy-go v1.27.1
+	github.com/aws/smithy-go v1.27.3
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fatih/color v1.18.0
@@ -228,8 +229,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNx
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
-github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
+github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
+github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.32.7 h1:vxUyWGUwmkQ2g19n7JY/9YL8MfAIl7bTesIUykECXmY=
@@ -118,10 +118,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.7 h1:tHK47VqqtJxOymRrNtUXN5SP/zUT
 github.com/aws/aws-sdk-go-v2/credentials v1.19.7/go.mod h1:qOZk8sPDrxhf+4Wf4oT2urYJrYt3RejHSzgAquYeppw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 h1:I0GyV8wiYrP8XpA70g1HBcQO1JlQxCMTW9npl5UbDHY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17/go.mod h1:tyw7BOl5bBe/oqvoIeECFJjMdzXoa/dfVz3QQ5lgHGA=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 h1:xM/Is9cKMHa8Jj8zkvWhvrFkZsXJV9E+BB4g0HW0duQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30/go.mod h1:WueJeNDZvK1fMYEWJIkcivBfEzUkTpBhzlrUKKY8EuA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 h1:jn46zC9LdsVR/ZpMIJqMqb8hHv31BlLx3ulVqNspUOk=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30/go.mod h1:1hTMsAgbdS/AtUi4bw8+gUuh1pceo+eXRLfpSuSQj3M=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
@@ -190,6 +190,8 @@ github.com/aws/aws-sdk-go-v2/service/organizations v1.50.2 h1:D64FjbJyjIRYLpMdNc
 github.com/aws/aws-sdk-go-v2/service/organizations v1.50.2/go.mod h1:6WyPYQBJwPA/71gHpvO2f5O7yxn1uQZBm600CiXno1s=
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoice v1.29.13 h1:m8sRsdPjINDHSCi958X6Fwy+75rpBhtF8XZp74pBGZo=
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoice v1.29.13/go.mod h1:teLhY/slKP/G6iw7y/+WFtqDdvONbLvZPN36M7ThA+w=
+github.com/aws/aws-sdk-go-v2/service/ram v1.38.1 h1:5/ZpVot41QqvEAaHr+rao4PMyVnVxyVJLxzf8g1g5J8=
+github.com/aws/aws-sdk-go-v2/service/ram v1.38.1/go.mod h1:aB4kUwB+6oHNxZWrmnal4DFYcOW+4Yo+ePVdrb/M7sk=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.3 h1:JRPXnIr0WwFsSHBmuCvT/uh0Vgys+crvwkOghbJEqi8=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.62.3/go.mod h1:DHddp7OO4bY467WVCqWBzk5+aEWn7vqYkap7UigJzGk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP1VyQpy15qWh1Pk=
@@ -214,8 +216,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 h1:5fFjR/ToSOzB2OQ/XqWpZBmNvmP/
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.6/go.mod h1:qgFDZQSD/Kys7nJnVqYlWKnh0SSdMjAi0uSwON4wgYQ=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.13 h1:Iu9ue+m7Ff/7S/QckPSB2kqkKHziyCwr/4DNuVvsCaE=
 github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.36.13/go.mod h1:CL79M20C9MGo2r0/MT7i9OcM/RY25wfNz043aG2fBvw=
-github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
-github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
+github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/pkg/aws/enumeration/enumerator.go
+++ b/pkg/aws/enumeration/enumerator.go
@@ -85,6 +85,7 @@ func NewEnumeratorWithProvider(opts plugin.AWSCommonRecon, provider *AWSConfigPr
 	e.Register(NewSSMParameterEnumerator(opts, provider, skipReport))
 	e.Register(NewOpenSearchDomainEnumerator(opts, provider, skipReport))
 	e.Register(NewClassicELBEnumerator(opts, provider, skipReport))
+	e.Register(NewRAMResourceShareEnumerator(opts, provider, skipReport))
 
 	return e
 }

--- a/pkg/aws/enumeration/enumerator_test.go
+++ b/pkg/aws/enumeration/enumerator_test.go
@@ -10,6 +10,7 @@ import (
 	smithy "github.com/aws/smithy-go"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,6 +95,19 @@ func TestEnumerator_List_InvalidIdentifier(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "identifier must be either an ARN or CloudControl resource type")
+}
+
+func TestNewEnumerator_RegistersRAMResourceShare(t *testing.T) {
+	e := NewEnumerator(plugin.AWSCommonRecon{Regions: []string{"us-east-1"}, Concurrency: 1})
+	defer func() { _ = e.Close() }()
+
+	enum, ok := e.enumerators["AWS::RAM::ResourceShare"]
+	if !ok {
+		t.Fatal("expected AWS::RAM::ResourceShare to be registered on the dispatcher")
+	}
+	if got := enum.ResourceType(); got != "AWS::RAM::ResourceShare" {
+		t.Errorf("registered enumerator ResourceType() = %q, want AWS::RAM::ResourceShare", got)
+	}
 }
 
 func TestEnumerator_enumerateByType_DispatchesSSMToRegisteredEnumerator(t *testing.T) {

--- a/pkg/aws/enumeration/ram_resourceshare_enumerator.go
+++ b/pkg/aws/enumeration/ram_resourceshare_enumerator.go
@@ -1,10 +1,20 @@
 package enumeration
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ram"
 	ramtypes "github.com/aws/aws-sdk-go-v2/service/ram/types"
 	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/pkg/ratelimit"
 )
 
 // RAMResourceShareEnumerator enumerates AWS RAM resource shares owned by the
@@ -75,4 +85,131 @@ func buildResourceShareResource(share ramtypes.ResourceShare, principals, resour
 			"ResourceArns":            resourceArns,
 		},
 	}
+}
+
+// EnumerateAll enumerates all RAM resource shares owned by the account
+// (ResourceOwner=SELF) across configured regions.
+func (l *RAMResourceShareEnumerator) EnumerateAll(out *pipeline.P[output.AWSResource]) error {
+	if len(l.Regions) == 0 {
+		return fmt.Errorf("no regions configured")
+	}
+
+	accountID, err := l.provider.GetAccountID(l.Regions[0])
+	if err != nil {
+		return fmt.Errorf("get account ID: %w", err)
+	}
+
+	actor := ratelimit.NewCrossRegionActor(l.Concurrency)
+	return actor.ActInRegions(l.Regions, func(region string) error {
+		return l.listSharesInRegion(region, accountID, out)
+	})
+}
+
+func (l *RAMResourceShareEnumerator) listSharesInRegion(region, accountID string, out *pipeline.P[output.AWSResource]) error {
+	cfg, err := l.provider.GetAWSConfig(region)
+	if err != nil {
+		return fmt.Errorf("create RAM client for %s: %w", region, err)
+	}
+	client := ram.NewFromConfig(*cfg)
+
+	paginator := ram.NewGetResourceSharesPaginator(client, &ram.GetResourceSharesInput{
+		ResourceOwner: ramtypes.ResourceOwnerSelf,
+	})
+	var skipped []SkippedOp
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.Background())
+		if err != nil {
+			if op := ClassifySkippable(err, "ram", "GetResourceShares", region); op != nil {
+				skipped = append(skipped, *op)
+				break
+			}
+			return fmt.Errorf("get resource shares in %s: %w", region, err)
+		}
+		for _, share := range page.ResourceShares {
+			arn := aws.ToString(share.ResourceShareArn)
+			if arn == "" {
+				continue
+			}
+			principals := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypePrincipal, region, &skipped)
+			resources := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypeResource, region, &skipped)
+			out.Send(buildResourceShareResource(share, principals, resources, accountID, region))
+		}
+	}
+
+	l.skipReport.RecordBatch(skipped)
+	return nil
+}
+
+// associatedEntities returns the AssociatedEntity values for a share for the
+// given association type (PRINCIPAL → account/org/OU/role ARNs; RESOURCE →
+// resource ARNs). Skippable errors are appended to skipped and an empty slice
+// is returned so the share is still emitted with whatever else resolved.
+func (l *RAMResourceShareEnumerator) associatedEntities(client *ram.Client, shareArn string, assocType ramtypes.ResourceShareAssociationType, region string, skipped *[]SkippedOp) []string {
+	paginator := ram.NewGetResourceShareAssociationsPaginator(client, &ram.GetResourceShareAssociationsInput{
+		AssociationType:   assocType,
+		ResourceShareArns: []string{shareArn},
+	})
+	var entities []string
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.Background())
+		if err != nil {
+			if op := ClassifySkippable(err, "ram", "GetResourceShareAssociations", region); op != nil {
+				*skipped = append(*skipped, *op)
+				return entities
+			}
+			slog.Warn("non-skippable GetResourceShareAssociations error, emitting partial associations",
+				"share", shareArn, "type", string(assocType), "region", region, "error", err)
+			return entities
+		}
+		for _, assoc := range page.ResourceShareAssociations {
+			if e := aws.ToString(assoc.AssociatedEntity); e != "" {
+				entities = append(entities, e)
+			}
+		}
+	}
+	return entities
+}
+
+// EnumerateByARN fetches a single RAM resource share by ARN (ResourceOwner=SELF).
+func (l *RAMResourceShareEnumerator) EnumerateByARN(arn string, out *pipeline.P[output.AWSResource]) error {
+	parsed, err := awsarn.Parse(arn)
+	if err != nil {
+		return fmt.Errorf("parse ARN %q: %w", arn, err)
+	}
+	if !strings.HasPrefix(parsed.Resource, "resource-share/") {
+		return fmt.Errorf("not a RAM resource-share ARN: %q", arn)
+	}
+	if parsed.Region == "" {
+		return fmt.Errorf("RAM resource share ARN missing region: %q", arn)
+	}
+
+	cfg, err := l.provider.GetAWSConfig(parsed.Region)
+	if err != nil {
+		return fmt.Errorf("create RAM client for %s: %w", parsed.Region, err)
+	}
+	client := ram.NewFromConfig(*cfg)
+
+	resp, err := client.GetResourceShares(context.Background(), &ram.GetResourceSharesInput{
+		ResourceOwner:     ramtypes.ResourceOwnerSelf,
+		ResourceShareArns: []string{arn},
+	})
+	if err != nil {
+		if op := ClassifySkippable(err, "ram", "GetResourceShares", parsed.Region); op != nil {
+			l.skipReport.RecordBatch([]SkippedOp{*op})
+			return nil
+		}
+		return fmt.Errorf("get resource share %s: %w", arn, err)
+	}
+	if len(resp.ResourceShares) == 0 {
+		return fmt.Errorf("resource share %s not found (owner=SELF) in %s", arn, parsed.Region)
+	}
+
+	var skipped []SkippedOp
+	share := resp.ResourceShares[0]
+	principals := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypePrincipal, parsed.Region, &skipped)
+	resources := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypeResource, parsed.Region, &skipped)
+	l.skipReport.RecordBatch(skipped)
+
+	out.Send(buildResourceShareResource(share, principals, resources, parsed.AccountID, parsed.Region))
+	return nil
 }

--- a/pkg/aws/enumeration/ram_resourceshare_enumerator.go
+++ b/pkg/aws/enumeration/ram_resourceshare_enumerator.go
@@ -1,0 +1,78 @@
+package enumeration
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ramtypes "github.com/aws/aws-sdk-go-v2/service/ram/types"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+)
+
+// RAMResourceShareEnumerator enumerates AWS RAM resource shares owned by the
+// account (ResourceOwner=SELF) using the native RAM SDK. CloudControl's
+// AWS::RAM::ResourceShare read/list handlers hold only ram:GetResourceShares,
+// so they cannot populate the associated principals or resources; this
+// enumerator calls GetResourceShareAssociations directly to attach both.
+//
+// The security-relevant signal is AllowExternalPrincipals (whether the share
+// may be associated with accounts outside the owner's AWS Organization);
+// downstream evaluation cross-references the associated principals against org
+// membership. Consumer-side shares (ResourceOwner=OTHER-ACCOUNTS) are out of
+// scope for this enumerator.
+type RAMResourceShareEnumerator struct {
+	plugin.AWSCommonRecon
+	provider   *AWSConfigProvider
+	skipReport *SkipReport
+}
+
+// NewRAMResourceShareEnumerator creates a RAMResourceShareEnumerator that uses the native RAM SDK.
+func NewRAMResourceShareEnumerator(opts plugin.AWSCommonRecon, provider *AWSConfigProvider, skipReport *SkipReport) *RAMResourceShareEnumerator {
+	return &RAMResourceShareEnumerator{
+		AWSCommonRecon: opts,
+		provider:       provider,
+		skipReport:     skipReport,
+	}
+}
+
+// ResourceType returns the CloudControl type string for RAM resource shares.
+func (l *RAMResourceShareEnumerator) ResourceType() string {
+	return "AWS::RAM::ResourceShare"
+}
+
+// buildResourceShareResource maps a RAM ResourceShare plus its resolved
+// principal and resource associations to an output.AWSResource. Pure function
+// (no SDK calls) so it is unit-testable. accountID is the caller's account,
+// used only when the share omits OwningAccountId.
+func buildResourceShareResource(share ramtypes.ResourceShare, principals, resourceArns []string, accountID, region string) output.AWSResource {
+	arn := aws.ToString(share.ResourceShareArn)
+	name := aws.ToString(share.Name)
+
+	owner := aws.ToString(share.OwningAccountId)
+	if owner == "" {
+		owner = accountID
+	}
+
+	if principals == nil {
+		principals = []string{}
+	}
+	if resourceArns == nil {
+		resourceArns = []string{}
+	}
+
+	return output.AWSResource{
+		ResourceType: "AWS::RAM::ResourceShare",
+		ResourceID:   arn,
+		ARN:          arn,
+		AccountRef:   owner,
+		Region:       region,
+		DisplayName:  name,
+		Properties: map[string]any{
+			"Name":                    name,
+			"AllowExternalPrincipals": aws.ToBool(share.AllowExternalPrincipals),
+			"Status":                  string(share.Status),
+			"FeatureSet":              string(share.FeatureSet),
+			"OwningAccountId":         owner,
+			"Principals":              principals,
+			"ResourceArns":            resourceArns,
+		},
+	}
+}

--- a/pkg/aws/enumeration/ram_resourceshare_enumerator.go
+++ b/pkg/aws/enumeration/ram_resourceshare_enumerator.go
@@ -113,7 +113,8 @@ func (l *RAMResourceShareEnumerator) listSharesInRegion(region, accountID string
 	client := ram.NewFromConfig(*cfg)
 
 	paginator := ram.NewGetResourceSharesPaginator(client, &ram.GetResourceSharesInput{
-		ResourceOwner: ramtypes.ResourceOwnerSelf,
+		ResourceOwner:       ramtypes.ResourceOwnerSelf,
+		ResourceShareStatus: ramtypes.ResourceShareStatusActive,
 	})
 	var skipped []SkippedOp
 	for paginator.HasMorePages() {
@@ -147,6 +148,7 @@ func (l *RAMResourceShareEnumerator) listSharesInRegion(region, accountID string
 func (l *RAMResourceShareEnumerator) associatedEntities(client *ram.Client, shareArn string, assocType ramtypes.ResourceShareAssociationType, region string, skipped *[]SkippedOp) []string {
 	paginator := ram.NewGetResourceShareAssociationsPaginator(client, &ram.GetResourceShareAssociationsInput{
 		AssociationType:   assocType,
+		AssociationStatus: ramtypes.ResourceShareAssociationStatusAssociated,
 		ResourceShareArns: []string{shareArn},
 	})
 	var entities []string
@@ -157,8 +159,19 @@ func (l *RAMResourceShareEnumerator) associatedEntities(client *ram.Client, shar
 				*skipped = append(*skipped, *op)
 				return entities
 			}
+			// The share is still emitted with whatever resolved, but the
+			// non-skippable failure is recorded so the data gap (possibly-empty
+			// or partial principals/resources) is visible in the skip report
+			// rather than silently swallowed by a log line.
 			slog.Warn("non-skippable GetResourceShareAssociations error, emitting partial associations",
 				"share", shareArn, "type", string(assocType), "region", region, "error", err)
+			*skipped = append(*skipped, SkippedOp{
+				Region:    region,
+				Service:   "ram",
+				Operation: "GetResourceShareAssociations",
+				ErrorCode: SkipReason(err),
+				Detail:    err.Error(),
+			})
 			return entities
 		}
 		for _, assoc := range page.ResourceShareAssociations {
@@ -190,8 +203,9 @@ func (l *RAMResourceShareEnumerator) EnumerateByARN(arn string, out *pipeline.P[
 	client := ram.NewFromConfig(*cfg)
 
 	resp, err := client.GetResourceShares(context.Background(), &ram.GetResourceSharesInput{
-		ResourceOwner:     ramtypes.ResourceOwnerSelf,
-		ResourceShareArns: []string{arn},
+		ResourceOwner:       ramtypes.ResourceOwnerSelf,
+		ResourceShareStatus: ramtypes.ResourceShareStatusActive,
+		ResourceShareArns:   []string{arn},
 	})
 	if err != nil {
 		if op := ClassifySkippable(err, "ram", "GetResourceShares", parsed.Region); op != nil {

--- a/pkg/aws/enumeration/ram_resourceshare_enumerator.go
+++ b/pkg/aws/enumeration/ram_resourceshare_enumerator.go
@@ -3,7 +3,6 @@ package enumeration
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -11,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ram"
 	ramtypes "github.com/aws/aws-sdk-go-v2/service/ram/types"
+	awshelpers "github.com/praetorian-inc/aurelian/internal/helpers/aws"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/praetorian-inc/aurelian/pkg/plugin"
@@ -94,29 +94,40 @@ func (l *RAMResourceShareEnumerator) EnumerateAll(out *pipeline.P[output.AWSReso
 		return fmt.Errorf("no regions configured")
 	}
 
-	accountID, err := l.provider.GetAccountID(l.Regions[0])
-	if err != nil {
-		return fmt.Errorf("get account ID: %w", err)
-	}
-
+	// Account ID is resolved inside each region's own (already-validated) config
+	// rather than from a single prerequisite region, so one disabled region does
+	// not abort the whole enumeration. It is only used as a fallback when a share
+	// omits OwningAccountId.
 	actor := ratelimit.NewCrossRegionActor(l.Concurrency)
 	return actor.ActInRegions(l.Regions, func(region string) error {
-		return l.listSharesInRegion(region, accountID, out)
+		return l.listSharesInRegion(region, out)
 	})
 }
 
-func (l *RAMResourceShareEnumerator) listSharesInRegion(region, accountID string, out *pipeline.P[output.AWSResource]) error {
+func (l *RAMResourceShareEnumerator) listSharesInRegion(region string, out *pipeline.P[output.AWSResource]) error {
 	cfg, err := l.provider.GetAWSConfig(region)
 	if err != nil {
 		return fmt.Errorf("create RAM client for %s: %w", region, err)
 	}
+
+	var skipped []SkippedOp
+	defer func() { l.skipReport.RecordBatch(skipped) }()
+
+	accountID, err := awshelpers.GetAccountId(*cfg)
+	if err != nil {
+		if op := ClassifySkippable(err, "sts", "GetCallerIdentity", region); op != nil {
+			skipped = append(skipped, *op)
+			return nil
+		}
+		return fmt.Errorf("resolve account for %s: %w", region, err)
+	}
+
 	client := ram.NewFromConfig(*cfg)
 
 	paginator := ram.NewGetResourceSharesPaginator(client, &ram.GetResourceSharesInput{
 		ResourceOwner:       ramtypes.ResourceOwnerSelf,
 		ResourceShareStatus: ramtypes.ResourceShareStatusActive,
 	})
-	var skipped []SkippedOp
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(context.Background())
 		if err != nil {
@@ -131,21 +142,28 @@ func (l *RAMResourceShareEnumerator) listSharesInRegion(region, accountID string
 			if arn == "" {
 				continue
 			}
-			principals := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypePrincipal, region, &skipped)
-			resources := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypeResource, region, &skipped)
+			principals, err := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypePrincipal, region, &skipped)
+			if err != nil {
+				return err
+			}
+			resources, err := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypeResource, region, &skipped)
+			if err != nil {
+				return err
+			}
 			out.Send(buildResourceShareResource(share, principals, resources, accountID, region))
 		}
 	}
-
-	l.skipReport.RecordBatch(skipped)
 	return nil
 }
 
 // associatedEntities returns the AssociatedEntity values for a share for the
 // given association type (PRINCIPAL → account/org/OU/role ARNs; RESOURCE →
-// resource ARNs). Skippable errors are appended to skipped and an empty slice
-// is returned so the share is still emitted with whatever else resolved.
-func (l *RAMResourceShareEnumerator) associatedEntities(client *ram.Client, shareArn string, assocType ramtypes.ResourceShareAssociationType, region string, skipped *[]SkippedOp) []string {
+// resource ARNs). A skippable error (access denied, region unsupported) is
+// appended to skipped and the entities resolved so far are returned, so the
+// share is still emitted best-effort. A non-skippable error is returned to the
+// caller so a genuine failure aborts the region rather than silently emitting a
+// share with a misleading (partial) principals/resources set.
+func (l *RAMResourceShareEnumerator) associatedEntities(client *ram.Client, shareArn string, assocType ramtypes.ResourceShareAssociationType, region string, skipped *[]SkippedOp) ([]string, error) {
 	paginator := ram.NewGetResourceShareAssociationsPaginator(client, &ram.GetResourceShareAssociationsInput{
 		AssociationType:   assocType,
 		AssociationStatus: ramtypes.ResourceShareAssociationStatusAssociated,
@@ -157,22 +175,9 @@ func (l *RAMResourceShareEnumerator) associatedEntities(client *ram.Client, shar
 		if err != nil {
 			if op := ClassifySkippable(err, "ram", "GetResourceShareAssociations", region); op != nil {
 				*skipped = append(*skipped, *op)
-				return entities
+				return entities, nil
 			}
-			// The share is still emitted with whatever resolved, but the
-			// non-skippable failure is recorded so the data gap (possibly-empty
-			// or partial principals/resources) is visible in the skip report
-			// rather than silently swallowed by a log line.
-			slog.Warn("non-skippable GetResourceShareAssociations error, emitting partial associations",
-				"share", shareArn, "type", string(assocType), "region", region, "error", err)
-			*skipped = append(*skipped, SkippedOp{
-				Region:    region,
-				Service:   "ram",
-				Operation: "GetResourceShareAssociations",
-				ErrorCode: SkipReason(err),
-				Detail:    err.Error(),
-			})
-			return entities
+			return nil, fmt.Errorf("get %s associations for %s in %s: %w", assocType, shareArn, region, err)
 		}
 		for _, assoc := range page.ResourceShareAssociations {
 			if e := aws.ToString(assoc.AssociatedEntity); e != "" {
@@ -180,7 +185,7 @@ func (l *RAMResourceShareEnumerator) associatedEntities(client *ram.Client, shar
 			}
 		}
 	}
-	return entities
+	return entities, nil
 }
 
 // EnumerateByARN fetches a single RAM resource share by ARN (ResourceOwner=SELF).
@@ -219,10 +224,17 @@ func (l *RAMResourceShareEnumerator) EnumerateByARN(arn string, out *pipeline.P[
 	}
 
 	var skipped []SkippedOp
+	defer func() { l.skipReport.RecordBatch(skipped) }()
+
 	share := resp.ResourceShares[0]
-	principals := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypePrincipal, parsed.Region, &skipped)
-	resources := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypeResource, parsed.Region, &skipped)
-	l.skipReport.RecordBatch(skipped)
+	principals, err := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypePrincipal, parsed.Region, &skipped)
+	if err != nil {
+		return err
+	}
+	resources, err := l.associatedEntities(client, arn, ramtypes.ResourceShareAssociationTypeResource, parsed.Region, &skipped)
+	if err != nil {
+		return err
+	}
 
 	out.Send(buildResourceShareResource(share, principals, resources, parsed.AccountID, parsed.Region))
 	return nil

--- a/pkg/aws/enumeration/ram_resourceshare_enumerator_integration_test.go
+++ b/pkg/aws/enumeration/ram_resourceshare_enumerator_integration_test.go
@@ -24,17 +24,10 @@ func TestRAMResourceShareEnumerator(t *testing.T) {
 	provider := NewAWSConfigProvider(opts)
 	enum := NewRAMResourceShareEnumerator(opts, provider, NewSkipReport())
 
-	out := pipeline.New[output.AWSResource]()
-	go func() {
-		require.NoError(t, enum.EnumerateAll(out))
-		out.Close()
-	}()
-
-	var results []output.AWSResource
-	for r := range out.Range() {
-		results = append(results, r)
-	}
-	require.NoError(t, out.Wait())
+	results, err := collectResourceShareResults(func(out *pipeline.P[output.AWSResource]) error {
+		return enum.EnumerateAll(out)
+	})
+	require.NoError(t, err)
 	require.NotEmpty(t, results)
 
 	externalArn := fixture.Output("external_share_arn")
@@ -55,4 +48,19 @@ func TestRAMResourceShareEnumerator(t *testing.T) {
 	org, ok := byArn[orgOnlyArn]
 	require.True(t, ok, "org-only share %s should be enumerated", orgOnlyArn)
 	assert.Equal(t, false, org.Properties["AllowExternalPrincipals"])
+}
+
+func collectResourceShareResults(run func(out *pipeline.P[output.AWSResource]) error) ([]output.AWSResource, error) {
+	out := pipeline.New[output.AWSResource]()
+	resultCh := make(chan []output.AWSResource, 1)
+	go func() {
+		var results []output.AWSResource
+		for r := range out.Range() {
+			results = append(results, r)
+		}
+		resultCh <- results
+	}()
+	err := run(out)
+	out.Close()
+	return <-resultCh, err
 }

--- a/pkg/aws/enumeration/ram_resourceshare_enumerator_integration_test.go
+++ b/pkg/aws/enumeration/ram_resourceshare_enumerator_integration_test.go
@@ -1,0 +1,58 @@
+//go:build integration
+
+package enumeration
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
+	"github.com/praetorian-inc/aurelian/test/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRAMResourceShareEnumerator(t *testing.T) {
+	fixture := testutil.NewAWSFixture(t, "aws/recon/ram-resource-share")
+	fixture.Setup()
+
+	opts := plugin.AWSCommonRecon{
+		Regions:     []string{"us-east-1"},
+		Concurrency: 2,
+	}
+	provider := NewAWSConfigProvider(opts)
+	enum := NewRAMResourceShareEnumerator(opts, provider, NewSkipReport())
+
+	out := pipeline.New[output.AWSResource]()
+	go func() {
+		require.NoError(t, enum.EnumerateAll(out))
+		out.Close()
+	}()
+
+	var results []output.AWSResource
+	for r := range out.Range() {
+		results = append(results, r)
+	}
+	require.NoError(t, out.Wait())
+	require.NotEmpty(t, results)
+
+	externalArn := fixture.Output("external_share_arn")
+	orgOnlyArn := fixture.Output("org_only_share_arn")
+	externalPrincipal := fixture.Output("external_principal_id")
+
+	byArn := make(map[string]output.AWSResource)
+	for _, r := range results {
+		assert.Equal(t, "AWS::RAM::ResourceShare", r.ResourceType)
+		byArn[r.ARN] = r
+	}
+
+	ext, ok := byArn[externalArn]
+	require.True(t, ok, "external share %s should be enumerated", externalArn)
+	assert.Equal(t, true, ext.Properties["AllowExternalPrincipals"])
+	assert.Contains(t, ext.Properties["Principals"], externalPrincipal)
+
+	org, ok := byArn[orgOnlyArn]
+	require.True(t, ok, "org-only share %s should be enumerated", orgOnlyArn)
+	assert.Equal(t, false, org.Properties["AllowExternalPrincipals"])
+}

--- a/pkg/aws/enumeration/ram_resourceshare_enumerator_test.go
+++ b/pkg/aws/enumeration/ram_resourceshare_enumerator_test.go
@@ -5,7 +5,11 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ramtypes "github.com/aws/aws-sdk-go-v2/service/ram/types"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/praetorian-inc/aurelian/pkg/plugin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildResourceShareResource_External(t *testing.T) {
@@ -68,4 +72,40 @@ func TestBuildResourceShareResource_MissingArnFallsBackToAccountID(t *testing.T)
 	r := buildResourceShareResource(share, nil, nil, "111111111111", "eu-west-1")
 
 	assert.Equal(t, "111111111111", r.AccountRef)
+}
+
+func TestRAMResourceShareEnumerator_EnumerateByARN_Errors(t *testing.T) {
+	provider := NewAWSConfigProvider(plugin.AWSCommonRecon{})
+	enum := NewRAMResourceShareEnumerator(plugin.AWSCommonRecon{}, provider, NewSkipReport())
+	out := pipeline.New[output.AWSResource]()
+
+	cases := []struct {
+		name        string
+		arn         string
+		wantErrText string
+	}{
+		{
+			name:        "bad ARN returns error",
+			arn:         "not-an-arn",
+			wantErrText: "parse ARN",
+		},
+		{
+			name:        "non-resource-share RAM ARN returns error",
+			arn:         "arn:aws:ram:us-east-1:123456789012:permission/AWSRAMDefaultPermissionVPCSubnet",
+			wantErrText: "not a RAM resource-share ARN",
+		},
+		{
+			name:        "resource-share ARN missing region returns error",
+			arn:         "arn:aws:ram::123456789012:resource-share/abc-123",
+			wantErrText: "missing region",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := enum.EnumerateByARN(tc.arn, out)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrText)
+		})
+	}
 }

--- a/pkg/aws/enumeration/ram_resourceshare_enumerator_test.go
+++ b/pkg/aws/enumeration/ram_resourceshare_enumerator_test.go
@@ -1,0 +1,71 @@
+package enumeration
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ramtypes "github.com/aws/aws-sdk-go-v2/service/ram/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildResourceShareResource_External(t *testing.T) {
+	share := ramtypes.ResourceShare{
+		ResourceShareArn:        aws.String("arn:aws:ram:us-east-1:123456789012:resource-share/abc-123"),
+		Name:                    aws.String("shared-tgw"),
+		OwningAccountId:         aws.String("123456789012"),
+		AllowExternalPrincipals: aws.Bool(true),
+		Status:                  ramtypes.ResourceShareStatusActive,
+		FeatureSet:              ramtypes.ResourceShareFeatureSetStandard,
+	}
+
+	r := buildResourceShareResource(
+		share,
+		[]string{"210987654321"},
+		[]string{"arn:aws:ec2:us-east-1:123456789012:transit-gateway/tgw-0abc"},
+		"123456789012", "us-east-1",
+	)
+
+	assert.Equal(t, "AWS::RAM::ResourceShare", r.ResourceType)
+	assert.Equal(t, "arn:aws:ram:us-east-1:123456789012:resource-share/abc-123", r.ARN)
+	assert.Equal(t, "arn:aws:ram:us-east-1:123456789012:resource-share/abc-123", r.ResourceID)
+	assert.Equal(t, "123456789012", r.AccountRef)
+	assert.Equal(t, "us-east-1", r.Region)
+	assert.Equal(t, "shared-tgw", r.DisplayName)
+	assert.Equal(t, true, r.Properties["AllowExternalPrincipals"])
+	assert.Equal(t, "ACTIVE", r.Properties["Status"])
+	assert.Equal(t, "STANDARD", r.Properties["FeatureSet"])
+	assert.Equal(t, []string{"210987654321"}, r.Properties["Principals"])
+	assert.Equal(t, []string{"arn:aws:ec2:us-east-1:123456789012:transit-gateway/tgw-0abc"}, r.Properties["ResourceArns"])
+}
+
+func TestBuildResourceShareResource_OrgOnlyNilFields(t *testing.T) {
+	// A share with AllowExternalPrincipals=false and no associations must not panic
+	// and must report AllowExternalPrincipals=false with empty principal/resource lists.
+	share := ramtypes.ResourceShare{
+		ResourceShareArn:        aws.String("arn:aws:ram:us-west-2:123456789012:resource-share/def-456"),
+		Name:                    aws.String("org-subnet-share"),
+		OwningAccountId:         aws.String("123456789012"),
+		AllowExternalPrincipals: aws.Bool(false),
+		Status:                  ramtypes.ResourceShareStatusActive,
+	}
+
+	r := buildResourceShareResource(share, nil, nil, "123456789012", "us-west-2")
+
+	assert.Equal(t, false, r.Properties["AllowExternalPrincipals"])
+	assert.Equal(t, "org-subnet-share", r.DisplayName)
+	assert.Empty(t, r.Properties["Principals"])
+	assert.Empty(t, r.Properties["ResourceArns"])
+}
+
+func TestBuildResourceShareResource_MissingArnFallsBackToAccountID(t *testing.T) {
+	// OwningAccountId absent → AccountRef falls back to the caller-supplied accountID.
+	share := ramtypes.ResourceShare{
+		ResourceShareArn:        aws.String("arn:aws:ram:eu-west-1:999999999999:resource-share/ghi-789"),
+		Name:                    aws.String("no-owner-field"),
+		AllowExternalPrincipals: aws.Bool(true),
+	}
+
+	r := buildResourceShareResource(share, nil, nil, "111111111111", "eu-west-1")
+
+	assert.Equal(t, "111111111111", r.AccountRef)
+}

--- a/pkg/aws/resourcetypes/types.go
+++ b/pkg/aws/resourcetypes/types.go
@@ -46,6 +46,7 @@ var baseline = []string{
 	"AWS::IAM::Role",
 	"AWS::IAM::User",
 	"AWS::KMS::Key",
+	"AWS::RAM::ResourceShare",
 	"AWS::RDS::DBCluster",
 	"AWS::SecretsManager::Secret",
 }

--- a/pkg/types/enriched_resource_description.go
+++ b/pkg/types/enriched_resource_description.go
@@ -397,6 +397,9 @@ var serviceResourcePrefixes = map[string][]resourcePrefixEntry{
 		{prefix: "subnet/", resourceType: "AWS::EC2::Subnet"},
 		{prefix: "vpc/", resourceType: "AWS::EC2::VPC"},
 	},
+	"ram": {
+		{prefix: "resource-share/", resourceType: "AWS::RAM::ResourceShare"},
+	},
 	"ssm": {
 		{prefix: "document/", resourceType: "AWS::SSM::Document"},
 		{prefix: "parameter/", resourceType: "AWS::SSM::Parameter"},

--- a/pkg/types/enriched_resource_description_test.go
+++ b/pkg/types/enriched_resource_description_test.go
@@ -46,6 +46,18 @@ func TestBuildResourceARN(t *testing.T) {
 	}
 }
 
+func TestResolveResourceType_RAM(t *testing.T) {
+	rt, ok := ResolveResourceType("ram", "resource-share/abc-123")
+	if !ok || rt != "AWS::RAM::ResourceShare" {
+		t.Errorf("ResolveResourceType(ram, resource-share/...) = (%q, %v), want (AWS::RAM::ResourceShare, true)", rt, ok)
+	}
+
+	// A RAM permission ARN must NOT resolve to ResourceShare.
+	if rt, ok := ResolveResourceType("ram", "permission/AWSRAMDefaultPermissionSubnet"); ok {
+		t.Errorf("ResolveResourceType(ram, permission/...) unexpectedly resolved to %q", rt)
+	}
+}
+
 // TestResolveResourceType_OpenSearch locks the by-ARN dispatch for OpenSearch /
 // legacy Elasticsearch domains. Both use the "es" service segment, and they must
 // resolve to the type the native OpenSearchDomainEnumerator is registered under

--- a/test/terraform/aws/recon/ram-resource-share/main.tf
+++ b/test/terraform/aws/recon/ram-resource-share/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
   backend "s3" {}
 }
@@ -12,8 +16,12 @@ provider "aws" {
   region = var.region
 }
 
+resource "random_id" "run" {
+  byte_length = 4
+}
+
 resource "aws_ram_resource_share" "external" {
-  name                      = "aurelian-it-external-share"
+  name                      = "aurelian-it-external-share-${random_id.run.hex}"
   allow_external_principals = true
 }
 
@@ -23,6 +31,6 @@ resource "aws_ram_principal_association" "external" {
 }
 
 resource "aws_ram_resource_share" "org_only" {
-  name                      = "aurelian-it-org-only-share"
+  name                      = "aurelian-it-org-only-share-${random_id.run.hex}"
   allow_external_principals = false
 }

--- a/test/terraform/aws/recon/ram-resource-share/main.tf
+++ b/test/terraform/aws/recon/ram-resource-share/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_ram_resource_share" "external" {
+  name                      = "aurelian-it-external-share"
+  allow_external_principals = true
+}
+
+resource "aws_ram_principal_association" "external" {
+  resource_share_arn = aws_ram_resource_share.external.arn
+  principal          = var.external_account_id
+}
+
+resource "aws_ram_resource_share" "org_only" {
+  name                      = "aurelian-it-org-only-share"
+  allow_external_principals = false
+}

--- a/test/terraform/aws/recon/ram-resource-share/outputs.tf
+++ b/test/terraform/aws/recon/ram-resource-share/outputs.tf
@@ -1,0 +1,15 @@
+output "external_share_arn" {
+  value = aws_ram_resource_share.external.arn
+}
+
+output "external_share_name" {
+  value = aws_ram_resource_share.external.name
+}
+
+output "org_only_share_arn" {
+  value = aws_ram_resource_share.org_only.arn
+}
+
+output "external_principal_id" {
+  value = var.external_account_id
+}

--- a/test/terraform/aws/recon/ram-resource-share/variables.tf
+++ b/test/terraform/aws/recon/ram-resource-share/variables.tf
@@ -1,0 +1,12 @@
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "external_account_id" {
+  description = "A 12-digit account ID to associate as a principal, exercising AllowExternalPrincipals=true."
+  type        = string
+  # A well-known non-org account id placeholder; the share is created regardless
+  # of whether an invitation is ever accepted, which is all the enumerator reads.
+  default = "210987654321"
+}


### PR DESCRIPTION
## Summary

Adds native AWS Resource Access Manager (RAM) resource-share enumeration to Aurelian's `list-all` recon path.

A new `RAMResourceShareEnumerator` (`pkg/aws/enumeration/ram_resourceshare_enumerator.go`) uses the native RAM SDK — `GetResourceShares` (`ResourceOwner=SELF`) then `GetResourceShareAssociations` for principals and resources — and emits one `output.AWSResource` per share carrying `AllowExternalPrincipals`, `Status`, `FeatureSet`, `Principals`, and `ResourceArns`.

- Registered on the enumeration dispatcher, so `list-all --scan-type full` requests it.
- `AWS::RAM::ResourceShare` added to the resource-type baseline union.
- `ram` ARN-resolver entry (`resource-share/` prefix) so by-ARN lookups route to the native enumerator instead of degrading to the CloudControl fallback — CloudControl's RAM read/list handlers hold only `ram:GetResourceShares` and cannot populate the associations.

## Why native SDK, not CloudControl

CloudControl surfaces `AllowExternalPrincipals` for free but cannot return the associated principals/resources (its read handler lacks the association permissions), and consumer-side visibility needs the SDK regardless — so a single native collector is simpler than CloudControl + a separate enrichment pass.

## Test plan

- Unit tests: pure `buildResourceShareResource` builder (external / org-only / missing-owner) and `EnumerateByARN` error branches (bad ARN, non-resource-share RAM ARN, missing region).
- Integration: terraform fixture (`test/terraform/aws/recon/ram-resource-share/`, randomized share names) + `//go:build integration` test exercising `EnumerateAll` — ran live against real RAM infra.
- `go build ./...` and the `pkg/aws/enumeration`, `pkg/aws/resourcetypes`, `pkg/types` suites pass, including the resource-type coverage/format/sort gates.

## Out of scope (follow-on)

- Finding generation: flagging `AllowExternalPrincipals=true` / principals outside the org as a risk in `public-resources` / `ResourceEvaluator`.
- Consumer-side shares (`ResourceOwner=OTHER-ACCOUNTS`, accepted external shares).

## Linear

Implements LAB-4944 (child of LAB-780 — AWS Attack Capabilities / Aurelian).
