### PR TITLE
LAB-4616: in-repo architecture docs and agent skills

### DIFF
--- a/.agents/skills/aurelian-code-review/SKILL.md
+++ b/.agents/skills/aurelian-code-review/SKILL.md
@@ -26,6 +26,15 @@ finding — a paraphrase drifts from the source and the author cannot contest it
 - Flag only what you can pin to a concrete file and line.
 - Flag only what is observable in the diff.
 
+Adjacent pre-existing issues are the one exception, and they are **not** findings. If
+the diff leads you to a real problem in untouched code, put it in Notes, say it is
+pre-existing and out of scope, and name the file. It does not count against the caps
+and does not change the verdict. Two reasons: the observation is worth keeping as
+backlog rather than discarding, and recording it separately stops it leaking into the
+findings table where it would block a PR that did not cause it. If it genuinely blocks
+this change — the diff cannot be correct until it is fixed — then it is in scope, and
+it goes in the table as a finding like any other.
+
 ## Procedure
 
 1. Read the PR title and body.
@@ -43,11 +52,21 @@ principle finding.
 Spend most of the budget here. These are review-only judgments: no document can state
 them in advance because they depend on what the diff does.
 
+**Every list in this pass is illustrative, not exhaustive.** The headings name the
+classes of defect worth hunting; the bullets are the shapes seen most often in this
+codebase. A defect that changes behaviour belongs in this pass whether or not it
+matches a bullet. Do not treat a list as a checklist you can complete, and never
+withhold a real finding because it is not enumerated.
+
 ### Intent
 
 Does the change do what the PR body and the changed function names claim? Flag scope
-creep beyond stated intent. A title-versus-code mismatch is not itself a defect — flag
-it only when the divergence introduces real risk.
+creep beyond stated intent.
+
+A PR body is a snapshot: authors push commits without rewriting it, so it is routinely
+incomplete rather than wrong. Silence in the body is not a finding. Flag only when the
+code **contradicts** a stated claim, or when work outside the stated scope carries real
+risk. Never open a finding whose remedy is "update the PR description".
 
 ### Logic
 
@@ -67,7 +86,8 @@ it only when the divergence introduces real risk.
 - A local variable shadowing an imported package name — `pipeline`, `context`,
   `errors`.
 
-The rules behind these are `DEVELOPMENT.md` §4. Your job is spotting the instance.
+The rules behind these are `DEVELOPMENT.md` §4, which you have already read. Cite the
+section; do not restate it. Your job is spotting the instance in the diff.
 
 ### Panic risk
 
@@ -180,4 +200,8 @@ Caps:
 - Quality over quantity. If a finding would not survive a human reviewer's pushback,
   omit it.
 
-If nothing significant: `No issues found — LGTM pending human review.`
+Use `No issues found — LGTM pending human review.` only when pass 1 produced nothing
+at all and passes 2 and 3 produced nothing above low severity. A low-severity finding
+still goes in the table; it does not by itself withhold the line. Anything in pass 1,
+or any medium or high from passes 2 or 3, means findings — not LGTM. Notes entries do
+not affect this: pre-existing observations are compatible with LGTM.

--- a/.agents/skills/aurelian-code-review/SKILL.md
+++ b/.agents/skills/aurelian-code-review/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: aurelian-code-review
+description: Use when reviewing an Aurelian pull request. Covers the behavioral defect pass, the architecture invariant pass, and the principles pass for Go cloud recon code across AWS, Azure, GCP, and Kubernetes.
+license: Apache-2.0
+---
+
+# Aurelian code review
+
+Advisory. Technical feedback only. You do not approve or reject — the human reviewer
+decides.
+
+Two normative documents hold the rules. This skill does not restate them:
+
+- `ARCHITECTURE.md` — Aurelian invariants, sections 1 through 11.
+- `DEVELOPMENT.md` — Go craft and the three enforceable principles, sections 1 through 9.
+
+Read both before reviewing. Cite them by section. Never paraphrase a rule into a
+finding — a paraphrase drifts from the source and the author cannot contest it.
+
+## Scope discipline
+
+- Code review only. Do not demand new tests. Do not comment on coverage, missing
+  tests, or test naming.
+- No stylistic, formatting, or naming nits beyond the low-severity list below.
+- Do not propose refactors outside the diff. Do not edit files. Do not push commits.
+- Flag only what you can pin to a concrete file and line.
+- Flag only what is observable in the diff.
+
+## Procedure
+
+1. Read the PR title and body.
+2. Read the diff.
+3. Read each changed file **in full**. Never review a diff in isolation — the
+   surrounding function decides whether a diff-local line is a defect.
+4. Run the three passes below, in order.
+5. Post one top-level comment. No inline comments.
+
+Order matters. A behavioral defect outranks an invariant deviation, which outranks a
+principle finding.
+
+## Pass 1 — behavioral defects
+
+Spend most of the budget here. These are review-only judgments: no document can state
+them in advance because they depend on what the diff does.
+
+### Intent
+
+Does the change do what the PR body and the changed function names claim? Flag scope
+creep beyond stated intent. A title-versus-code mismatch is not itself a defect — flag
+it only when the divergence introduces real risk.
+
+### Logic
+
+- Off-by-one, wrong loop bounds, wrong slice indices.
+- Filter loops that validate one slice then operate on the unfiltered one.
+- Branches genuinely unreachable given the call graph. Check the `ARCHITECTURE.md` §11
+  carve-outs first: blank imports, `init()` registration, registry and reflection
+  dispatch, and CSP interface boundaries are load-bearing and are never dead code.
+
+### Concurrency
+
+- A closure capturing the wrong variable when the closure is created outside a `for`
+  statement. The for-loop case is fixed by the language; closures built in other
+  constructs still carry the risk.
+- Two goroutines writing the same field with no synchronization.
+- Cancellation dropped on a long-running call.
+- A local variable shadowing an imported package name — `pipeline`, `context`,
+  `errors`.
+
+The rules behind these are `DEVELOPMENT.md` §4. Your job is spotting the instance.
+
+### Panic risk
+
+- Nil pointer dereference on a value not nil-checked first.
+- Type assertion without the `, ok` form and without a fallback, on SDK responses or
+  map values.
+- Slice indexing without a length check on SDK, user, or external data.
+- `MustX` outside `init()` or a package-level `var` — it becomes a runtime panic at
+  call time rather than a startup failure.
+- Sending on a pipeline after it is closed. Closing twice is safe — `Close` is guarded
+  by a `sync.Once` — so do not flag a double close.
+
+### Dropped errors
+
+The `%w`, `errors.Is`, and no-string-matching rules are `DEVELOPMENT.md` §3. Cite them;
+do not re-derive them. What belongs here is the diff-local judgment of whether a drop
+is deliberate:
+
+- `if err != nil { return nil }` with no log at `slog.Warn` or higher and no comment
+  saying why. Deliberate best-effort is fine when it is documented; silent is a defect.
+- Returning `nil` on partial failure when the contract is all-or-nothing.
+- Swallowing a sentinel the caller relies on — `io.EOF`, `context.Canceled`, a
+  not-found error.
+
+Enrichment is best-effort by design (`ARCHITECTURE.md` §7). An enricher error that is
+logged and continued is correct, not a dropped error.
+
+### Test meaningfulness
+
+Only when test files are part of the PR. You may not demand more tests.
+
+- Tautological assertions that pass without exercising the change.
+- Mocks that swallow the path the test claims to exercise.
+- Table-driven rows that all land on the same branch.
+- Fixtures that never reach the new code.
+- Assertions on internal state instead of on the contract.
+- A test whose failure would not represent a regression of the changed behavior.
+
+### Cypher
+
+A query that drops the matched target from `WITH` and re-matches it downstream produces
+O(n²) false edges. Carry the target through: `WITH attacker, target`.
+
+## Pass 2 — architecture invariants
+
+Check the diff against `ARCHITECTURE.md`. Name the section in the finding. Do not
+restate the rule — the author reads it at the anchor.
+
+| Concern | Anchor |
+| --- | --- |
+| Layering, dependency direction | §1 |
+| File and directory placement | §2 |
+| Module contract, registration, thin `Run()` | §3 |
+| Pipeline lifecycle and what `Run` returns | §4 |
+| Components and the registry pattern | §5 |
+| Parameter binding, tags, post-bind | §6 |
+| Enricher registration, mutator and evaluator split | §7 |
+| Output types | §8 |
+| Pagination, region fan-out, rate limiting, keyed state | §9 |
+| The six prohibitions | §10 |
+| Load-bearing patterns — a carve-out, never a finding | §11 |
+
+§4 is the highest-value check in this pass; it is the codebase's primary deadlock
+source. §10 prohibition 5 binds new and changed code only — the tree has pre-existing
+violations, so do not flag untouched lines.
+
+Go craft — stdlib over hand-rolled loops, error wrapping, concurrency primitives,
+logging, generics — is `DEVELOPMENT.md` §§1-6. Same discipline: cite the section.
+
+## Pass 3 — principles
+
+Mandatory. This is what holds a PR author accountable to `DEVELOPMENT.md` §§7-9. Each
+of those sections defines a **Rule**, an observable **Trigger**, and **Carve-outs**.
+
+1. **Trigger required.** Fire only when the diff shows the observable trigger the
+   section defines. No trigger, no finding. This is what separates enforcement from
+   taste.
+2. **Cite the anchor.** Name the `DEVELOPMENT.md` section. The author must be able to
+   read the rule, check the carve-outs, and contest a specific claim.
+3. **Carve-outs checked first,** including `ARCHITECTURE.md` §11. A carve-out hit is
+   silent — not a finding with a caveat attached.
+
+Scope discipline still applies: no demands for new tests, no naming or formatting nits,
+no refactors outside the diff.
+
+## Severity
+
+- **high** — a behavioral defect from pass 1.
+- **medium** — an architecture deviation from pass 2, or a pass 3 principle violation
+  whose trigger fired.
+- **low** — a soft preference. `regexp.MustCompile` in a hot path that belongs at
+  package level. A non-trivial inline closure that deserves a name.
+
+A principle finding reaches high only when the trigger also implies a defect — for
+example a config field added and never read, so the setting is silently ignored at
+runtime.
+
+No per-rule severity table. Severity follows the pass that produced the finding.
+
+## Output
+
+One comment: a summary of what the PR actually does, drawn from the diff rather than
+the PR body, then a findings table with number, severity, rule, file, location, and
+detail. Optional notes last.
+
+Caps:
+
+- Under 15 findings.
+- At least two-thirds from pass 1, unless the PR is purely a convention fix.
+- Quality over quantity. If a finding would not survive a human reviewer's pushback,
+  omit it.
+
+If nothing significant: `No issues found — LGTM pending human review.`

--- a/.agents/skills/aurelian-integration-testing/SKILL.md
+++ b/.agents/skills/aurelian-integration-testing/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: aurelian-integration-testing
+description: Use when writing or modifying integration tests for Aurelian modules and components - covers Terraform fixtures, test structure, assertion quality, Neo4j graph tests, and teardown
+license: Apache-2.0
+---
+
+# Aurelian Integration Testing
+
+Integration tests run modules and components against live cloud infrastructure
+provisioned by Terraform fixtures.
+
+## Hard rules
+
+- **Integration tests deploy real infrastructure.** No mocks, fakes, or stubs in a
+  `//go:build integration` file. Mock-based logic belongs in an untagged unit test in
+  the same package.
+- Directory layout, fixture path, and where module vs component code lives are
+  architecture invariants. See ARCHITECTURE.md §2. Do not restate them in tests.
+- Never hardcode an expected value that Terraform already knows. Read it from a
+  fixture output.
+
+## Conventions
+
+| Item | Pattern |
+| --- | --- |
+| Test file | `<module_name>_integration_test.go`, in the same package as the code under test |
+| Build tag | `//go:build integration` — first line, blank line, then `package` |
+| Fixture directory | Mirrors the module path. See ARCHITECTURE.md §2. |
+| Fixture path argument | Relative to `test/terraform`, e.g. `"aws/recon/graph"` |
+
+## Workflow
+
+1. Identify the module or component under test.
+2. Create or reuse a Terraform fixture.
+3. Write the test.
+4. Run it.
+5. Tear down (or deliberately leave the fixture up).
+
+## 1. Identify the target
+
+Modules are addressed by the triple the module registers with: platform, category,
+module ID. Read the module's `init()` registration for the exact ID — do not guess it
+from the filename.
+
+Components are called directly. They have no registry entry.
+
+## 2. Create or reuse the fixture
+
+Reuse first. A component almost never needs its own fixture — point it at a module
+fixture that already provisions the resources it reads.
+
+**Backend is mandatory and must be S3:**
+
+```hcl
+terraform {
+  backend "s3" {}
+}
+```
+
+Fixture setup runs `terraform init -backend-config` with `bucket`, `region`, and `key`.
+Those flags are only valid when the backend type is S3. A `backend "local" {}` fixture
+fails at init. Leave the block empty — values are injected.
+
+Fixture rules:
+
+- Derive resource names from a `prefix` variable or local so parallel stacks do not
+  collide. Build the prefix from caller identity where possible.
+- Sanitize the prefix for CSP naming constraints. Azure storage accounts are 3–24
+  characters, lowercase alphanumeric only.
+- Export every identifier the test asserts on as an output — ARNs, IDs, names.
+- Provision *diverse* resources. A module that enumerates ten resource types needs a
+  fixture with ten resource types, each with its own assertion.
+- Keep retention and TTL short to save cost. Ephemeral data is re-injected by the test
+  (below), not preserved by the fixture.
+
+```hcl
+output "resource_ids" {
+  value = [aws_instance.test.id]
+}
+```
+
+## 3. Write the test
+
+Canonical module test:
+
+```go
+//go:build integration
+
+package recon
+
+import (
+    "context"
+    "testing"
+
+    "github.com/praetorian-inc/aurelian/pkg/model"
+    "github.com/praetorian-inc/aurelian/pkg/pipeline"
+    "github.com/praetorian-inc/aurelian/pkg/plugin"
+    "github.com/praetorian-inc/aurelian/test/testutil"
+    "github.com/stretchr/testify/require"
+)
+
+func TestMyModule(t *testing.T) {
+    fixture := testutil.NewAWSFixture(t, "aws/recon/graph")
+    fixture.Setup()
+
+    mod, ok := plugin.Get(plugin.PlatformAWS, plugin.CategoryRecon, "module-id")
+    require.True(t, ok, "module-id not registered in plugin system")
+
+    cfg := plugin.Config{
+        Args:    map[string]any{"regions": []string{"us-east-2"}},
+        Context: context.Background(),
+    }
+    p1 := pipeline.From(cfg)
+    p2 := pipeline.New[model.AurelianModel]()
+    pipeline.Pipe(p1, mod.Run, p2)
+
+    results, err := p2.Collect()
+    require.NoError(t, err)
+
+    testutil.AssertMinResults(t, results, 1)
+    for _, id := range fixture.OutputList("resource_ids") {
+        testutil.AssertResultContainsString(t, results, id)
+    }
+}
+```
+
+A component test is the same shape minus the registry lookup — instantiate the
+component and call its method. Parameter structs such as `plugin.AWSCommonRecon` carry
+regions and other common inputs.
+
+### Fixture API
+
+| Call | Returns | Use |
+| --- | --- | --- |
+| `testutil.NewAWSFixture(t, dir)` | Fixture | AWS fixture; `dir` relative to `test/terraform` |
+| `testutil.NewAzureFixture(t, dir)` | Fixture | Azure fixture |
+| `testutil.NewGCPFixture(t, dir)` | Fixture | GCP fixture |
+| `fixture.Setup()` | — | Deploy or reuse. Hash-based: redeploys only when the template changes. |
+| `fixture.Output(key)` | `string` | One Terraform output |
+| `fixture.OutputList(key)` | `[]string` | List output |
+| `fixture.OutputMap(key)` | `map[string]string` | Map output |
+
+### Assertion helpers
+
+Defined in `test/testutil`:
+
+```go
+testutil.AssertMinResults(t, results, 5)
+testutil.AssertResultContainsARN(t, results, arn)
+testutil.AssertResultContainsString(t, results, substr)
+testutil.AssertNoDuplicateResults(t, results)
+testutil.RunAndCollect(t, mod, cfg)   // registry lookup already done
+```
+
+For typed checks, type-switch to the concrete output type and use testify directly.
+
+### Collecting results
+
+One type — collect:
+
+```go
+results, err := p2.Collect()
+require.NoError(t, err)
+```
+
+Several types — range and switch, then wait:
+
+```go
+var entities []output.AWSIAMResource
+var rels []output.AWSIAMRelationship
+for m := range p2.Range() {
+    switch v := m.(type) {
+    case output.AWSIAMResource:
+        entities = append(entities, v)
+    case output.AWSIAMRelationship:
+        rels = append(rels, v)
+    }
+}
+require.NoError(t, p2.Wait())
+```
+
+### Subtests
+
+Run the module **once**, then split assertions into subtests. Clear diagnostics, no
+repeated cloud calls.
+
+```go
+results, err := testutil.RunAndCollect(t, mod, cfg)
+require.NoError(t, err)
+
+t.Run("discovers storage accounts", func(t *testing.T) {
+    testutil.AssertResultContainsString(t, results, fixture.Output("storage_account_id"))
+})
+```
+
+Call `fixture.Setup()` once before the subtests, never per-subtest. Do not retry module
+runs — fixtures are long-lived and resources have already propagated. Name subtests for
+behavior (`"discovers X"`), not raw resource IDs.
+
+### Ephemeral fixture data
+
+Fixtures are long-lived, so short-retention data (CloudWatch log events, Step Functions
+execution history) expires and dependent subtests fail quietly. Re-inject it between
+`fixture.Setup()` and the module run, with an idempotent helper that no-ops when the
+data is already present:
+
+```go
+testutil.EnsureLogEvent(t, "us-east-2",
+    fixture.Output("log_group_name"),
+    fixture.Output("log_stream_name"),
+    fixture.Output("log_event_message"),
+)
+```
+
+Every input comes from a fixture output. Add a Terraform output rather than hardcoding
+a message string.
+
+### Enricher dependencies
+
+If the module under test depends on enrichers, blank-import them so their `init()`
+registration runs:
+
+```go
+import _ "github.com/praetorian-inc/aurelian/pkg/modules/aws/enrichers"
+```
+
+## 4. Test quality
+
+**`require` vs `assert`.** `require` for preconditions — the rest of the test is
+meaningless without them, so fail fast. `assert` for independent verifications, so one
+run reports every failure.
+
+```go
+require.NoError(t, err)
+require.True(t, ok, "module not registered")
+assert.NotEmpty(t, v.RiskName, "risk name should be populated")
+assert.NotEmpty(t, v.Severity, "severity should be populated")
+```
+
+**Assert structurally.** `len(results) > 0` is not an assertion. Type-switch to the
+concrete type and check named fields. For risk-producing modules check risk name,
+severity, populated context, and the impacted resource identifier.
+
+**Assert against fixture outputs.** Prove the module found *the intentionally vulnerable
+resource*, not that it found something.
+
+**Cover negative paths.** Assert what must NOT happen: a compliant resource produces no
+finding, an error surfaces instead of being swallowed, a duplicate registration panics.
+
+**Assert invariants across the whole result set**, not just spot checks:
+
+```go
+t.Run("no duplicate resources", func(t *testing.T) {
+    seen := map[string]bool{}
+    for _, r := range resources {
+        require.False(t, seen[r.ResourceID], "duplicate resource: %s", r.ResourceID)
+        seen[r.ResourceID] = true
+    }
+})
+```
+
+**Table-driven for pure functions** with many input/output pairs. Individual functions
+for behavior with side effects.
+
+**Reset shared state.** Any test touching a package-level registry or singleton resets
+first — otherwise the suite develops ordering dependencies. `plugin.ResetRegistry` for
+the module registry.
+
+**Do not write thin tests.** One to three assertions against real infrastructure is
+almost certainly insufficient. More assertions on a single module run are cheap;
+re-running modules is expensive.
+
+| Module type | Minimum |
+| --- | --- |
+| Resource enumeration | 5+ distinct resource checks |
+| Risk or finding detection | 3–5+ unique risk outputs, with field validation |
+| Public resource detection | 3–5+ resource checks plus risk field correctness |
+
+## 5. Graph tests (Neo4j)
+
+Graph analysis modules need a Neo4j container via testcontainers. Start it in the test
+and register cleanup:
+
+```go
+boltURL, cleanup, err := testutil.StartNeo4jContainer(ctx)
+require.NoError(t, err)
+t.Cleanup(cleanup)
+
+testutil.ClearNeo4jDatabase(t, boltURL)
+```
+
+Reset the database before each test that shares a container. Docker is required. Use
+`-timeout 30m` — IAM provisioning alone can take 15–30 minutes.
+
+| Aspect | Convention |
+| --- | --- |
+| Node labels | `User`, `Role`, `Group`, `Resource`, `ServicePrincipal` |
+| Relationship types | Uppercase with underscores: `IAM_CREATEPOLICYVERSION` |
+| GAAD properties | PascalCase: `Arn`, `UserName`, `RoleName` |
+| Cloud resource properties | lowercase: `arn`, `region`, `account_id` |
+| Isolation | Filter Cypher by the fixture's `random_suffix` output |
+
+## 6. Run
+
+```bash
+scripts/run-integration-tests.sh                                    # everything
+scripts/run-integration-tests.sh ./pkg/modules/aws/recon/...        # one package
+scripts/run-integration-tests.sh ./pkg/modules/aws/recon/... -v -run TestMyModule -timeout 30m
+scripts/run-integration-tests.sh --destroy                          # redeploy fixtures first
+```
+
+Flags: `-v`, `-run PATTERN`, `-count N`, `-timeout DURATION`, `--destroy`. The script
+loads credentials from `.env.integration`.
+
+Equivalent direct invocation:
+
+```bash
+go test -tags=integration -v -timeout 30m -run TestMyModule ./pkg/modules/aws/recon/
+```
+
+Requirements: cloud credentials for the CSP under test, `terraform` in `PATH`, Docker
+for graph tests, and a 30-minute timeout.
+
+## 7. Tear down
+
+Fixtures persist between runs by design — redeploying costs more than leaving them up,
+and `fixture.Setup()` reuses a stack whose template hash is unchanged.
+
+```bash
+AURELIAN_DESTROY_FIXTURES=1 go test -tags=integration ./...   # destroy + redeploy
+scripts/teardown-integration-fixtures.sh                      # DRY RUN, lists targets
+scripts/teardown-integration-fixtures.sh --yes                # destroy all fixtures
+scripts/teardown-integration-fixtures.sh --yes aws/           # only keys matching aws/
+```
+
+Teardown destroys from the artifacts actually applied, pulled from S3 remote state, then
+removes the hash marker so the next run redeploys cleanly. Azure and GCP fixtures need
+valid `az` / `gcloud` credentials to destroy; AWS-only teardown needs `AWS_PROFILE`.
+
+## Verify before claiming done
+
+```bash
+go test ./...                                              # unit tests still pass
+go vet -tags=integration ./pkg/modules/<csp>/<category>/   # the test compiles
+scripts/run-integration-tests.sh ./pkg/modules/<csp>/<category>/... -v -run TestMyModule
+```
+
+`go build` does not compile tagged test files. `go vet -tags=integration` is the only
+cheap check that the test compiles at all — run it before spending money on cloud
+resources.
+
+## Common mistakes
+
+- Mocking a cloud API inside a tagged integration test.
+- A thin test: one assertion, no field checks, no negative path.
+- Hardcoded ARNs, IDs, or region names instead of fixture outputs.
+- A dedicated fixture for a component that could reuse a module's.
+- Re-running the module per subtest instead of once up front.
+- `backend "local" {}` in a fixture.
+- Forgetting the blank enricher import, then debugging an empty result set.

--- a/.agents/skills/aurelian-integration-testing/SKILL.md
+++ b/.agents/skills/aurelian-integration-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aurelian-integration-testing
-description: Use when writing or modifying integration tests for Aurelian modules and components - covers Terraform fixtures, test structure, assertion quality, Neo4j graph tests, and teardown
+description: Use when writing, modifying, running, or tearing down integration tests for Aurelian modules and components - covers Terraform fixtures, test structure, assertion quality, Neo4j graph tests, executing the suite, and destroying fixtures
 license: Apache-2.0
 ---
 

--- a/.agents/skills/aurelian-module-development/SKILL.md
+++ b/.agents/skills/aurelian-module-development/SKILL.md
@@ -38,7 +38,7 @@ Ordered. Do not skip step 6.
 2. **Define the config struct.** Embed the CSP common struct rather than redeclaring
    its fields; ARCHITECTURE.md §6 lists the embeds and the supported tags. Every
    exported, non-embedded field needs a `param` tag or binding fails at runtime.
-   Concurrency limits, thresholds, and timeouts are parameters, never literals.
+   §6 also governs what must be a parameter rather than a constant.
 
 3. **Declare the module struct**, embedding the config struct.
 

--- a/.agents/skills/aurelian-module-development/SKILL.md
+++ b/.agents/skills/aurelian-module-development/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: aurelian-module-development
+description: Use when adding or changing an Aurelian module, component, or enricher. Covers file placement, registration, pipeline wiring, and local verification for Go cloud recon modules across AWS, Azure, and GCP.
+license: Apache-2.0
+---
+
+# Aurelian module development
+
+Conform to `../../../ARCHITECTURE.md` and `../../../DEVELOPMENT.md`. Deviations are
+flagged in review.
+
+This file is workflow only: what to create, in what order, and how to prove it works.
+Every contract it refers to is defined once in ARCHITECTURE.md and is not restated here.
+When a step cites a section, read it before writing the code.
+
+## 0. Pick the category first
+
+The category decides the directory, and the directory decides what you implement.
+
+| You are adding | Goes in | Follow |
+| --- | --- | --- |
+| A unit of work a user invokes from the CLI | `pkg/modules/<csp>/<category>/` | Section 1 |
+| Cloud API calls, pagination, parsing | `pkg/<csp>/<service>/` | Section 2 |
+| Extra properties on an already-enumerated resource | `pkg/modules/<csp>/enrichers/` | Section 3 |
+| A detection expressible as data, no Go | `pkg/modules/aws/rules/` | ARCHITECTURE.md §2 |
+
+`<category>` is one of recon, analyze, enrichers, evaluators. If the detection can be a
+YAML rule consumed by `pkg/modules/common/`, write the rule, not a module.
+
+## 1. Add a module
+
+Ordered. Do not skip step 6.
+
+1. **Create the file.** One module per file, at
+   `pkg/modules/<csp>/<category>/<name>.go`. No cloud API calls in this file — that is
+   a layering violation (ARCHITECTURE.md §1).
+
+2. **Define the config struct.** Embed the CSP common struct rather than redeclaring
+   its fields; ARCHITECTURE.md §6 lists the embeds and the supported tags. Every
+   exported, non-embedded field needs a `param` tag or binding fails at runtime.
+   Concurrency limits, thresholds, and timeouts are parameters, never literals.
+
+3. **Declare the module struct**, embedding the config struct.
+
+4. **Implement `plugin.Module`** (`pkg/plugin/module.go`). ARCHITECTURE.md §3 lists
+   every method and states what each must return — in particular, the input-targets
+   method means the types a caller may aim the module at, not the types it discovers.
+   Getting that wrong changes how Guard dispatches the module.
+
+5. **Return the config from `Parameters()`** as a pointer. Never call `plugin.Bind`
+   yourself; `plugin.ModuleWrapper` binds and runs post-binders before `Run`. Put
+   credential construction, region resolution, and cross-field validation in a
+   `PostBind` method (`plugin.PostBinder`), not in `Run`.
+
+6. **Register in `init()`** with `plugin.Register`. Then make the package reachable:
+   add a blank import to `cmd/module_imports.go` if its package is not already listed,
+   and regenerate `pkg/modules/loader/loader.go` with
+   `go generate ./pkg/modules/loader` — never hand-edit that file. A module with no
+   blank import compiles, registers nothing, and silently does not exist at runtime.
+
+7. **Write `Run`.** Read the bound config, build the topology, delegate to components,
+   emit. Keep it thin.
+
+8. **Choose what `Run` returns using the table in ARCHITECTURE.md §4 ("What Run
+   returns").** This is the single most common source of deadlocks and truncated
+   output in this codebase. The right answer depends on who closes the output
+   pipeline, and there are three distinct cases. Read the table; do not guess.
+
+9. **Emit an output type from the §8 table.** Do not invent a result type. New
+   findings use `output.AurelianRisk`.
+
+## 2. Add a component
+
+Components hold every cloud API call and are reused across modules.
+
+1. Create `pkg/<csp>/<service>/`, or add to the existing service package.
+2. Expose a `NewXxx()` constructor taking the module's bound config plus collaborators.
+3. Shape work methods so they drop into `pipeline.Pipe` as a stage with no adapter —
+   ARCHITECTURE.md §5 gives the signature and two in-tree examples.
+4. Page with the CSP's paginator and fan out with `ratelimit.NewCrossRegionActor`
+   rather than a hand-written region loop (ARCHITECTURE.md §9 explains which paginator
+   and why manual loops throttle the account).
+5. No `init()`, no registry. The module constructs the component explicitly.
+6. Do not import `pkg/modules/` from a component.
+
+## 3. Add an enricher
+
+An enricher adds properties a bulk listing cannot return.
+
+1. Implement it in `pkg/modules/<csp>/enrichers/`.
+2. Register in `init()`, keyed by resource type, using the CSP's register function —
+   ARCHITECTURE.md §7 has the per-CSP table, including which type Azure operates on.
+3. Mutate the resource and return. If you are deciding whether a condition holds, you
+   want an evaluator, not an enricher (§7).
+4. Assume best-effort: returning an error logs and forwards the resource unchanged, it
+   does not fail the scan (§7). Write it so a partial result is still useful.
+
+`pkg/modules/aws/enrichers/redshift.go` is a complete 22-line example.
+
+## 4. Verify locally
+
+Run all of these before opening a PR. The first two catch the wiring mistakes that
+compile cleanly.
+
+```bash
+go build ./...
+go generate ./pkg/modules/loader && git diff --exit-code pkg/modules/loader/loader.go
+go run . list-modules | grep '<your-module-id>'
+go run . <csp> <category> <your-module-id> --help
+go test ./... && go test -race ./pkg/...
+golangci-lint run
+```
+
+`list-modules` is the registration check: if your module is absent, step 6 is
+incomplete. The `--help` invocation is the parameter check — every bound parameter
+appears as a flag, so a missing flag means a missing or malformed tag.
+
+Integration tests that stand up real infrastructure live under `test/terraform/`, in a
+path mirroring the module path. See the aurelian-integration-testing skill.
+
+## Worked example: a minimal module
+
+`pkg/modules/aws/recon/org_policies.go` is the smallest complete module in the tree —
+read it in full. It is the shape to copy when a module calls one collector and emits
+one result. The load-bearing parts:
+
+```go
+package recon
+
+func init() {
+	plugin.Register(&AWSOrgPoliciesModule{})
+}
+
+type OrgPoliciesConfig struct {
+	plugin.AWSReconBase
+}
+
+type AWSOrgPoliciesModule struct {
+	OrgPoliciesConfig
+}
+
+// Metadata methods elided -- ARCHITECTURE.md §3 lists the full set and what
+// each returns. They are fixed values: no I/O, no config reads.
+
+func (m *AWSOrgPoliciesModule) Parameters() any {
+	return &m.OrgPoliciesConfig
+}
+
+func (m *AWSOrgPoliciesModule) Run(cfg plugin.Config, out *pipeline.P[model.AurelianModel]) error {
+	c := m.OrgPoliciesConfig
+
+	orgPols, err := orgpolicies.CollectOrgPolicies(cfg.Context, orgpolicies.CollectorOptions{
+		Profile:    c.Profile,
+		ProfileDir: c.ProfileDir,
+	})
+	if err != nil {
+		return err
+	}
+
+	out.Send(orgPols)
+	return nil
+}
+```
+
+Note what this `Run` does and does not do. It sends directly and returns nil, which is
+row 1 of the §4 table — correct precisely because nothing else is writing to `out`. A
+module that instead builds stages with `pipeline.Pipe` falls under row 2 or 3 and must
+return something different. Re-read §4 when you change the topology.

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -45,37 +45,32 @@ jobs:
       - name: Validate Agent Skills
         run: |
           set -euo pipefail
-          # LC_ALL=C is load-bearing: under a UTF-8 locale bash's [a-z] range
-          # follows collation order and matches uppercase, so the name check
-          # below would accept "Aurelian-Code-Review". Do not remove.
+          # LC_ALL=C: under a UTF-8 locale bash's [a-z] follows collation order and
+          # matches uppercase, so the name check would accept "Aurelian-Code-Review".
           export LC_ALL=C
           shopt -s nullglob
           dirs=(.agents/skills/*/)
-          # Without this guard an unexpanded/empty glob iterates zero times and
-          # the job passes having validated nothing -- including if every skill
-          # is later deleted.
-          if [ ${#dirs[@]} -eq 0 ]; then
-            echo "::error::no skill directories found under .agents/skills/ - nothing to validate"
-            exit 1
-          fi
-          count=0
+          # An empty glob would iterate zero times and pass having validated nothing.
+          [ ${#dirs[@]} -gt 0 ] || { echo "::error::no skill directories under .agents/skills/"; exit 1; }
+
           for d in "${dirs[@]}"; do
             echo "== $d"
-            test -f "$d/SKILL.md" || { echo "::error::$d missing SKILL.md"; exit 1; }
-            test ! -d "$d/references" || { echo "::error::$d has references/ (skills are self-contained)"; exit 1; }
-            # Extract metadata ONLY from the YAML front matter block. A bare grep for
-            # 'name:' matches anywhere in the body, so a file with no front matter at
-            # all would pass this gate.
-            head -1 "$d/SKILL.md" | grep -qx -- '---' || { echo "::error::$d SKILL.md must open with ---"; exit 1; }
-            fm=$(awk 'NR==1&&/^---$/{f=1;next} f&&/^---$/{exit} f' "$d/SKILL.md")
-            printf '%s\n' "$fm" | grep -q '^name:' || { echo "::error::$d front matter missing name"; exit 1; }
-            printf '%s\n' "$fm" | grep -q '^description:' || { echo "::error::$d front matter missing description"; exit 1; }
-            name=$(printf '%s\n' "$fm" | awk -F': *' '/^name:/{print $2; exit}')
-            [ "$name" = "$(basename "$d")" ] || { echo "::error::$d name '$name' != dir"; exit 1; }
-            case "$name" in
-              *[![:lower:][:digit:]-]*|-*|*-|*--*) echo "::error::$d name '$name' must be lowercase/digits/single hyphens"; exit 1;;
-            esac
-            [ "${#name}" -le 64 ] || { echo "::error::$d name '$name' exceeds 64 chars"; exit 1; }
-            count=$((count + 1))
+            f="$d/SKILL.md"; name=$(basename "$d")
+            die() { echo "::error::$d $1"; exit 1; }
+
+            test -f "$f"              || die "missing SKILL.md"
+            test ! -d "$d/references" || die "has references/ (skills are self-contained)"
+
+            # Read metadata only from the front matter block; a bare grep for "name:"
+            # matches the body, so a file with no front matter would pass.
+            head -1 "$f" | grep -qx -- '---' || die "SKILL.md must open with ---"
+            fm=$(awk 'NR==1&&/^---$/{f=1;next} f&&/^---$/{exit} f' "$f")
+            grep -q '^description:' <<<"$fm" || die "front matter missing description"
+            grep -q '^name:'        <<<"$fm" || die "front matter missing name"
+
+            declared=$(awk -F': *' '/^name:/{print $2; exit}' <<<"$fm")
+            [ "$declared" = "$name" ] || die "name '$declared' != directory"
+            [ ${#name} -le 64 ]       || die "name exceeds 64 chars"
+            case "$name" in *[![:lower:][:digit:]-]*|-*|*-|*--*) die "name must be lowercase/digits/single hyphens";; esac
           done
-          echo "validated $count skill(s)"
+          echo "validated ${#dirs[@]} skill(s)"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -10,6 +10,12 @@ on:
       - 'scripts/check-architecture-refs.sh'
       - '.github/workflows/docs-check.yml'
       - 'go.mod'
+      # Source roots the gate resolves against. Docs go stale when CODE moves, not
+      # when docs move, so a rename under pkg/ must trigger this check too.
+      - 'pkg/**'
+      - 'cmd/**'
+      - 'test/**'
+      - 'internal/**'
   push:
     branches: [main]
 
@@ -57,9 +63,15 @@ jobs:
             echo "== $d"
             test -f "$d/SKILL.md" || { echo "::error::$d missing SKILL.md"; exit 1; }
             test ! -d "$d/references" || { echo "::error::$d has references/ (skills are self-contained)"; exit 1; }
-            name=$(awk -F': *' '/^name:/{print $2; exit}' "$d/SKILL.md")
+            # Extract metadata ONLY from the YAML front matter block. A bare grep for
+            # 'name:' matches anywhere in the body, so a file with no front matter at
+            # all would pass this gate.
+            head -1 "$d/SKILL.md" | grep -qx -- '---' || { echo "::error::$d SKILL.md must open with ---"; exit 1; }
+            fm=$(awk 'NR==1&&/^---$/{f=1;next} f&&/^---$/{exit} f' "$d/SKILL.md")
+            printf '%s\n' "$fm" | grep -q '^name:' || { echo "::error::$d front matter missing name"; exit 1; }
+            printf '%s\n' "$fm" | grep -q '^description:' || { echo "::error::$d front matter missing description"; exit 1; }
+            name=$(printf '%s\n' "$fm" | awk -F': *' '/^name:/{print $2; exit}')
             [ "$name" = "$(basename "$d")" ] || { echo "::error::$d name '$name' != dir"; exit 1; }
-            grep -q '^description:' "$d/SKILL.md" || { echo "::error::$d missing description"; exit 1; }
             case "$name" in
               *[![:lower:][:digit:]-]*|-*|*-|*--*) echo "::error::$d name '$name' must be lowercase/digits/single hyphens"; exit 1;;
             esac

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,69 @@
+name: Docs Check
+
+on:
+  pull_request:
+    paths:
+      - 'ARCHITECTURE.md'
+      - 'DEVELOPMENT.md'
+      - 'AGENTS.md'
+      - '.agents/**'
+      - 'scripts/check-architecture-refs.sh'
+      - '.github/workflows/docs-check.yml'
+      - 'go.mod'
+  push:
+    branches: [main]
+
+concurrency:
+  group: docs-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  refs:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Check doc references
+        run: bash scripts/check-architecture-refs.sh
+
+  skills:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Validate Agent Skills
+        run: |
+          set -euo pipefail
+          # LC_ALL=C is load-bearing: under a UTF-8 locale bash's [a-z] range
+          # follows collation order and matches uppercase, so the name check
+          # below would accept "Aurelian-Code-Review". Do not remove.
+          export LC_ALL=C
+          shopt -s nullglob
+          dirs=(.agents/skills/*/)
+          # Without this guard an unexpanded/empty glob iterates zero times and
+          # the job passes having validated nothing -- including if every skill
+          # is later deleted.
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "::error::no skill directories found under .agents/skills/ - nothing to validate"
+            exit 1
+          fi
+          count=0
+          for d in "${dirs[@]}"; do
+            echo "== $d"
+            test -f "$d/SKILL.md" || { echo "::error::$d missing SKILL.md"; exit 1; }
+            test ! -d "$d/references" || { echo "::error::$d has references/ (skills are self-contained)"; exit 1; }
+            name=$(awk -F': *' '/^name:/{print $2; exit}' "$d/SKILL.md")
+            [ "$name" = "$(basename "$d")" ] || { echo "::error::$d name '$name' != dir"; exit 1; }
+            grep -q '^description:' "$d/SKILL.md" || { echo "::error::$d missing description"; exit 1; }
+            case "$name" in
+              *[![:lower:][:digit:]-]*|-*|*-|*--*) echo "::error::$d name '$name' must be lowercase/digits/single hyphens"; exit 1;;
+            esac
+            [ "${#name}" -le 64 ] || { echo "::error::$d name '$name' exceeds 64 chars"; exit 1; }
+            count=$((count + 1))
+          done
+          echo "validated $count skill(s)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,23 +3,32 @@
 Aurelian is a modular multi-cloud security recon framework in Go (AWS, Azure, GCP,
 Kubernetes). It ships as a standalone binary.
 
-## Rules
+## Required reading before you change anything
 
-- Architecture and Aurelian invariants: ARCHITECTURE.md
-- Go craft, DRY, YAGNI, comments: DEVELOPMENT.md
+Normative and binding on new code. Not restated anywhere else.
 
-Both are normative and binding on new code. Read the relevant one before changing
-code. Neither is restated anywhere else — this file points, it does not duplicate.
+- `ARCHITECTURE.md` — Aurelian invariants: layering, module contract, pipeline
+  lifecycle, output types, boundaries.
+- `DEVELOPMENT.md` — Go craft, and the DRY / YAGNI / comment principles that code
+  review enforces against you.
 
-## Skills
+## You must load the matching skill
 
-Load the one matching your task from `.agents/skills/<name>/SKILL.md`:
+Do not work from memory or from this file's summary. Before starting any task below,
+read the whole `SKILL.md` and follow it. If a task matches more than one row, read
+both.
 
-| Task | Skill |
+| If you are… | Read first |
 | --- | --- |
-| Add or change a module, component, enricher | aurelian-module-development |
-| Write an integration test | aurelian-integration-testing |
-| Review a pull request | aurelian-code-review |
+| Adding or changing a module, component, or enricher | `.agents/skills/aurelian-module-development/SKILL.md` |
+| Writing or changing an integration test | `.agents/skills/aurelian-integration-testing/SKILL.md` |
+| Reviewing a pull request | `.agents/skills/aurelian-code-review/SKILL.md` |
+
+Skipping the skill produces code that fails review on rules stated in
+`ARCHITECTURE.md` and `DEVELOPMENT.md`. Reviewers cite those documents by section, so
+"I did not know" is not an available answer.
+
+Skills are loaded by path. Do not rely on your harness auto-discovering them.
 
 ## Build and test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+Aurelian is a modular multi-cloud security recon framework in Go (AWS, Azure, GCP,
+Kubernetes). It ships as a standalone binary.
+
+## Rules
+
+- Architecture and Aurelian invariants: ARCHITECTURE.md
+- Go craft, DRY, YAGNI, comments: DEVELOPMENT.md
+
+Both are normative and binding on new code. Read the relevant one before changing
+code. Neither is restated anywhere else — this file points, it does not duplicate.
+
+## Skills
+
+Load the one matching your task from `.agents/skills/<name>/SKILL.md`:
+
+| Task | Skill |
+| --- | --- |
+| Add or change a module, component, enricher | aurelian-module-development |
+| Write an integration test | aurelian-integration-testing |
+| Review a pull request | aurelian-code-review |
+
+## Build and test
+
+```bash
+go build ./...
+go test ./...
+go generate ./pkg/modules/loader                # regenerate module blank imports
+bash scripts/run-integration-tests.sh           # deploys real cloud infrastructure
+bash scripts/check-architecture-refs.sh         # doc freshness gate
+```
+
+Integration tests stand up real infrastructure and cost money. Read the
+aurelian-integration-testing skill before running them.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,353 @@
+# Aurelian Architecture
+
+Normative. States what Aurelian is and what it must be. Rules here are binding on
+new code and enforced in review.
+
+Go language craft and code principles live in DEVELOPMENT.md, not here.
+Task workflows live in .agents/skills/, not here.
+Nothing in this file is restated in a skill.
+
+Aurelian is a standalone Go binary: a modular multi-cloud security recon framework
+covering AWS, Azure, GCP, and Kubernetes.
+
+## 1. Layering
+
+Seven layers. Each depends only on those below it.
+
+1. **CLI** — `cmd/`. Cobra. `Execute` calls `initCommands`, which calls
+   `generateCommands` (`cmd/generator.go`). One cobra command per registered module,
+   one flag per parameter derived through `plugin.ParametersFrom`. No module logic
+   lives here.
+2. **Registry** — `pkg/plugin`. Modules self-register in `init()` via
+   `plugin.Register`. `cmd/module_imports.go` and `pkg/modules/loader/loader.go`
+   blank-import the module packages so those `init()` functions run. A module with no
+   blank import does not exist at runtime.
+3. **Modules** — `pkg/modules/<csp>/<category>/`. Thin. Bind parameters, build the
+   pipeline topology, delegate to components, emit.
+4. **Pipelines** — `pkg/pipeline`. `pipeline.P[T]` carries items between stages.
+   Leaf package: imports nothing first-party.
+5. **Components** — `pkg/<csp>/<service>/`. All cloud API calls, pagination, and
+   parsing. Reused across modules.
+6. **Enrichment** — enrichers and evaluators registered in `init()`, applied by
+   `pkg/<csp>/enrichment/` as a pipeline stage.
+7. **Output** — `pkg/output`. Result types. Serialized by `cmd/generator.go`.
+
+Dependency direction is one-way: `cmd/` → `pkg/plugin` → `pkg/modules/` →
+`pkg/<csp>/<service>/` → `pkg/output` → `pkg/model`. Components must not import
+`pkg/modules/`. Nothing under `pkg/` may import `cmd/`.
+
+## 2. Directory contract
+
+| Directory | Contents | Rule |
+| --- | --- | --- |
+| `pkg/modules/<csp>/<category>/` | Module implementations. `<csp>` ∈ aws, azure, gcp. `<category>` ∈ recon, analyze, enrichers, evaluators. | One module per file. Register in `init()`. No cloud API calls — delegate to a component. |
+| `pkg/modules/aws/rules/` | Declarative YAML rules consumed by `pkg/modules/common/`. | Data, not code. |
+| `pkg/modules/common/` | CSP-agnostic YAML rule engine: analyzer, matcher, rule. | Not a CSP. Nothing CSP-specific goes here. |
+| `pkg/modules/loader/` | Generated blank-import file. | `pkg/modules/loader/loader.go` is generated — `go generate ./pkg/modules/loader`. Never hand-edit. |
+| `pkg/<csp>/<service>/` | Components: enumerators, checkers, listers, extractors, enrichment appliers. | Cloud API work lives here and only here. Must not import `pkg/modules/`. |
+| `pkg/types/` | Shared structural types (IAM policy, GAAD, enriched resource description). | Cross-package types only. Not module-local shapes. |
+| `pkg/graph/` | Neo4j adapters, queries, transformers. | Graph concerns only. |
+| `test/terraform/<csp>/<category>/<module>/` | Terraform fixtures for integration tests. | Path mirrors the module path. One directory per module under test. |
+
+`pkg/model`, `pkg/pipeline`, `pkg/plugin`, `pkg/output`, `pkg/ratelimit`, `pkg/store`
+are framework packages, contracted in sections 3 through 9.
+
+## 3. Module contract
+
+A module implements `plugin.Module` (`pkg/plugin/module.go:78`) and registers itself
+in `init()` with `plugin.Register` (`pkg/plugin/registry.go:30`). Registration keys on
+`platform/category/id`; a duplicate key panics at startup.
+
+- **Metadata** methods (`ID`, `Name`, `Description`, `Platform`, `Category`,
+  `OpsecLevel`, `Authors`, `References`) return fixed values. No I/O, no config reads.
+- **`SupportedResourceTypes()`** returns the module's *input targets* — the resource
+  types a caller may aim it at. Never the types it discovers internally. Guard matches
+  on this value to decide dispatch, so widening it changes orchestration.
+- **`Parameters()`** returns a pointer to the module's config struct, or nil. The
+  registry wraps every module in `plugin.ModuleWrapper` (`pkg/plugin/module.go:109`),
+  which calls `plugin.Bind` and then the post-binders before `Run`. A module must not
+  call `Bind` itself.
+- **`Run()`** stays thin: read the bound config, build the pipeline topology, delegate
+  to `pkg/<csp>/<service>/` components, emit. Cloud API calls in `Run` are a layering
+  violation.
+
+Modules emit `model.AurelianModel` (`pkg/model/model.go:13`). The interface is sealed
+by an unexported token; the only way to satisfy it is to embed
+`model.BaseAurelianModel`.
+
+The caller owns the output pipeline, including `Close`. `cmd/generator.go:287` runs
+`Run` as a `pipeline.Pipe` stage, so `Pipe` closes the pipeline once `Run` returns. A
+module must never close the pipeline it was handed.
+
+## 4. Pipeline lifecycle
+
+`pipeline.P[T]` (`pkg/pipeline/pipeline.go:18`) wraps an unbuffered channel. Unbuffered
+means every `Send` blocks until a consumer reads — backpressure is the default and
+stalls are real.
+
+Surface (`pkg/pipeline/pipeline.go`):
+
+```
+Send(item T)            Sent() int64      Close()
+CloseWithError(error)   Wait() error      Range() <-chan T
+Drain() error           Collect() ([]T, error)
+```
+
+`Send` returns nothing. There is no error to check.
+
+### What Run returns
+
+Because the caller closes the output pipeline only *after* `Run` returns, what `Run`
+returns decides whether in-flight producers are still writing when that close happens.
+Choose from the table. A wrong choice deadlocks or truncates output.
+
+| Situation | Return |
+| --- | --- |
+| Direct `out.Send()`, no internal pipeline | `return nil` |
+| `pipeline.Pipe(x, fn, out)` targets `out` | `return out.Wait()` |
+| Internal pipeline drained via `Range()`, re-emitted | `return internal.Wait()` |
+
+Row 2: the inner `Pipe` owns `out` and closes it, so `out.Wait()` blocks until that
+stage finishes. Returning `nil` instead races the outer close against a live producer.
+
+Row 3: `out` is written synchronously by `Run`'s own goroutine, so `nil` would be safe
+for ordering — but returning `internal.Wait()` is what propagates the internal stage's
+error. Both `Range()` and `Collect()` must be followed by a `Wait()` whose error is
+returned; ranging alone silently discards upstream failures.
+
+Never `return out.Wait()` when nothing else closes `out`. `Wait` blocks on a channel
+the caller closes only after `Run` returns — that is the deadlock.
+
+### Stage options
+
+`pipeline.PipeOpts` (`pkg/pipeline/pipeline.go:112`) carries `Concurrency` and
+`Progress`. `Concurrency > 1` selects `pipeParallel`, which bounds workers with
+`errgroup` `SetLimit` (`:221`); otherwise stages run sequentially. Concurrency comes
+from a bound parameter, never a literal — see section 6.
+
+## 5. Components and the registry pattern
+
+### Components
+
+Components live in `pkg/<csp>/<service>/` and hold every cloud API call. They are
+plain structs built by a `NewXxx()` constructor that takes the module's bound config
+(`plugin.AWSCommonRecon` and peers) plus collaborators.
+
+Their work methods are shaped `func(T, *pipeline.P[U]) error` so they drop directly
+into `pipeline.Pipe` as a stage with no adapter — for example
+`(*CloudControlEnumerator).List` (`pkg/aws/enumeration/cloud_control_enumerator.go:41`)
+and `(*AWSEnricher).Enrich` (`pkg/aws/enrichment/enricher.go:28`). Write new component
+methods to that shape.
+
+Components have no registry and no `init()`. They are constructed explicitly by the
+module that needs them, which is what makes them reusable across modules.
+
+### The registry pattern
+
+Every registry in `pkg/plugin` has the same shape: a package-level map guarded by a
+mutex, a `Register*` function called from `init()`, and a `Get*` lookup at dispatch
+time. Enrichers get one registry per CSP, not one shared map.
+
+| Registry | Register | Keyed on |
+| --- | --- | --- |
+| Modules | `plugin.Register` | `platform/category/id` |
+| Enrichers (one per CSP) | `plugin.RegisterEnricher`, `plugin.RegisterAzureEnricher`, `plugin.RegisterGCPEnricher` | resource type |
+| Azure evaluators | `plugin.RegisterAzureEvaluator` | template ID |
+
+Registration is a side effect of importing the package. Blank imports in
+`cmd/module_imports.go` and `pkg/modules/loader/loader.go` are the only thing that
+makes registered code reachable. See section 11 — they are not dead code.
+
+## 6. Parameters
+
+Every module parameter is a tagged struct field. `plugin.Bind` (`pkg/plugin/bind.go:11`)
+derives `plugin.Parameter` values from the tags via `plugin.ParametersFrom`, applies
+`cfg.Args`, validates, and populates the struct. `ModuleWrapper` does this before
+`Run`; modules never call it.
+
+Supported tags: `param`, `desc`, `default`, `enum`, `shortcode`, `required`, `hidden`,
+`sensitive`. Every exported, non-embedded field must carry a `param` tag — use
+`param:"-"` to opt a field out. An untagged exported field fails binding at runtime
+with:
+
+```
+field %q in %s is exported but has no `param` tag (use `param:"-"` to skip)
+```
+
+Embed the CSP common struct rather than redeclaring its fields:
+`plugin.AWSReconBase`, `plugin.AWSCommonRecon`, `plugin.OrgPoliciesParam`,
+`plugin.AzureReconBase`, `plugin.AzureCommonRecon`, `plugin.AzureEntraRecon`,
+`plugin.GCPCommonRecon`.
+
+Post-bind work — credential construction, region resolution, clamping, cross-field
+validation — goes in a `PostBind` method satisfying `plugin.PostBinder`
+(`pkg/plugin/module.go:105`). `runPostBindersValue` (`:136`) walks the config struct
+recursively and calls `PostBind` on every embedded struct that implements it, innermost
+first, so embedding `AWSCommonRecon` inherits its region resolution for free. A module
+may add its own `PostBind` alongside.
+
+Concurrency limits, thresholds, and timeouts are parameters, never magic constants.
+
+## 7. Enrichers
+
+An enricher adds properties a bulk listing cannot return. Registration happens in
+`init()`; the function is keyed by resource type.
+
+| CSP | Register | Operates on | Source |
+| --- | --- | --- | --- |
+| AWS | `plugin.RegisterEnricher` | `output.AWSResource` | `pkg/plugin/enricher.go:27` |
+| Azure | `plugin.RegisterAzureEnricher` | `templates.ARGQueryResult` | `pkg/plugin/azure_enricher.go:34` |
+| GCP | `plugin.RegisterGCPEnricher` | `output.GCPResource` | `pkg/plugin/gcp_enricher.go:27` |
+
+Azure enrichers operate on Resource Graph query results, not on `output.AzureResource`.
+
+Enricher implementations live in `pkg/modules/<csp>/enrichers/`. They are applied as a
+pipeline stage by `pkg/<csp>/enrichment/`.
+
+### Mutators versus evaluators
+
+Split the two. A **mutator** is an enricher: it fills in fields on the resource and
+returns. An **evaluator** decides whether a condition holds. Azure evaluators are a
+separate registry — `plugin.RegisterAzureEvaluator` (`pkg/plugin/azure_evaluator.go:23`),
+keyed by template ID, returning `bool`, implemented in
+`pkg/modules/azure/evaluators/`. Risk emission belongs to the module or an evaluator
+stage, not inside a mutating enricher.
+
+### Enrichment is best-effort
+
+An enricher returning an error does not fail the pipeline. The applier logs
+`slog.Warn` and forwards the resource unchanged (`pkg/aws/enrichment/enricher.go:52`).
+A failure to build the per-region cloud config is likewise logged and skipped. Write
+enrichers so a partial result is still useful, and never rely on an enricher's error
+to abort a scan.
+
+## 8. Output types
+
+`pkg/output` holds every result type. Emitted types satisfy `model.AurelianModel` by
+embedding `model.BaseAurelianModel` — `output.AWSIAMResource` gets it transitively
+through the `output.AWSResource` it embeds. This is the complete set:
+
+| Type | Source | Use |
+| --- | --- | --- |
+| `output.AWSResource` | `aws_resource.go:19` | An AWS resource and its properties |
+| `output.AzureResource` | `azure_resource.go:6` | An Azure resource |
+| `output.GCPResource` | `gcp_resource.go:6` | A GCP resource |
+| `output.AWSIAMResource` | `aws_iam_resource.go:8` | IAM principals and policies |
+| `output.AWSIAMRelationship` | `aws_iam_relationship.go:7` | Edges between IAM principals |
+| `output.AurelianRisk` | `aurelian_risk.go:36` | A security finding |
+| `output.Risk` | `risk.go:8` | Legacy finding shape — see below |
+| `output.AnalyzeResult` | `analyze_result.go:13` | Analysis module results |
+| `output.CallerIdentity` | `aws_caller_identity.go:7` | Resolved AWS caller |
+| `output.AWSCostSummary` | `aws_cost_summary.go:10` | Cost Explorer summary |
+| `output.AzureConditionalAccessPolicy` | `azure_conditional_access.go:6` | Entra CA policy, with `output.ResolvedEntity` and the `ConditionalAccess*` sub-shapes |
+| `output.ScanInput` | `scan_input.go:4` | Content extracted for secret scanning. The one exception: it does not embed `model.BaseAurelianModel` and is not emitted — it is an intermediate carried between `pkg/<csp>/extraction/` and the scanner. |
+
+There is no `CloudResource` type and no `SecretFinding` type; anything citing either
+is wrong. Secret scanning results are `secrets.SecretScanResult`
+(`pkg/secrets/scanner.go:24`).
+
+### Risk versus AurelianRisk
+
+Both exist. They are not interchangeable.
+
+`output.AurelianRisk` is the current shape and the one modules emit: 15 composite
+literals across 9 files under `pkg/modules/`, referenced by 28 files. It carries a
+`RiskSeverity` (`output.NormalizeSeverity` canonicalizes the string) and a
+`json.RawMessage` context blob.
+
+`output.Risk` has zero composite literals under `pkg/modules/`. It is constructed only
+by the CDK scanner in `pkg/aws/cdk` (10 literals) and forwarded unchanged by one
+module, `pkg/modules/aws/recon/cdk_bucket_takeover.go:64`. It carries a `Target
+*AWSResource` and a two-letter `Status` severity code.
+
+New findings use `output.AurelianRisk`. `output.Risk` stays confined to the CDK path.
+
+### Direction
+
+Output types are migrating to capability-sdk/pkg/capmodel. Not yet landed in Aurelian:
+go.mod has no capability-sdk requirement and the tree has no capmodel references.
+
+Plan: docs/superpowers/plans/2026-04-29-aurelian-capability-sdk-migration.md
+Aurelian's work is phases 4-6, gated behind phases 1-3 in capability-sdk, tabularium,
+and guard. Translation will live in pkg/sdkadapter/, not in modules. capmodel has
+per-CSP resource models and its own risk and proof models.
+
+When phase 4 lands and pkg/sdkadapter/ exists, this section flips: capmodel becomes
+current, pkg/output becomes legacy, and the section 10 import boundary narrows to
+modules only. This doc is staged for that, not stale.
+
+## 9. Cross-cutting infrastructure
+
+Use these rather than hand-rolling. Each already handles a failure mode that bit this
+codebase.
+
+**Pagination and retry.** `pkg/ratelimit` supplies one paginator per CSP, differing
+only in the retry predicate: `ratelimit.NewAWSPaginator` (`paginator.go:20`, retries
+`ThrottlingException: Rate exceeded`), `ratelimit.NewGCPPaginator` (`:30`, retries 429
+and 503), `ratelimit.NewAzurePaginator` (`:43`, retries 429 and 503 via
+`azcore.ResponseError`). Default `MaxAttempts` is 5.
+
+**Region fan-out.** `ratelimit.NewCrossRegionActor(concurrency)`
+(`region_actor.go:19`). `ActInRegions` bounds workers with `errgroup` `SetLimit` and
+acquires the per-region limiter for each call; `ActInRegion` does one region. Do not
+write manual region loops — they bypass the per-region limiter and throttle the account.
+
+**Rate limiting.** `ratelimit.NewAWSRegionLimiter(limit)` (`aws_region_limiter.go:48`)
+gives each region its own semaphore. `ratelimit.Global()` (`:57`) also exists: a
+process-wide singleton fixed at 5 per region, shared by every concurrent scan. It has
+no callers today and new code does not add one — see section 10.
+
+**Keyed state.** `store.Map[T]` (`pkg/store/map.go:43`). `store.NewMap[T]()` (`:48`)
+returns a **value**, not a pointer; a zero-value `Map` is safe to use, so call sites
+need no nil checks. Build tags select the backend: `compute` uses SQLite
+(`pkg/store/new_map_sqlite.go`), `!compute` uses memory (`pkg/store/new_map.go`).
+Reach for it only when a later stage needs random-access lookup of earlier results. A
+pipeline is almost always the better answer.
+
+## 10. Boundaries
+
+Six prohibitions. Prohibitions 1, 2, 3, 4, and 6 have zero violations today, so any
+hit is a regression. Prohibition 5 has pre-existing violations; it binds new and
+changed code.
+
+1. **AWS SDK v2 only.** `github.com/aws/aws-sdk-go` (v1) is prohibited. go.mod
+   requires only `aws-sdk-go-v2` modules and the tree has zero v1 imports.
+2. **No Chariot or Tabularium imports under `pkg/modules/`.** Zero today. Aurelian
+   ships as a standalone binary and module code stays free of platform coupling.
+3. **No dispatcher or orchestrator package.** Neither pkg/dispatcher nor
+   pkg/orchestrator exists and neither may be created. Dispatch is the registry
+   (section 5); modules go in `pkg/modules/`.
+4. **No `ratelimit.Global()` in new code.** It is a process-wide singleton pinned at 5
+   concurrent calls per region, shared across unrelated scans, with no way to tune it
+   per module. Construct a scoped `ratelimit.NewAWSRegionLimiter(limit)` or use
+   `ratelimit.NewCrossRegionActor`. Current callers: zero. Keep it that way.
+5. **Parse resource identifiers with a real parser, never `strings.Split`.** AWS:
+   `arn.Parse` from the SDK. Azure: `arm.ParseResourceID`. GCP publishes no equivalent
+   — use the shared helpers in `pkg/gcp/enumeration/resource_helpers.go` rather than
+   splitting a self-link inline.
+6. **No `capability-sdk` import under `pkg/modules/`.** Modules emit
+   `model.AurelianModel`; translation to capmodel belongs in a future
+   pkg/sdkadapter/. From the migration plan's constraint table: *"No capability-sdk
+   imports leak into Aurelian module `init()`. SDK registration lives in chariot
+   bridge."* This is enforceable now, before any of the migration lands, and it is what
+   protects the standalone-binary constraint. Section 8 Direction describes the
+   migration; this is the rule.
+
+## 11. Load-bearing patterns
+
+These four look like dead code, over-engineering, or indirection for its own sake.
+They are none of those. Do not flag them, and do not "simplify" them away.
+
+1. **Blank imports for `init()` side effects.** `_ "path"` in `cmd/module_imports.go`
+   and `pkg/modules/loader/loader.go` is the only thing that makes a module reachable.
+   An unused-looking import here is the wiring.
+2. **`init()` functions and registry self-registration.** `plugin.Register`,
+   `plugin.RegisterEnricher` and peers, `plugin.RegisterAzureEvaluator`. The registered
+   function has no static caller by design; the registry is the caller.
+3. **Dispatch through a registry or reflection.** Enricher and evaluator functions are
+   invoked from a map keyed by resource type or template ID. `plugin.PostBinder` is
+   discovered by reflection over embedded structs (`pkg/plugin/module.go:136`). Neither
+   has a call site a static analyzer can see.
+4. **Interface boundaries for CSP polymorphism.** An interface with one implementation
+   today is correct when it exists to hold the AWS/Azure/GCP/Kubernetes shape uniform.
+   The second implementation is the point.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,9 +32,22 @@ Seven layers. Each depends only on those below it.
    `pkg/<csp>/enrichment/` as a pipeline stage.
 7. **Output** — `pkg/output`. Result types. Serialized by `cmd/generator.go`.
 
-Dependency direction is one-way: `cmd/` → `pkg/plugin` → `pkg/modules/` →
-`pkg/<csp>/<service>/` → `pkg/output` → `pkg/model`. Components must not import
-`pkg/modules/`. Nothing under `pkg/` may import `cmd/`.
+Dependency direction, stated as "imports" rather than arrows:
+
+- `cmd/` imports `pkg/modules/<csp>/<category>/` — blank imports, for `init()` registration —
+  plus `pkg/plugin`, `pkg/output`, `pkg/model`.
+- `pkg/modules/` imports `pkg/plugin`, `pkg/<csp>/<service>/`, `pkg/output`, `pkg/pipeline`.
+- `pkg/plugin` imports `pkg/output`, `pkg/model`, `pkg/pipeline`, `pkg/templates`, `pkg/graph`,
+  and some `pkg/<csp>/<service>/` packages. It **never** imports `pkg/modules/`.
+
+Two rules follow, and both hold today:
+
+- **Nothing under `pkg/` imports `cmd/`.** Zero violations.
+- **`pkg/plugin` does not import `pkg/modules/`.** Zero violations. Registration is inverted:
+  107 module files import `pkg/plugin` and register themselves through it.
+
+Components under `pkg/<csp>/<service>/` do not import `pkg/modules/` in production code. One
+test file blank-imports `pkg/modules/loader` for registration coverage; that is not a violation.
 
 ## 2. Directory contract
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,6 @@
 .github/workflows/ @praetorian-inc/CapDev-Maintainers-CloudSec @praetorian-inc/CapDev-Admins-All
+/CODEOWNERS        @praetorian-inc/CapDev-Maintainers-CloudSec @praetorian-inc/CapDev-Admins-All
+/AGENTS.md         @praetorian-inc/CapDev-Maintainers-CloudSec @praetorian-inc/CapDev-Admins-All
+/ARCHITECTURE.md   @praetorian-inc/CapDev-Maintainers-CloudSec @praetorian-inc/CapDev-Admins-All
+/DEVELOPMENT.md    @praetorian-inc/CapDev-Maintainers-CloudSec @praetorian-inc/CapDev-Admins-All
+/.agents/          @praetorian-inc/CapDev-Maintainers-CloudSec @praetorian-inc/CapDev-Admins-All

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,200 @@
+# Development Standards
+
+Normative Go craft rules for this repository. Code review enforces all of them.
+Architecture-specific contracts live in ARCHITECTURE.md.
+
+## 1. Go version
+
+`go.mod` declares Go 1.25.8. Every pattern in this document is available at that
+version, so "the compiler doesn't support it" is never true here.
+
+The declared version is the only valid reason to reject a modern pattern. Team
+familiarity, time pressure, and "the surrounding code does it the old way" are not.
+
+When you touch a file, modernize the legacy patterns in the code you touch. Do not
+sweep files the task does not touch (§8).
+
+## 2. Legacy smells
+
+If the stdlib has a function for it, use the stdlib function. A manual loop that
+`slices`, `maps`, or `cmp` already implements is legacy code.
+
+| Legacy | Modern |
+| --- | --- |
+| Loop to find an element | `slices.Contains`, `slices.ContainsFunc` |
+| Loop returning an index | `slices.Index` |
+| `sort.Slice`, `sort.Strings` | `slices.Sort`, `slices.SortFunc` |
+| `append([]T(nil), s...)`, make + copy loop | `slices.Clone`, `maps.Clone` |
+| `append(s[:i], s[j:]...)` | `slices.Delete` |
+| Manual consecutive-dedup loop | `slices.Compact` |
+| Length check + element-compare loop | `slices.Equal`, `maps.Equal` |
+| make + append + append | `slices.Concat` |
+| Loop copying map entries | `maps.Copy` |
+| Custom `minInt` / `maxInt` helpers | `min`, `max` builtins |
+| `for k := range m { delete(m, k) }` | `clear(m)` |
+| Conditional map-delete loop | `maps.DeleteFunc` |
+| `for i := 0; i < n; i++` | `for i := range n` |
+| Chained `if x == "" { x = fallback }` | `cmp.Or(x, fallback)` |
+| Loop to collect and sort map keys | `slices.Sorted(maps.Keys(m))` |
+| Loop to collect map values | `slices.Collect(maps.Values(m))` |
+| Index arithmetic to batch a slice | `slices.Chunk(s, size)` |
+| Channel-based iterator | `iter.Seq`, `iter.Seq2` |
+| `strings.SplitN(s, sep, 2)` | `strings.Cut` |
+| `HasPrefix` + `TrimPrefix` | `strings.CutPrefix` (same for `CutSuffix`) |
+| `interface{}` | `any` |
+| `err == ErrSentinel` | `errors.Is` (§3) |
+| `log.Printf` with a formatted string | `slog` (§5) |
+| `sync.WaitGroup` + error channel | `errgroup` (§4) |
+| Manual `b.N` loop in a benchmark | `for b.Loop()` |
+
+Loop variable copies (`v := v` at the top of a loop body) are dead code. Delete on
+sight.
+
+Multi-field sort composes through `cmp.Or`:
+
+```go
+slices.SortFunc(rows, func(a, b Row) int {
+    return cmp.Or(cmp.Compare(a.Kind, b.Kind), cmp.Compare(a.Name, b.Name))
+})
+```
+
+Two traps:
+
+- `clear(s)` on a slice zeros the elements and keeps `len(s)`. Use `s = s[:0]` to
+  truncate.
+- `cmp.Or` evaluates every argument eagerly. Never pass it an expensive call.
+
+## 3. Error handling
+
+- Wrap with `%w`, not `%v`. `%w` preserves the chain that `errors.Is` and `errors.As`
+  walk.
+- Use `%v` only to deliberately hide an internal error from callers. That is an API
+  decision — make it on purpose, not by reflex.
+- Compare with `errors.Is`, never `==`. Equality breaks the moment anything in the
+  call path wraps.
+- Reach a concrete error type with `errors.As`, never a type assertion.
+- Aggregate with `errors.Join(errs...)`. It returns nil when every element is nil. No
+  third-party multierror package.
+- `fmt.Errorf` accepts more than one `%w` in a single format string.
+- **Never classify an error by string-matching its message.** Provider and SDK message
+  text changes without notice and silently disables the branch. Use `errors.As` to get
+  the typed error and read its code — cloud SDK error types expose an `ErrorCode()`
+  accessor for exactly this.
+- Every wrap must add context the caller does not already have. `"failed to fetch: %w"`
+  inside `Fetch` adds nothing; the location is already in the chain.
+- Handle the error or return it. Never both, and never discard it into `_`.
+
+## 4. Concurrency
+
+Use `errgroup` (`golang.org/x/sync/errgroup`) whenever concurrent work can fail. It
+replaces `sync.WaitGroup` plus an error channel plus manual cancellation.
+
+```go
+g, ctx := errgroup.WithContext(ctx)
+g.SetLimit(10) // match the real constraint: pool size, rate limit, CPU count
+for _, item := range items {
+    g.Go(func() error { return process(ctx, item) })
+}
+if err := g.Wait(); err != nil {
+    return fmt.Errorf("processing items: %w", err)
+}
+```
+
+- `WithContext` cancels the derived context on the first error. Use it; do not
+  hand-roll cancellation.
+- `SetLimit` replaces semaphore channels. `g.Go` blocks once the limit is reached, so
+  no buffered channel is needed.
+- Use `TryGo` when the correct behavior is to skip work rather than wait for a slot.
+- Long-running goroutines must check `ctx.Err()` or select on `ctx.Done()`. A goroutine
+  that ignores cancellation is a leak.
+- Never reuse a Group after `Wait`. Construct a new one.
+- `ctx context.Context` is the first parameter of any function that blocks, and it is
+  propagated, not replaced with `context.Background()` mid-call.
+- Do not store a request-scoped context in a struct that outlives the request.
+- `context.WithoutCancel` for work that must outlive its parent.
+- `context.AfterFunc` for cleanup on cancellation, instead of a goroutine parked on
+  `<-ctx.Done()`.
+- Guard shared mutable state with a mutex or keep it in one goroutine. Run the race
+  detector on anything concurrent: `go test -race ./...`.
+
+## 5. Structured logging
+
+`slog` only. Key-value attributes, never a preformatted message.
+
+```go
+slog.Info("scan complete", "target", target, "findings", len(findings))
+```
+
+- Severity: `Debug` is developer trace detail. `Info` is normal operation, one record
+  per meaningful unit of work. `Warn` is degraded but proceeding. `Error` is the
+  operation failed.
+- Do not log an error and also return it — the caller logs it again, and one failure
+  becomes five records. Whoever stops propagating it logs it.
+- Scope repeated attributes instead of retyping them:
+  `logger := slog.Default().With("run_id", runID)`. Pass the logger down.
+- Attribute keys are stable snake_case identifiers. Never interpolate a value into a
+  key; that makes the field unqueryable.
+- Never log credentials, tokens, or raw customer data. Log identifiers.
+
+## 6. Generics
+
+Three valid uses, and no others:
+
+1. Container utilities over slices, maps, or channels where the element type varies.
+2. Generic data structures — sets, trees, queues.
+3. Identical implementations where only the type differs.
+
+- Write the concrete code first. Add type parameters when duplication exists, not when
+  you predict it (§8).
+- Do not replace an interface with a type parameter. If the body only calls methods,
+  take the interface.
+- Use the minimum sufficient constraint: `any` < `comparable` < `cmp.Ordered` < a
+  custom method interface. Over-constraining rejects valid callers.
+- Do not under-constrain either. A constraint too loose for the body forces type
+  assertions back inside, which defeats the point.
+- Let inference work. Do not spell out type arguments the compiler deduces.
+- Prefer a function parameter such as `cmp func(T, T) int` over a method constraint.
+  Method constraints force wrapper types around primitives.
+- Iterators are `iter.Seq[V]` and `iter.Seq2[K, V]`. Always honor a false return from
+  `yield` and stop. Never use a channel as an iterator.
+
+## 7. DRY
+
+**Rule.** Extract logic that appears three times into a shared component or helper.
+
+**Trigger.** The same logic appears a third time. Two occurrences is not a violation —
+two is the sample size at which the wrong abstraction still looks correct. Naming
+tells: numbered identifiers (`data1`, `data2`), parallel function families, adjacent
+blocks differing only in a constant.
+
+**Carve-outs.** Parallel implementations of one interface that merely resemble each
+other and will diverge on their own schedule. Generated code. Test fixtures and test
+setup, where readability beats deduplication. Patterns not yet clear enough to name.
+See ARCHITECTURE.md §11.
+
+## 8. YAGNI
+
+**Rule.** Build only what the current change requires.
+
+**Trigger.** A parameter, struct field, config value, or exported helper added in this
+diff with zero readers in this diff. An interface with one implementation and no second
+one named in the PR. A config struct where a literal or an existing flag would do. A
+dependency for something the stdlib already does. Compile-time interface-compliance
+assertions, and placeholder types with no members.
+
+**Carve-outs.** ARCHITECTURE.md §11 load-bearing patterns. Correctness work the
+requested change depends on: a bug that would break it, a security hole it would
+introduce, a data-loss path it would open. Take those, and say so in the PR
+description.
+
+## 9. Comments
+
+**Rule.** Comment why, never what.
+
+**Trigger.** A comment restating what the next line does. Doc comments of the form
+`// NewFoo creates a new Foo` on a self-describing signature.
+
+**Carve-outs.** Non-obvious behavior, and the reason for it. External constraints the
+code cannot express (rate limits, provider quirks, protocol requirements). Algorithms
+whose correctness argument is not visible locally. Deliberate-simplification markers
+recording that the simple form was chosen on purpose.

--- a/scripts/check-architecture-refs.sh
+++ b/scripts/check-architecture-refs.sh
@@ -1,66 +1,45 @@
 #!/usr/bin/env bash
-# Asserts every repo path and Go identifier cited in the agent-facing docs still
-# exists, and that the Go version cited matches go.mod. Docs that rot silently
-# produce confident-but-wrong AI review findings, so this runs on every PR.
+# Fails when the agent-facing docs cite a repo path, first-party identifier, or Go
+# version that no longer matches the tree. Stale docs produce confident-but-wrong
+# AI review findings, so this runs on every PR that touches the docs or the source
+# they cite.
 set -euo pipefail
-
 cd "$(dirname "$0")/.."
 
-DOCS=(ARCHITECTURE.md DEVELOPMENT.md AGENTS.md)
-while IFS= read -r f; do DOCS+=("$f"); done < <(find .agents/skills -name 'SKILL.md' 2>/dev/null)
+docs=(ARCHITECTURE.md DEVELOPMENT.md AGENTS.md)
+while IFS= read -r f; do docs+=("$f"); done < <(find .agents/skills -name SKILL.md 2>/dev/null)
 
 fail=0
 note() { printf '%s\n' "$1" >&2; fail=1; }
 
-# 1. Go version must match go.mod
-gomod_ver=$(awk '/^go /{print $2; exit}' go.mod)
-if ! grep -qF "$gomod_ver" DEVELOPMENT.md 2>/dev/null; then
-  note "DEVELOPMENT.md does not cite go.mod version $gomod_ver"
-fi
-# Read line-by-line: the match "Go 1.24" contains a space, so an unquoted
-# command substitution would split it into "Go" and "1.24" and report twice --
-# and the bare "Go" token can never match the go.mod version, so every doc
-# citing any Go version would fail the gate.
-while IFS= read -r bad; do
-  [ -n "$bad" ] || continue
-  # Compare on major.minor. go.mod may be two-part ("1.25") or three-part
-  # ("1.25.8"); ${v%.*} on a two-part value yields "1", which would match any
-  # 1.x and silently disable this check.
-  case "$gomod_ver" in *.*.*) want="${gomod_ver%.*}";; *) want="$gomod_ver";; esac
-  case "$bad" in *"$want"*) ;; *) note "stale Go version '$bad' (go.mod: $gomod_ver)";; esac
-done < <(grep -ohE 'Go 1\.[0-9]+' "${DOCS[@]}" 2>/dev/null | sort -u)
+# 1. Go version. Compare on major.minor; go.mod may be "1.25" or "1.25.8".
+ver=$(awk '/^go /{print $2; exit}' go.mod)
+case "$ver" in *.*.*) want=${ver%.*};; *) want=$ver;; esac
+grep -qF "$ver" DEVELOPMENT.md 2>/dev/null || note "DEVELOPMENT.md does not cite go.mod version $ver"
+# read -r, not $(...): "Go 1.24" contains a space and would word-split.
+while IFS= read -r v; do
+  case "$v" in *"$want"*) ;; *) note "stale Go version '$v' (go.mod: $ver)";; esac
+done < <(grep -ohE 'Go 1\.[0-9]+' "${docs[@]}" 2>/dev/null | sort -u)
 
-# 2. Every backticked repo path must exist
-for doc in "${DOCS[@]}"; do
+for doc in "${docs[@]}"; do
   [ -f "$doc" ] || continue
-  for p in $(grep -ohE '`(pkg|cmd|test|internal|scripts)/[A-Za-z0-9_./<>-]*`' "$doc" \
-             | tr -d '`' | grep -v '<' | sort -u); do
+
+  # 2. Backticked repo paths must exist. Placeholders like <csp> are skipped.
+  for p in $(grep -ohE '`(pkg|cmd|test|internal|scripts)/[A-Za-z0-9_./<>-]*`' "$doc" |
+             tr -d '`' | grep -v '<' | sort -u); do
     [ -e "${p%/}" ] || note "$doc: path does not exist: $p"
   done
-done
 
-# 3. Every backticked pkg-qualified identifier must resolve.
-#    First-party prefixes only. Third-party types that ARCHITECTURE.md documents as a
-#    migration target (notably capmodel.*, see ARCHITECTURE.md section 8 Direction) are
-#    deliberately NOT checked -- they are documented before they are imported. The
-#    backtick anchors the alternation, so `capmodel.X` does not match `model\.`.
-for doc in "${DOCS[@]}"; do
-  [ -f "$doc" ] || continue
-  for sym in $(grep -ohE '`(pipeline|plugin|ratelimit|store|output|model)\.[A-Z][A-Za-z0-9_]*`' "$doc" \
-               | tr -d '`' | sort -u); do
-    pkgname="${sym%%.*}"; ident="${sym##*.}"
-    # Three shapes must resolve:
-    #   1. top-level  func/type/var/const Name ...
-    #   2. methods    func (r *Recv) Name(...)  and generic receivers func (r *R[T, K]) Name
-    #   3. block members  const ( ... \n\tName Type = ... )  -- an indented member of a
-    #      const(/var( block. Without this a real block constant is reported unresolved.
-    grep -rqE "^(func|type|var|const) +${ident}\b|^func +\([^)]*\) *${ident}\b|^[[:space:]]+${ident}([[:space:]]|,|=)" \
-      "pkg/${pkgname}/" 2>/dev/null || note "$doc: unresolved identifier: $sym"
+  # 3. Backticked first-party identifiers must resolve. capmodel.* is deliberately
+  #    excluded -- ARCHITECTURE.md section 8 documents it before the repo imports it.
+  for sym in $(grep -ohE '`(pipeline|plugin|ratelimit|store|output|model)\.[A-Z][A-Za-z0-9_]*`' "$doc" |
+               tr -d '`' | sort -u); do
+    id=${sym##*.}
+    # top-level decl | method, incl. generic receiver | member of a const(/var( block
+    grep -rqE "^(func|type|var|const) +$id\b|^func +\([^)]*\) *$id\b|^[[:space:]]+$id([[:space:]]|,|=)" \
+      "pkg/${sym%%.*}/" 2>/dev/null || note "$doc: unresolved identifier: $sym"
   done
 done
 
-if [ "$fail" -ne 0 ]; then
-  echo "FAIL: doc references drifted from source" >&2
-  exit 1
-fi
+[ "$fail" -eq 0 ] || { echo "FAIL: doc references drifted from source" >&2; exit 1; }
 echo "OK: all doc references resolve"

--- a/scripts/check-architecture-refs.sh
+++ b/scripts/check-architecture-refs.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Asserts every repo path and Go identifier cited in the agent-facing docs still
+# exists, and that the Go version cited matches go.mod. Docs that rot silently
+# produce confident-but-wrong AI review findings, so this runs on every PR.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DOCS=(ARCHITECTURE.md DEVELOPMENT.md AGENTS.md)
+while IFS= read -r f; do DOCS+=("$f"); done < <(find .agents/skills -name 'SKILL.md' 2>/dev/null)
+
+fail=0
+note() { printf '%s\n' "$1" >&2; fail=1; }
+
+# 1. Go version must match go.mod
+gomod_ver=$(awk '/^go /{print $2; exit}' go.mod)
+if ! grep -qF "$gomod_ver" DEVELOPMENT.md 2>/dev/null; then
+  note "DEVELOPMENT.md does not cite go.mod version $gomod_ver"
+fi
+# Read line-by-line: the match "Go 1.24" contains a space, so an unquoted
+# command substitution would split it into "Go" and "1.24" and report twice --
+# and the bare "Go" token can never match the go.mod version, so every doc
+# citing any Go version would fail the gate.
+while IFS= read -r bad; do
+  [ -n "$bad" ] || continue
+  case "$bad" in *"${gomod_ver%.*}"*) ;; *) note "stale Go version '$bad' (go.mod: $gomod_ver)";; esac
+done < <(grep -ohE 'Go 1\.[0-9]+' "${DOCS[@]}" 2>/dev/null | sort -u)
+
+# 2. Every backticked repo path must exist
+for doc in "${DOCS[@]}"; do
+  [ -f "$doc" ] || continue
+  for p in $(grep -ohE '`(pkg|cmd|test|internal|scripts)/[A-Za-z0-9_./<>-]*`' "$doc" \
+             | tr -d '`' | grep -v '<' | sort -u); do
+    [ -e "${p%/}" ] || note "$doc: path does not exist: $p"
+  done
+done
+
+# 3. Every backticked pkg-qualified identifier must resolve.
+#    First-party prefixes only. Third-party types that ARCHITECTURE.md documents as a
+#    migration target (notably capmodel.*, see ARCHITECTURE.md section 8 Direction) are
+#    deliberately NOT checked -- they are documented before they are imported. The
+#    backtick anchors the alternation, so `capmodel.X` does not match `model\.`.
+for doc in "${DOCS[@]}"; do
+  [ -f "$doc" ] || continue
+  for sym in $(grep -ohE '`(pipeline|plugin|ratelimit|store|output|model)\.[A-Z][A-Za-z0-9_]*`' "$doc" \
+               | tr -d '`' | sort -u); do
+    pkgname="${sym%%.*}"; ident="${sym##*.}"
+    grep -rqE "^(func|type|var|const) +\(?[A-Za-z]* ?\*?[A-Za-z\[\]]*\)? *${ident}\b|^(func|type) +${ident}\b" \
+      "pkg/${pkgname}/" 2>/dev/null || note "$doc: unresolved identifier: $sym"
+  done
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL: doc references drifted from source" >&2
+  exit 1
+fi
+echo "OK: all doc references resolve"

--- a/scripts/check-architecture-refs.sh
+++ b/scripts/check-architecture-refs.sh
@@ -23,7 +23,11 @@ fi
 # citing any Go version would fail the gate.
 while IFS= read -r bad; do
   [ -n "$bad" ] || continue
-  case "$bad" in *"${gomod_ver%.*}"*) ;; *) note "stale Go version '$bad' (go.mod: $gomod_ver)";; esac
+  # Compare on major.minor. go.mod may be two-part ("1.25") or three-part
+  # ("1.25.8"); ${v%.*} on a two-part value yields "1", which would match any
+  # 1.x and silently disable this check.
+  case "$gomod_ver" in *.*.*) want="${gomod_ver%.*}";; *) want="$gomod_ver";; esac
+  case "$bad" in *"$want"*) ;; *) note "stale Go version '$bad' (go.mod: $gomod_ver)";; esac
 done < <(grep -ohE 'Go 1\.[0-9]+' "${DOCS[@]}" 2>/dev/null | sort -u)
 
 # 2. Every backticked repo path must exist
@@ -45,7 +49,12 @@ for doc in "${DOCS[@]}"; do
   for sym in $(grep -ohE '`(pipeline|plugin|ratelimit|store|output|model)\.[A-Z][A-Za-z0-9_]*`' "$doc" \
                | tr -d '`' | sort -u); do
     pkgname="${sym%%.*}"; ident="${sym##*.}"
-    grep -rqE "^(func|type|var|const) +\(?[A-Za-z]* ?\*?[A-Za-z\[\]]*\)? *${ident}\b|^(func|type) +${ident}\b" \
+    # Three shapes must resolve:
+    #   1. top-level  func/type/var/const Name ...
+    #   2. methods    func (r *Recv) Name(...)  and generic receivers func (r *R[T, K]) Name
+    #   3. block members  const ( ... \n\tName Type = ... )  -- an indented member of a
+    #      const(/var( block. Without this a real block constant is reported unresolved.
+    grep -rqE "^(func|type|var|const) +${ident}\b|^func +\([^)]*\) *${ident}\b|^[[:space:]]+${ident}([[:space:]]|,|=)" \
       "pkg/${pkgname}/" 2>/dev/null || note "$doc: unresolved identifier: $sym"
   done
 done


### PR DESCRIPTION
Closes LAB-4616.

Migrates Aurelian's architecture docs and agent skills into the repo ahead of the `praetorian-cloud` and `praetorian-core` retirement, and puts a CI gate on their accuracy. Harness-agnostic throughout — no `CLAUDE.md`, no vendor-specific syntax.

## What lands

| File | Role |
| --- | --- |
| `ARCHITECTURE.md` | Aurelian invariants — what is true and must be true about this system |
| `DEVELOPMENT.md` | Go craft invariants plus DRY/YAGNI/comments; lifts into any Praetorian Go repo |
| `AGENTS.md` | Vendor-neutral router per [agents.md](https://agents.md/); points, never inlines |
| `.agents/skills/*/SKILL.md` | Three [Agent Skills](https://agentskills.io) workflows: module development, integration testing, code review |
| `scripts/check-architecture-refs.sh` + `docs-check.yml` | Freshness gate and skill-format validation |
| `CODEOWNERS` | Extended to the new rule paths |

## The organising rule

Anything true both while building **and** while reviewing is an invariant. It lives in `ARCHITECTURE.md` (Aurelian) or `DEVELOPMENT.md` (Go craft), in exactly one of them, and skills cite it rather than restate it. A CI audit asserts each invariant appears in exactly one file.

That is the fix for the actual problem: the rules previously existed in three places — a private skill library, a ~200-line inline prompt in `ai-review.yml`, and 16 lines of README — and had already drifted apart.

## Corrections to live behaviour

Every symbol was verified against `pkg/` rather than transcribed. Two of the errors found are **currently active in `ai-review.yml`**, meaning the reviewer has been generating findings against correct code:

- **`output.CloudResource` does not exist.** The prompt instructs "modules emit `output.CloudResource` only". `grep -rn '^type CloudResource' pkg/` returns nothing. Same for `SecretFinding` (the real type is `secrets.SecretScanResult`).
- **Double-close is safe, not a defect.** The prompt lists "double-close on the same pipeline" as a Tier 1 bug. `pkg/pipeline/pipeline.go:59` documents `Close` as *"safe to call multiple times"* and guards it with `closeOnce`. Send-after-close is real and is kept.

Also corrected from the source material: `ratelimit.NewPaginator` (constructors are per-CSP), the nebula-era `modules/aurelian/test/terraform/` fixture path, a nonexistent exported GCP ID parser, an `output.ScanInput`/`BaseAurelianModel` overclaim, an enricher-registry undercount, and a shared-container `TestMain` pattern asserted in bold by the source that has **zero occurrences** repo-wide.

`strings.Split` on resource identifiers is scoped to new and changed code — 18 existing violations mean an absolute rule would fire on every touched legacy file.

## capability-sdk

`ARCHITECTURE.md` §8 documents the migration to `capability-sdk/pkg/capmodel` as **direction, with no rule attached** — it has not reached this repo (`go.mod` has no requirement, the tree has no `capmodel` references), so a rule would flag correct code today. The enforceable part is §10 item 6: no `capability-sdk` import under `pkg/modules/`, preserving the migration plan's own constraint that Aurelian stays a standalone binary.

## Not in this PR

- **`ai-review.yml` is untouched.** It is rewired in a follow-up to read these files from `main` via a base-ref checkout, which requires them to be on `main` first.
- **CODEOWNERS is advisory until `require_code_owner_review` is enabled.** All three rulesets carrying a `pull_request` rule have it `false`, and two are Organization-scoped — so that is not a repo-side change.

## Verification

```
scripts/check-architecture-refs.sh   OK: all doc references resolve
skills validation                    validated 3 skill(s)
DRY audit                            every invariant in exactly one file
```
