### PR TITLE
feat(dnstakeover): S3 website, Front Door, Route53 alias DNSName (ENG-7424)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v8 v8.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/digitaltwins/armdigitaltwins v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/digitaltwins/armdigitaltwi
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/digitaltwins/armdigitaltwins v1.2.0/go.mod h1:ESqbgba0Fl1eop2bwoJ84Vmh+d093eDrYK2TdR9bKEM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 h1:lpOxwrQ919lCZoNCd69rVt8u1eLZuMORrGXqy8sNf3c=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0/go.mod h1:fSvRkb8d26z9dbL40Uf/OO6Vo9iExtZK3D0ulRV+8M0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0 h1:dz5II+dFuMkrdpIkO9f/Ht3f8hnRUURiQdLj1hwKO5Q=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0/go.mod h1:0tuwjeZbMwLV7h1bcyfTlnXUH6GBKkPml8ukX6EoS3o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0 h1:VvSZmyJEBvdzQXbs1Ued+iaapfSze5+rawR0EFFzyVw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0/go.mod h1:6BoXNi4OfvyyIdP4vl4fEGt8CWHFFDMHgiUtNLHl1/0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=

--- a/pkg/aws/cloudfront/buckets.go
+++ b/pkg/aws/cloudfront/buckets.go
@@ -16,10 +16,10 @@ type S3API interface {
 	GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
 }
 
-// checkBucketExists determines whether an S3 bucket exists and is owned by the
+// CheckBucketExists determines whether an S3 bucket exists and is owned by the
 // current account. On a PermanentRedirect (bucket exists globally but in a
 // different region), it falls through to GetBucketLocation to verify ownership.
-func checkBucketExists(ctx context.Context, client S3API, bucketName string) BucketExistence {
+func CheckBucketExists(ctx context.Context, client S3API, bucketName string) BucketExistence {
 	_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: &bucketName,
 	})
@@ -115,13 +115,13 @@ func checkDistributionOrigins(ctx context.Context, client S3API, dist Distributi
 			continue
 		}
 
-		bucketName := extractBucketName(origin.DomainName)
+		bucketName := ExtractBucketName(origin.DomainName)
 		if bucketName == "" {
 			slog.Debug("could not extract bucket name from origin domain", "domain", origin.DomainName)
 			continue
 		}
 
-		existence := checkBucketExists(ctx, client, bucketName)
+		existence := CheckBucketExists(ctx, client, bucketName)
 		if existence == BucketNotExists || existence == BucketExistsNotOwned {
 			vulnerable = append(vulnerable, VulnerableDistribution{
 				DistributionID:     dist.ID,

--- a/pkg/aws/cloudfront/distributions.go
+++ b/pkg/aws/cloudfront/distributions.go
@@ -45,8 +45,8 @@ var bucketNamePatterns = []struct {
 	{regexp.MustCompile(`^s3-([a-z0-9-]+)\.amazonaws\.com/([^/]+)`), 2},
 }
 
-// extractBucketName extracts the S3 bucket name from an origin domain using regex-based matching.
-func extractBucketName(originDomain string) string {
+// ExtractBucketName extracts the S3 bucket name from an origin domain using regex-based matching.
+func ExtractBucketName(originDomain string) string {
 	domain := strings.TrimPrefix(originDomain, "https://")
 	domain = strings.TrimPrefix(domain, "http://")
 

--- a/pkg/aws/cloudfront/distributions_test.go
+++ b/pkg/aws/cloudfront/distributions_test.go
@@ -93,7 +93,7 @@ func TestExtractBucketName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.domain, func(t *testing.T) {
-			assert.Equal(t, tt.expected, extractBucketName(tt.domain))
+			assert.Equal(t, tt.expected, ExtractBucketName(tt.domain))
 		})
 	}
 }

--- a/pkg/aws/dnstakeover/check_s3.go
+++ b/pkg/aws/dnstakeover/check_s3.go
@@ -20,9 +20,8 @@ func init() {
 	mustRegister("AAAA", "s3-website-takeover", checkS3)
 }
 
-// s3WebsiteEndpointPattern matches regional S3 website alias targets that do
-// not include the bucket name (the record FQDN is the bucket).
 var s3WebsiteEndpointPattern = regexp.MustCompile(`^s3-website[-.](?:dualstack\.)?[a-z0-9-]+\.amazonaws\.com$`)
+var s3VirtualHostedWebsitePattern = regexp.MustCompile(`^.+\.s3-website[-.].+\.amazonaws\.com$`)
 
 func checkS3(ctx CheckContext, rec Route53Record, out *pipeline.P[model.AurelianModel]) error {
 	cfg, err := awshelpers.NewAWSConfig(awshelpers.AWSConfigInput{
@@ -74,21 +73,26 @@ func checkS3WithClient(ctx CheckContext, client cloudfront.S3API, rec Route53Rec
 }
 
 func s3BucketFromRecord(rec Route53Record) (string, bool) {
+	name := strings.TrimSuffix(rec.RecordName, ".")
+	if name == "" {
+		return "", false
+	}
 	for _, val := range rec.Values {
 		host := strings.TrimSuffix(val, ".")
-		// ExtractBucketName's fallback keys on substring ".s3" and will
-		// return a bucket for non-AWS hosts (e.g. files.s3.internal.example.com).
-		if strings.HasSuffix(host, ".amazonaws.com") {
-			if bucket := cloudfront.ExtractBucketName(host); bucket != "" {
-				return bucket, true
-			}
-		}
-		if rec.IsAlias && s3WebsiteEndpointPattern.MatchString(host) {
-			name := strings.TrimSuffix(rec.RecordName, ".")
-			if name != "" {
-				return name, true
-			}
+		if isS3WebsiteEndpoint(host) {
+			return name, true
 		}
 	}
 	return "", false
+}
+
+func isS3WebsiteEndpoint(host string) bool {
+	if strings.Contains(host, "s3-accesspoint") ||
+		strings.Contains(host, "s3-object-lambda") ||
+		strings.Contains(host, "s3-control") ||
+		strings.HasSuffix(host, ".vpce.amazonaws.com") ||
+		strings.Contains(host, ".elb.") {
+		return false
+	}
+	return s3WebsiteEndpointPattern.MatchString(host) || s3VirtualHostedWebsitePattern.MatchString(host)
 }

--- a/pkg/aws/dnstakeover/check_s3.go
+++ b/pkg/aws/dnstakeover/check_s3.go
@@ -87,12 +87,5 @@ func s3BucketFromRecord(rec Route53Record) (string, bool) {
 }
 
 func isS3WebsiteEndpoint(host string) bool {
-	if strings.Contains(host, "s3-accesspoint") ||
-		strings.Contains(host, "s3-object-lambda") ||
-		strings.Contains(host, "s3-control") ||
-		strings.HasSuffix(host, ".vpce.amazonaws.com") ||
-		strings.Contains(host, ".elb.") {
-		return false
-	}
 	return s3WebsiteEndpointPattern.MatchString(host) || s3VirtualHostedWebsitePattern.MatchString(host)
 }

--- a/pkg/aws/dnstakeover/check_s3.go
+++ b/pkg/aws/dnstakeover/check_s3.go
@@ -1,0 +1,90 @@
+package dnstakeover
+
+import (
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	awshelpers "github.com/praetorian-inc/aurelian/internal/helpers/aws"
+	"github.com/praetorian-inc/aurelian/pkg/aws/cloudfront"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+)
+
+func init() {
+	mustRegister("CNAME", "s3-website-takeover", checkS3)
+	mustRegister("A", "s3-website-takeover", checkS3)
+	mustRegister("AAAA", "s3-website-takeover", checkS3)
+}
+
+// s3WebsiteEndpointPattern matches regional S3 website alias targets that do
+// not include the bucket name (the record FQDN is the bucket).
+var s3WebsiteEndpointPattern = regexp.MustCompile(`^s3-website[-.](?:dualstack\.)?[a-z0-9-]+\.amazonaws\.com$`)
+
+func checkS3(ctx CheckContext, rec Route53Record, out *pipeline.P[model.AurelianModel]) error {
+	cfg, err := awshelpers.NewAWSConfig(awshelpers.AWSConfigInput{
+		Region:     "us-east-1",
+		Profile:    ctx.Opts.Profile,
+		ProfileDir: ctx.Opts.ProfileDir,
+	})
+	if err != nil {
+		return fmt.Errorf("create s3 config: %w", err)
+	}
+	return checkS3WithClient(ctx, s3.NewFromConfig(cfg), rec, out)
+}
+
+func checkS3WithClient(ctx CheckContext, client cloudfront.S3API, rec Route53Record, out *pipeline.P[model.AurelianModel]) error {
+	bucket, ok := s3BucketFromRecord(rec)
+	if !ok {
+		return nil
+	}
+
+	existence := cloudfront.CheckBucketExists(ctx.Ctx, client, bucket)
+	if existence != cloudfront.BucketNotExists {
+		if existence == cloudfront.BucketUnknown {
+			slog.Warn("s3 website existence unknown", "bucket", bucket, "record", rec.RecordName)
+		}
+		return nil
+	}
+
+	out.Send(NewTakeoverRisk(
+		"s3-website-subdomain-takeover",
+		output.RiskSeverityHigh,
+		rec,
+		ctx.AccountID,
+		map[string]any{
+			"service":      "S3 website",
+			"cname_target": strings.Join(rec.Values, ","),
+			"bucket_name":  bucket,
+			"description": fmt.Sprintf(
+				"Route53 %s %q points to missing S3 bucket %q. An attacker can create the bucket and serve content.",
+				rec.Type, rec.RecordName, bucket,
+			),
+			"recommendation": "Remove the stale record or recreate the bucket. Do not leave website CNAMEs/aliases dangling.",
+			"references": []string{
+				"https://docs.aws.amazon.com/AmazonS3/latest/userguide/website-hosting-custom-domain-walkthrough.html",
+				"https://arxiv.org/abs/2403.19368",
+			},
+		},
+	))
+	return nil
+}
+
+func s3BucketFromRecord(rec Route53Record) (string, bool) {
+	for _, val := range rec.Values {
+		host := strings.TrimSuffix(val, ".")
+		if bucket := cloudfront.ExtractBucketName(host); bucket != "" {
+			return bucket, true
+		}
+		if rec.IsAlias && s3WebsiteEndpointPattern.MatchString(host) {
+			name := strings.TrimSuffix(rec.RecordName, ".")
+			if name != "" {
+				return name, true
+			}
+		}
+	}
+	return "", false
+}

--- a/pkg/aws/dnstakeover/check_s3.go
+++ b/pkg/aws/dnstakeover/check_s3.go
@@ -76,8 +76,12 @@ func checkS3WithClient(ctx CheckContext, client cloudfront.S3API, rec Route53Rec
 func s3BucketFromRecord(rec Route53Record) (string, bool) {
 	for _, val := range rec.Values {
 		host := strings.TrimSuffix(val, ".")
-		if bucket := cloudfront.ExtractBucketName(host); bucket != "" {
-			return bucket, true
+		// ExtractBucketName's fallback keys on substring ".s3" and will
+		// return a bucket for non-AWS hosts (e.g. files.s3.internal.example.com).
+		if strings.HasSuffix(host, ".amazonaws.com") {
+			if bucket := cloudfront.ExtractBucketName(host); bucket != "" {
+				return bucket, true
+			}
 		}
 		if rec.IsAlias && s3WebsiteEndpointPattern.MatchString(host) {
 			name := strings.TrimSuffix(rec.RecordName, ".")

--- a/pkg/aws/dnstakeover/check_s3_test.go
+++ b/pkg/aws/dnstakeover/check_s3_test.go
@@ -55,7 +55,7 @@ func TestS3BucketFromTarget_VirtualHostedWebsite(t *testing.T) {
 		Values:     []string{"mybucket.s3-website-us-east-1.amazonaws.com"},
 	})
 	require.True(t, ok)
-	assert.Equal(t, "mybucket", b)
+	assert.Equal(t, "blog.example.com", b)
 }
 
 func TestS3BucketFromTarget_AliasEndpointUsesRecordName(t *testing.T) {
@@ -87,10 +87,31 @@ func TestS3BucketFromTarget_SkipNonAWS_S3Substring(t *testing.T) {
 	assert.False(t, ok, "non-AWS host containing .s3 must not parse as an S3 website bucket")
 }
 
+func TestS3BucketFromTarget_SkipAccessPointObjectLambdaVPCE(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+	}{
+		{"s3-accesspoint", "myap-123456789012.s3-accesspoint.us-east-1.amazonaws.com"},
+		{"s3-object-lambda", "mylambda-123456789012.s3-object-lambda.us-east-1.amazonaws.com"},
+		{"s3-vpce", "bucket.vpce-0123456789abcdef0-abcdefgh.s3.us-east-1.vpce.amazonaws.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := s3BucketFromRecord(Route53Record{
+				Type:       "CNAME",
+				RecordName: "files.example.com",
+				Values:     []string{tt.host},
+			})
+			assert.False(t, ok)
+		})
+	}
+}
+
 func TestCheckS3_MissingBucketEmitsRisk(t *testing.T) {
 	client := &mockS3Client{
 		bucketResponses: map[string]error{
-			"mybucket": fmt.Errorf("404 Not Found"),
+			"blog.example.com": fmt.Errorf("404 Not Found"),
 		},
 	}
 	rec := Route53Record{
@@ -107,14 +128,14 @@ func TestCheckS3_MissingBucketEmitsRisk(t *testing.T) {
 
 	var ctx map[string]any
 	require.NoError(t, json.Unmarshal(risks[0].Context, &ctx))
-	assert.Equal(t, "mybucket", ctx["bucket_name"])
+	assert.Equal(t, "blog.example.com", ctx["bucket_name"])
 	assert.Equal(t, "S3 website", ctx["service"])
 }
 
 func TestCheckS3_ExistingBucketNoRisk(t *testing.T) {
 	client := &mockS3Client{
 		bucketResponses: map[string]error{
-			"mybucket": nil,
+			"blog.example.com": nil,
 		},
 	}
 	rec := Route53Record{
@@ -128,10 +149,10 @@ func TestCheckS3_ExistingBucketNoRisk(t *testing.T) {
 func TestCheckS3_NotOwnedNoRisk(t *testing.T) {
 	client := &mockS3Client{
 		bucketResponses: map[string]error{
-			"mybucket": fmt.Errorf("PermanentRedirect: bucket is in a different region"),
+			"blog.example.com": fmt.Errorf("PermanentRedirect: bucket is in a different region"),
 		},
 		locationResponses: map[string]error{
-			"mybucket": fmt.Errorf("AccessDenied: access denied"),
+			"blog.example.com": fmt.Errorf("AccessDenied: access denied"),
 		},
 	}
 	rec := Route53Record{
@@ -140,6 +161,44 @@ func TestCheckS3_NotOwnedNoRisk(t *testing.T) {
 		Values:     []string{"mybucket.s3-website-us-east-1.amazonaws.com"},
 	}
 	assert.Empty(t, collectS3Risks(t, client, rec), "BucketExistsNotOwned must not produce an S3-website finding")
+}
+
+func TestCheckS3_TargetLabelMissingRecordBucketPresentNoRisk(t *testing.T) {
+	client := &mockS3Client{
+		bucketResponses: map[string]error{
+			"mybucket":         fmt.Errorf("404 Not Found"),
+			"blog.example.com": nil,
+		},
+	}
+	rec := Route53Record{
+		Type:       "CNAME",
+		RecordName: "blog.example.com",
+		Values:     []string{"mybucket.s3-website-us-east-1.amazonaws.com"},
+	}
+	assert.Empty(t, collectS3Risks(t, client, rec), "missing CNAME target label must not produce a finding when the record-hostname bucket exists")
+}
+
+func TestCheckS3_RecordBucketMissingTargetLabelPresentEmitsRisk(t *testing.T) {
+	client := &mockS3Client{
+		bucketResponses: map[string]error{
+			"blog.example.com": fmt.Errorf("404 Not Found"),
+			"mybucket":         nil,
+		},
+	}
+	rec := Route53Record{
+		ZoneID:     "Z1",
+		ZoneName:   "example.com",
+		Type:       "CNAME",
+		RecordName: "blog.example.com",
+		Values:     []string{"mybucket.s3-website-us-east-1.amazonaws.com"},
+	}
+	risks := collectS3Risks(t, client, rec)
+	require.Len(t, risks, 1)
+	assert.Equal(t, "s3-website-subdomain-takeover", risks[0].Name)
+
+	var ctx map[string]any
+	require.NoError(t, json.Unmarshal(risks[0].Context, &ctx))
+	assert.Equal(t, "blog.example.com", ctx["bucket_name"])
 }
 
 func collectS3Risks(t *testing.T, client *mockS3Client, rec Route53Record) []output.AurelianRisk {

--- a/pkg/aws/dnstakeover/check_s3_test.go
+++ b/pkg/aws/dnstakeover/check_s3_test.go
@@ -1,0 +1,156 @@
+package dnstakeover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockS3Client copies cloudfront.checker_test.go's unexported mock (YAGNI: no shared mock package).
+type mockS3Client struct {
+	bucketResponses   map[string]error
+	locationResponses map[string]error
+}
+
+func (m *mockS3Client) HeadBucket(_ context.Context, params *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+	if params.Bucket == nil {
+		return nil, fmt.Errorf("nil bucket name")
+	}
+	if err, ok := m.bucketResponses[*params.Bucket]; ok {
+		if err != nil {
+			return nil, err
+		}
+		return &s3.HeadBucketOutput{}, nil
+	}
+	return nil, fmt.Errorf("404 Not Found")
+}
+
+func (m *mockS3Client) GetBucketLocation(_ context.Context, params *s3.GetBucketLocationInput, _ ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+	if params.Bucket == nil {
+		return nil, fmt.Errorf("nil bucket name")
+	}
+	if m.locationResponses != nil {
+		if err, ok := m.locationResponses[*params.Bucket]; ok {
+			if err != nil {
+				return nil, err
+			}
+			return &s3.GetBucketLocationOutput{}, nil
+		}
+	}
+	return &s3.GetBucketLocationOutput{}, nil
+}
+
+func TestS3BucketFromTarget_VirtualHostedWebsite(t *testing.T) {
+	b, ok := s3BucketFromRecord(Route53Record{
+		Type:       "CNAME",
+		RecordName: "blog.example.com",
+		Values:     []string{"mybucket.s3-website-us-east-1.amazonaws.com"},
+	})
+	require.True(t, ok)
+	assert.Equal(t, "mybucket", b)
+}
+
+func TestS3BucketFromTarget_AliasEndpointUsesRecordName(t *testing.T) {
+	b, ok := s3BucketFromRecord(Route53Record{
+		Type:       "A",
+		IsAlias:    true,
+		RecordName: "shop.example.com",
+		Values:     []string{"s3-website-us-east-2.amazonaws.com"},
+	})
+	require.True(t, ok)
+	assert.Equal(t, "shop.example.com", b)
+}
+
+func TestS3BucketFromTarget_SkipELB(t *testing.T) {
+	_, ok := s3BucketFromRecord(Route53Record{
+		Type:    "A",
+		IsAlias: true,
+		Values:  []string{"dualstack.my-elb.us-east-1.elb.amazonaws.com"},
+	})
+	assert.False(t, ok)
+}
+
+func TestCheckS3_MissingBucketEmitsRisk(t *testing.T) {
+	client := &mockS3Client{
+		bucketResponses: map[string]error{
+			"mybucket": fmt.Errorf("404 Not Found"),
+		},
+	}
+	rec := Route53Record{
+		ZoneID:     "Z1",
+		ZoneName:   "example.com",
+		Type:       "CNAME",
+		RecordName: "blog.example.com",
+		Values:     []string{"mybucket.s3-website-us-east-1.amazonaws.com"},
+	}
+	risks := collectS3Risks(t, client, rec)
+	require.Len(t, risks, 1)
+	assert.Equal(t, "s3-website-subdomain-takeover", risks[0].Name)
+	assert.Equal(t, output.RiskSeverityHigh, risks[0].Severity)
+
+	var ctx map[string]any
+	require.NoError(t, json.Unmarshal(risks[0].Context, &ctx))
+	assert.Equal(t, "mybucket", ctx["bucket_name"])
+	assert.Equal(t, "S3 website", ctx["service"])
+}
+
+func TestCheckS3_ExistingBucketNoRisk(t *testing.T) {
+	client := &mockS3Client{
+		bucketResponses: map[string]error{
+			"mybucket": nil,
+		},
+	}
+	rec := Route53Record{
+		Type:       "CNAME",
+		RecordName: "blog.example.com",
+		Values:     []string{"mybucket.s3-website-us-east-1.amazonaws.com"},
+	}
+	assert.Empty(t, collectS3Risks(t, client, rec), "existing bucket must not produce a finding")
+}
+
+func TestCheckS3_NotOwnedNoRisk(t *testing.T) {
+	client := &mockS3Client{
+		bucketResponses: map[string]error{
+			"mybucket": fmt.Errorf("PermanentRedirect: bucket is in a different region"),
+		},
+		locationResponses: map[string]error{
+			"mybucket": fmt.Errorf("AccessDenied: access denied"),
+		},
+	}
+	rec := Route53Record{
+		Type:       "CNAME",
+		RecordName: "blog.example.com",
+		Values:     []string{"mybucket.s3-website-us-east-1.amazonaws.com"},
+	}
+	assert.Empty(t, collectS3Risks(t, client, rec), "BucketExistsNotOwned must not produce an S3-website finding")
+}
+
+func collectS3Risks(t *testing.T, client *mockS3Client, rec Route53Record) []output.AurelianRisk {
+	t.Helper()
+	out := pipeline.New[model.AurelianModel]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, checkS3WithClient(CheckContext{
+			Ctx:       context.Background(),
+			AccountID: "123456789012",
+		}, client, rec, out))
+	}()
+	items, err := out.Collect()
+	require.NoError(t, err)
+
+	risks := make([]output.AurelianRisk, 0, len(items))
+	for _, item := range items {
+		risk, ok := item.(output.AurelianRisk)
+		require.True(t, ok, "expected AurelianRisk, got %T", item)
+		risks = append(risks, risk)
+	}
+	return risks
+}

--- a/pkg/aws/dnstakeover/check_s3_test.go
+++ b/pkg/aws/dnstakeover/check_s3_test.go
@@ -78,6 +78,15 @@ func TestS3BucketFromTarget_SkipELB(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestS3BucketFromTarget_SkipNonAWS_S3Substring(t *testing.T) {
+	_, ok := s3BucketFromRecord(Route53Record{
+		Type:       "CNAME",
+		RecordName: "files.example.com",
+		Values:     []string{"files.s3.internal.example.com"},
+	})
+	assert.False(t, ok, "non-AWS host containing .s3 must not parse as an S3 website bucket")
+}
+
 func TestCheckS3_MissingBucketEmitsRisk(t *testing.T) {
 	client := &mockS3Client{
 		bucketResponses: map[string]error{

--- a/pkg/aws/dnstakeover/check_s3_test.go
+++ b/pkg/aws/dnstakeover/check_s3_test.go
@@ -108,6 +108,16 @@ func TestS3BucketFromTarget_SkipAccessPointObjectLambdaVPCE(t *testing.T) {
 	}
 }
 
+func TestS3BucketFromTarget_WebsiteBucketLabelContainsAccessPoint(t *testing.T) {
+	b, ok := s3BucketFromRecord(Route53Record{
+		Type:       "CNAME",
+		RecordName: "blog.example.com",
+		Values:     []string{"logs-s3-accesspoint.s3-website-us-east-1.amazonaws.com"},
+	})
+	require.True(t, ok)
+	assert.Equal(t, "blog.example.com", b)
+}
+
 func TestCheckS3_MissingBucketEmitsRisk(t *testing.T) {
 	client := &mockS3Client{
 		bucketResponses: map[string]error{
@@ -204,15 +214,17 @@ func TestCheckS3_RecordBucketMissingTargetLabelPresentEmitsRisk(t *testing.T) {
 func collectS3Risks(t *testing.T, client *mockS3Client, rec Route53Record) []output.AurelianRisk {
 	t.Helper()
 	out := pipeline.New[model.AurelianModel]()
+	errCh := make(chan error, 1)
 	go func() {
 		defer out.Close()
-		require.NoError(t, checkS3WithClient(CheckContext{
+		errCh <- checkS3WithClient(CheckContext{
 			Ctx:       context.Background(),
 			AccountID: "123456789012",
-		}, client, rec, out))
+		}, client, rec, out)
 	}()
 	items, err := out.Collect()
 	require.NoError(t, err)
+	require.NoError(t, <-errCh)
 
 	risks := make([]output.AurelianRisk, 0, len(items))
 	for _, item := range items {

--- a/pkg/aws/dnstakeover/route53.go
+++ b/pkg/aws/dnstakeover/route53.go
@@ -96,19 +96,12 @@ func (e *Route53Enumerator) enumerateRecords(ctx context.Context, client *route5
 		}
 
 		for _, rrs := range resp.ResourceRecordSets {
-			var values []string
-			for _, rr := range rrs.ResourceRecords {
-				if rr.Value != nil {
-					values = append(values, aws.ToString(rr.Value))
-				}
-			}
-
 			out.Send(Route53Record{
 				ZoneID:     zoneID,
 				ZoneName:   zoneName,
 				RecordName: strings.TrimSuffix(aws.ToString(rrs.Name), "."),
 				Type:       string(rrs.Type),
-				Values:     values,
+				Values:     recordValues(rrs),
 				IsAlias:    rrs.AliasTarget != nil,
 			})
 		}
@@ -121,4 +114,17 @@ func (e *Route53Enumerator) enumerateRecords(ctx context.Context, client *route5
 	}
 
 	return nil
+}
+
+func recordValues(rrs r53types.ResourceRecordSet) []string {
+	var values []string
+	for _, rr := range rrs.ResourceRecords {
+		if rr.Value != nil {
+			values = append(values, aws.ToString(rr.Value))
+		}
+	}
+	if rrs.AliasTarget != nil && rrs.AliasTarget.DNSName != nil {
+		values = append(values, strings.TrimSuffix(aws.ToString(rrs.AliasTarget.DNSName), "."))
+	}
+	return values
 }

--- a/pkg/aws/dnstakeover/route53_test.go
+++ b/pkg/aws/dnstakeover/route53_test.go
@@ -1,0 +1,54 @@
+package dnstakeover
+
+import (
+	"testing"
+
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordValues_AliasDNSName(t *testing.T) {
+	dnsName := "s3-website-us-east-2.amazonaws.com."
+	rrs := r53types.ResourceRecordSet{
+		Type:        r53types.RRTypeA,
+		AliasTarget: &r53types.AliasTarget{DNSName: &dnsName},
+	}
+	got := recordValues(rrs)
+	require.Equal(t, []string{"s3-website-us-east-2.amazonaws.com"}, got)
+}
+
+func TestRecordValues_CNAMEResourceRecordsUnchanged(t *testing.T) {
+	v := "prefix.us-east-2.elasticbeanstalk.com."
+	rrs := r53types.ResourceRecordSet{
+		Type:            r53types.RRTypeCname,
+		ResourceRecords: []r53types.ResourceRecord{{Value: &v}},
+	}
+	got := recordValues(rrs)
+	require.Equal(t, []string{"prefix.us-east-2.elasticbeanstalk.com."}, got)
+}
+
+func TestRecordValues_EmptyRecordSet(t *testing.T) {
+	got := recordValues(r53types.ResourceRecordSet{})
+	require.Empty(t, got)
+}
+
+func TestRecordValues_AliasNilDNSName(t *testing.T) {
+	rrs := r53types.ResourceRecordSet{
+		Type:        r53types.RRTypeA,
+		AliasTarget: &r53types.AliasTarget{DNSName: nil},
+	}
+	got := recordValues(rrs)
+	require.Empty(t, got)
+}
+
+func TestRecordValues_ResourceRecordsAndAlias(t *testing.T) {
+	rr := "kept.example.com."
+	alias := "s3-website-us-east-2.amazonaws.com."
+	rrs := r53types.ResourceRecordSet{
+		Type:            r53types.RRTypeA,
+		ResourceRecords: []r53types.ResourceRecord{{Value: &rr}},
+		AliasTarget:     &r53types.AliasTarget{DNSName: &alias},
+	}
+	got := recordValues(rrs)
+	require.Equal(t, []string{"kept.example.com.", "s3-website-us-east-2.amazonaws.com"}, got)
+}

--- a/pkg/azure/dnstakeover/check_cname_frontdoor.go
+++ b/pkg/azure/dnstakeover/check_cname_frontdoor.go
@@ -1,0 +1,93 @@
+package dnstakeover
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
+)
+
+func init() {
+	mustRegister("CNAME", "frontdoor-takeover", checkFrontDoor)
+}
+
+const frontdoorSuffix = ".azurefd.net"
+
+func checkFrontDoor(ctx CheckContext, rec AzureDNSRecord, out *pipeline.P[model.AurelianModel]) error {
+	for _, val := range rec.Values {
+		endpointName, ok := frontDoorEndpointName(val)
+		if !ok {
+			continue
+		}
+
+		available, err := checkFrontDoorNameAvailability(ctx, endpointName)
+		if err != nil {
+			slog.Warn("front door name check failed",
+				"record", rec.RecordName, "endpoint", endpointName, "error", err)
+			continue
+		}
+
+		if !available {
+			continue
+		}
+
+		out.Send(NewTakeoverRisk(
+			"frontdoor-subdomain-takeover",
+			output.RiskSeverityHigh,
+			rec,
+			map[string]any{
+				"service":       "Front Door",
+				"cname_target":  val,
+				"endpoint_name": endpointName,
+				"description": fmt.Sprintf(
+					"CNAME %q points to %s which is available for registration. "+
+						"An attacker can create a Front Door endpoint with this name and serve arbitrary content.",
+					rec.FQDN, val,
+				),
+				"remediation": "Remove the stale CNAME record or recreate the Front Door endpoint.",
+				"references": []string{
+					"https://learn.microsoft.com/en-us/azure/security/fundamentals/subdomain-takeover",
+				},
+			},
+		))
+	}
+	return nil
+}
+
+func frontDoorEndpointName(val string) (string, bool) {
+	v := strings.ToLower(strings.TrimSuffix(val, "."))
+	name, ok := strings.CutSuffix(v, frontdoorSuffix)
+	if !ok || name == "" || strings.Contains(name, ".") {
+		return "", false
+	}
+	return name, true
+}
+
+func checkFrontDoorNameAvailability(ctx CheckContext, endpointName string) (bool, error) {
+	client, err := armcdn.NewManagementClient(ctx.SubscriptionID, ctx.Credential, nil)
+	if err != nil {
+		return false, fmt.Errorf("create cdn client: %w", err)
+	}
+
+	resp, err := client.CheckNameAvailabilityWithSubscription(
+		context.Background(),
+		armcdn.CheckNameAvailabilityInput{
+			Name: &endpointName,
+			Type: ptrTo(armcdn.ResourceTypeMicrosoftCdnProfilesAfdEndpoints),
+		},
+		nil,
+	)
+	if err != nil {
+		return false, fmt.Errorf("check name availability: %w", err)
+	}
+
+	if resp.NameAvailable == nil {
+		return false, nil
+	}
+	return *resp.NameAvailable, nil
+}

--- a/pkg/azure/dnstakeover/check_cname_frontdoor.go
+++ b/pkg/azure/dnstakeover/check_cname_frontdoor.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
 	"github.com/praetorian-inc/aurelian/pkg/model"
 	"github.com/praetorian-inc/aurelian/pkg/output"
 	"github.com/praetorian-inc/aurelian/pkg/pipeline"
@@ -18,14 +18,26 @@ func init() {
 
 const frontdoorSuffix = ".azurefd.net"
 
+type frontDoorNameAvailabilityClient interface {
+	Check(ctx context.Context, checkFrontDoorNameAvailabilityInput armfrontdoor.CheckNameAvailabilityInput, options *armfrontdoor.NameAvailabilityWithSubscriptionClientCheckOptions) (armfrontdoor.NameAvailabilityWithSubscriptionClientCheckResponse, error)
+}
+
 func checkFrontDoor(ctx CheckContext, rec AzureDNSRecord, out *pipeline.P[model.AurelianModel]) error {
+	client, err := armfrontdoor.NewNameAvailabilityWithSubscriptionClient(ctx.SubscriptionID, ctx.Credential, nil)
+	if err != nil {
+		return fmt.Errorf("create front door client: %w", err)
+	}
+	return checkFrontDoorWithClient(client, rec, out)
+}
+
+func checkFrontDoorWithClient(client frontDoorNameAvailabilityClient, rec AzureDNSRecord, out *pipeline.P[model.AurelianModel]) error {
 	for _, val := range rec.Values {
 		endpointName, ok := frontDoorEndpointName(val)
 		if !ok {
 			continue
 		}
 
-		available, err := checkFrontDoorNameAvailability(ctx, endpointName)
+		available, err := checkFrontDoorNameAvailability(client, endpointName)
 		if err != nil {
 			slog.Warn("front door name check failed",
 				"record", rec.RecordName, "endpoint", endpointName, "error", err)
@@ -68,17 +80,12 @@ func frontDoorEndpointName(val string) (string, bool) {
 	return name, true
 }
 
-func checkFrontDoorNameAvailability(ctx CheckContext, endpointName string) (bool, error) {
-	client, err := armcdn.NewManagementClient(ctx.SubscriptionID, ctx.Credential, nil)
-	if err != nil {
-		return false, fmt.Errorf("create cdn client: %w", err)
-	}
-
-	resp, err := client.CheckNameAvailabilityWithSubscription(
+func checkFrontDoorNameAvailability(client frontDoorNameAvailabilityClient, endpointName string) (bool, error) {
+	resp, err := client.Check(
 		context.Background(),
-		armcdn.CheckNameAvailabilityInput{
+		armfrontdoor.CheckNameAvailabilityInput{
 			Name: &endpointName,
-			Type: ptrTo(armcdn.ResourceTypeMicrosoftCdnProfilesAfdEndpoints),
+			Type: ptrTo(armfrontdoor.ResourceTypeMicrosoftNetworkFrontDoors),
 		},
 		nil,
 	)
@@ -86,8 +93,8 @@ func checkFrontDoorNameAvailability(ctx CheckContext, endpointName string) (bool
 		return false, fmt.Errorf("check name availability: %w", err)
 	}
 
-	if resp.NameAvailable == nil {
+	if resp.NameAvailability == nil {
 		return false, nil
 	}
-	return *resp.NameAvailable, nil
+	return *resp.NameAvailability == armfrontdoor.AvailabilityAvailable, nil
 }

--- a/pkg/azure/dnstakeover/check_cname_frontdoor.go
+++ b/pkg/azure/dnstakeover/check_cname_frontdoor.go
@@ -27,17 +27,17 @@ func checkFrontDoor(ctx CheckContext, rec AzureDNSRecord, out *pipeline.P[model.
 	if err != nil {
 		return fmt.Errorf("create front door client: %w", err)
 	}
-	return checkFrontDoorWithClient(client, rec, out)
+	return checkFrontDoorWithClient(ctx.Ctx, client, rec, out)
 }
 
-func checkFrontDoorWithClient(client frontDoorNameAvailabilityClient, rec AzureDNSRecord, out *pipeline.P[model.AurelianModel]) error {
+func checkFrontDoorWithClient(ctx context.Context, client frontDoorNameAvailabilityClient, rec AzureDNSRecord, out *pipeline.P[model.AurelianModel]) error {
 	for _, val := range rec.Values {
 		endpointName, ok := frontDoorEndpointName(val)
 		if !ok {
 			continue
 		}
 
-		available, err := checkFrontDoorNameAvailability(client, endpointName)
+		available, err := checkFrontDoorNameAvailability(ctx, client, endpointName)
 		if err != nil {
 			slog.Warn("front door name check failed",
 				"record", rec.RecordName, "endpoint", endpointName, "error", err)
@@ -80,9 +80,9 @@ func frontDoorEndpointName(val string) (string, bool) {
 	return name, true
 }
 
-func checkFrontDoorNameAvailability(client frontDoorNameAvailabilityClient, endpointName string) (bool, error) {
+func checkFrontDoorNameAvailability(ctx context.Context, client frontDoorNameAvailabilityClient, endpointName string) (bool, error) {
 	resp, err := client.Check(
-		context.Background(),
+		ctx,
 		armfrontdoor.CheckNameAvailabilityInput{
 			Name: &endpointName,
 			Type: ptrTo(armfrontdoor.ResourceTypeMicrosoftNetworkFrontDoors),

--- a/pkg/azure/dnstakeover/check_cname_frontdoor_test.go
+++ b/pkg/azure/dnstakeover/check_cname_frontdoor_test.go
@@ -1,0 +1,31 @@
+package dnstakeover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrontDoorEndpointName(t *testing.T) {
+	n, ok := frontDoorEndpointName("myfd.azurefd.net")
+	require.True(t, ok)
+	assert.Equal(t, "myfd", n)
+
+	_, ok = frontDoorEndpointName("myfd-abc.z01.azurefd.net")
+	assert.False(t, ok, "hashed Standard/Premium hostnames are a documented FN")
+
+	_, ok = frontDoorEndpointName("x.azureedge.net")
+	assert.False(t, ok)
+}
+
+func TestFrontDoorEndpointName_TrailingDotAndCase(t *testing.T) {
+	n, ok := frontDoorEndpointName("MyFD.AzureFD.net.")
+	require.True(t, ok)
+	assert.Equal(t, "myfd", n)
+}
+
+func TestFrontDoorEndpointName_EmptyLabel(t *testing.T) {
+	_, ok := frontDoorEndpointName(".azurefd.net")
+	assert.False(t, ok)
+}

--- a/pkg/azure/dnstakeover/check_cname_frontdoor_test.go
+++ b/pkg/azure/dnstakeover/check_cname_frontdoor_test.go
@@ -103,12 +103,14 @@ func TestCheckFrontDoor_HashedZ01SkipsCheck(t *testing.T) {
 func collectFrontDoorRisks(t *testing.T, client *mockFrontDoorClient, rec AzureDNSRecord) []output.AurelianRisk {
 	t.Helper()
 	out := pipeline.New[model.AurelianModel]()
+	errCh := make(chan error, 1)
 	go func() {
 		defer out.Close()
-		require.NoError(t, checkFrontDoorWithClient(client, rec, out))
+		errCh <- checkFrontDoorWithClient(context.Background(), client, rec, out)
 	}()
 	items, err := out.Collect()
 	require.NoError(t, err)
+	require.NoError(t, <-errCh)
 
 	risks := make([]output.AurelianRisk, 0, len(items))
 	for _, item := range items {

--- a/pkg/azure/dnstakeover/check_cname_frontdoor_test.go
+++ b/pkg/azure/dnstakeover/check_cname_frontdoor_test.go
@@ -1,8 +1,13 @@
 package dnstakeover
 
 import (
+	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
+	"github.com/praetorian-inc/aurelian/pkg/model"
+	"github.com/praetorian-inc/aurelian/pkg/output"
+	"github.com/praetorian-inc/aurelian/pkg/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,4 +33,88 @@ func TestFrontDoorEndpointName_TrailingDotAndCase(t *testing.T) {
 func TestFrontDoorEndpointName_EmptyLabel(t *testing.T) {
 	_, ok := frontDoorEndpointName(".azurefd.net")
 	assert.False(t, ok)
+}
+
+type mockFrontDoorClient struct {
+	available bool
+	inputs    []armfrontdoor.CheckNameAvailabilityInput
+}
+
+func (m *mockFrontDoorClient) Check(_ context.Context, input armfrontdoor.CheckNameAvailabilityInput, _ *armfrontdoor.NameAvailabilityWithSubscriptionClientCheckOptions) (armfrontdoor.NameAvailabilityWithSubscriptionClientCheckResponse, error) {
+	m.inputs = append(m.inputs, input)
+	avail := armfrontdoor.AvailabilityUnavailable
+	if m.available {
+		avail = armfrontdoor.AvailabilityAvailable
+	}
+	return armfrontdoor.NameAvailabilityWithSubscriptionClientCheckResponse{
+		CheckNameAvailabilityOutput: armfrontdoor.CheckNameAvailabilityOutput{
+			NameAvailability: &avail,
+		},
+	}, nil
+}
+
+func classicFrontDoorRecord() AzureDNSRecord {
+	return AzureDNSRecord{
+		SubscriptionID: "sub",
+		ResourceGroup:  "rg",
+		ZoneName:       "example.com",
+		RecordName:     "www",
+		FQDN:           "www.example.com",
+		Type:           "CNAME",
+		Values:         []string{"foo.azurefd.net"},
+	}
+}
+
+func TestCheckFrontDoor_ClassicAvailableEmitsRisk(t *testing.T) {
+	client := &mockFrontDoorClient{available: true}
+	risks := collectFrontDoorRisks(t, client, classicFrontDoorRecord())
+	require.Len(t, risks, 1)
+	assert.Equal(t, "frontdoor-subdomain-takeover", risks[0].Name)
+
+	require.Len(t, client.inputs, 1)
+	require.NotNil(t, client.inputs[0].Type)
+	assert.Equal(t, armfrontdoor.ResourceTypeMicrosoftNetworkFrontDoors, *client.inputs[0].Type)
+}
+
+func TestCheckFrontDoor_ClassicUnavailableNoRisk(t *testing.T) {
+	client := &mockFrontDoorClient{available: false}
+	assert.Empty(t, collectFrontDoorRisks(t, client, classicFrontDoorRecord()))
+
+	require.Len(t, client.inputs, 1)
+	require.NotNil(t, client.inputs[0].Type)
+	assert.Equal(t, armfrontdoor.ResourceTypeMicrosoftNetworkFrontDoors, *client.inputs[0].Type)
+}
+
+func TestCheckFrontDoor_HashedZ01SkipsCheck(t *testing.T) {
+	client := &mockFrontDoorClient{available: true}
+	rec := AzureDNSRecord{
+		SubscriptionID: "sub",
+		ResourceGroup:  "rg",
+		ZoneName:       "example.com",
+		RecordName:     "www",
+		FQDN:           "www.example.com",
+		Type:           "CNAME",
+		Values:         []string{"myfd-abc.z01.azurefd.net"},
+	}
+	assert.Empty(t, collectFrontDoorRisks(t, client, rec))
+	assert.Empty(t, client.inputs)
+}
+
+func collectFrontDoorRisks(t *testing.T, client *mockFrontDoorClient, rec AzureDNSRecord) []output.AurelianRisk {
+	t.Helper()
+	out := pipeline.New[model.AurelianModel]()
+	go func() {
+		defer out.Close()
+		require.NoError(t, checkFrontDoorWithClient(client, rec, out))
+	}()
+	items, err := out.Collect()
+	require.NoError(t, err)
+
+	risks := make([]output.AurelianRisk, 0, len(items))
+	for _, item := range items {
+		risk, ok := item.(output.AurelianRisk)
+		require.True(t, ok, "expected AurelianRisk, got %T", item)
+		risks = append(risks, risk)
+	}
+	return risks
 }


### PR DESCRIPTION
Fixes ENG-7424. AliasTarget.DNSName in Values; HeadBucket-only S3 website checker; Front Door .azurefd.net CheckNameAvailability; .amazonaws.com gate to avoid .s3 substring FPs.

Parent ENG-7407.